### PR TITLE
fix: fix CI and finish #16 in the Printing modules

### DIFF
--- a/examples/nsl_pk/DY.Example.NSL.Debug.Printing.fst
+++ b/examples/nsl_pk/DY.Example.NSL.Debug.Printing.fst
@@ -81,5 +81,5 @@ val get_nsl_trace_to_string_printers: bytes -> bytes -> trace_to_string_printers
 let get_nsl_trace_to_string_printers priv_key_alice priv_key_bob = 
   trace_to_string_printers_builder 
     (message_to_string priv_key_alice priv_key_bob)
-    [(nsl_session_label, session_to_string)]
+    [(nsl_session_tag, session_to_string)]
     [(event_nsl_event.tag, event_to_string)]

--- a/src/lib/utils/DY.Lib.Printing.fst
+++ b/src/lib/utils/DY.Lib.Printing.fst
@@ -2,7 +2,7 @@ module DY.Lib.Printing
 
 open Comparse
 open DY.Core
-open DY.Lib.State.Labeled
+open DY.Lib.State.Tagged
 open DY.Lib.State.Map
 
 /// This module provides functions to convert types
@@ -138,16 +138,16 @@ let default_pki_state_to_string content_bytes =
   let? state = parse (map DY.Lib.State.PKI.pki_types) content_bytes in
   Some (Printf.sprintf "[%s]" (pki_types_to_string state.key_values))
 
-/// Searches for a printer with the correct label
+/// Searches for a printer with the correct tag
 /// and returns the first one it finds.
 
 val find_printer: list (string & (bytes -> option string)) -> string -> (bytes -> option string)
-let rec find_printer printer_list label =
+let rec find_printer printer_list tag =
   match printer_list with
   | [] -> (fun b -> Some (bytes_to_string b))
-  | (parser_label, parser) :: tl -> (
-    if parser_label = label then parser
-    else find_printer tl label
+  | (parser_tag, parser) :: tl -> (
+    if parser_tag = tag then parser
+    else find_printer tl tag
   )
 
 val option_to_string: (bytes -> option string) -> bytes -> string
@@ -161,8 +161,8 @@ val state_to_string: list (string & (bytes -> option string)) -> bytes -> string
 let state_to_string printer_list full_content_bytes =
   let full_content = parse session full_content_bytes in
   match full_content with
-  | Some ({label; content}) -> (
-    let parser = find_printer printer_list label in
+  | Some ({tag; content}) -> (
+    let parser = find_printer printer_list tag in
     option_to_string parser content
   )
   | None -> bytes_to_string full_content_bytes
@@ -260,8 +260,8 @@ let trace_to_string_printers_builder message_to_string state_to_string event_to_
     state_to_string = (
       List.append state_to_string (
         [
-          (DY.Lib.State.PrivateKeys.private_keys_label, default_private_keys_state_to_string);
-          (DY.Lib.State.PKI.pki_label, default_pki_state_to_string)
+          (DY.Lib.State.PrivateKeys.private_keys_tag, default_private_keys_state_to_string);
+          (DY.Lib.State.PKI.pki_tag, default_pki_state_to_string)
         ]
       ) // User supplied functions will override the default functions because the
         // find printer function will choose the first match.


### PR DESCRIPTION
Although we can only merge a pull request when the CI succeeds on the pull-request, the GitHub interface allowed me to push buttons in a way that we have a red commit on the main branch…

It happened because latest commit of `main` (hence #4) was not merged in #16, and although the latest commit of #16 did pass the CI checks, the merge of #4 and #16 was not passing the CI checks.

This pull-request fixes the CI and finish the work of #16 in the files added by #4. I will see if one of the branch protection rules would have prevented this, or if we should have the discipline of merging main in the pull-request before merging the pull-request in main.