### PR TITLE
feat: add support for intrinsic proofs in states

### DIFF
--- a/examples/nsl_pk/DY.Example.NSL.Protocol.Stateful.Proof.fst
+++ b/examples/nsl_pk/DY.Example.NSL.Protocol.Stateful.Proof.fst
@@ -101,6 +101,7 @@ let nsl_trace_invs: trace_invariants (nsl_crypto_invs) = {
 }
 
 instance nsl_protocol_invs: protocol_invariants = {
+  state_inv = nsl_state_functional_predicate;
   crypto_invs = nsl_crypto_invs;
   trace_invs = nsl_trace_invs;
 }

--- a/src/core/DY.Core.Trace.Invariant.fst
+++ b/src/core/DY.Core.Trace.Invariant.fst
@@ -102,6 +102,14 @@ let rec trace_functional_invariant #sfp tr =
     trace_functional_event_invariant event /\
     trace_functional_invariant tr_init
 
+val trace_functional_invariant_empty_trace:
+  {|state_functional_predicate|} ->
+  Lemma
+  (ensures trace_functional_invariant Nil)
+  [SMTPat (trace_functional_invariant Nil)]
+let trace_functional_invariant_empty_trace #invs =
+  norm_spec [zeta; delta_only [`%trace_functional_invariant]] (trace_functional_invariant)
+
 /// The invariant that must be satisfied by each event in the trace.
 
 val trace_event_invariant: {|protocol_invariants|} -> trace -> trace_event -> prop

--- a/src/lib/event/DY.Lib.Event.Typed.fst
+++ b/src/lib/event/DY.Lib.Event.Typed.fst
@@ -111,10 +111,11 @@ let mk_event_pred_correct invs lpreds =
 
 [@@ "opaque_to_smt"]
 val trigger_event:
+  {|state_functional_predicate|} ->
   #a:Type -> {|event a|} ->
   principal -> a ->
   crypto unit
-let trigger_event #a #ev prin e =
+let trigger_event #sfp #a #ev prin e =
   DY.Core.trigger_event prin ev.tag (serialize a e)
 
 [@@ "opaque_to_smt"]
@@ -152,7 +153,7 @@ val trigger_event_trace_invariant:
    SMTPat (has_event_pred invs epred);
    SMTPat (trace_invariant tr)]
 let trigger_event_trace_invariant #invs #a #ev epred prin e tr =
-  reveal_opaque (`%trigger_event) (trigger_event #a);
+  reveal_opaque (`%trigger_event) (trigger_event #_ #a);
   reveal_opaque (`%event_triggered_at) (event_triggered_at #a);
   local_eq_global_lemma split_event_pred_func event_pred ev.tag (compile_event_pred epred) (tr, prin, ev.tag, serialize _ e) (tr, prin, serialize _ e)
 


### PR DESCRIPTION
While porting some proofs from DY*-intrinsic to DY*-extrinsic, I noticed that sometimes, intrinsic proofs are useful!

Indeed, in DY*, the state invariant roughly contain two kind of properties:
- security properties (e.g. properties on labels, usage, etc)
- functional properties (e.g. "this binary tree is a binary search tree")

In DY*-intrinsic, when you do `get_state`, you obtain (as a post-condition) that its output satisfy the security properties, and the functional properties. The functional properties might then be used to call pure functions that require this property as a precondition (e.g. adding a node in a binary search tree requires the BST invariant on the input and ensure the BST invariant on the output).
In DY*-extrinsic, doing such things is impossible: when you do `get_state`, you cannot have the functional post-condition, because for that you would need the precondition that the trace satisfy the trace invariants, which we don't know because we do extrinsic proofs.

This pull-request is an attempt to allow such kind of intrinsic proofs in DY*-extrinsic. The `crypto` monad will now preserve the `trace_functional_invariant`, which is parametrized by `state_functional_predicate`. The `state_functional_predicate` is a predicate on states that deals with state contents in a trace, namely it is a `bytes -> prop`. In particular, this predicate do not have the trace as input, because its purpose is not to express trace properties.

What do you think about such an addition to DY*? I was too lazy to do it starting from DY.Lib.State.Map (hence PKI and PrivateKeys), but if people agree it's a good idea I will propagate the changes properly.

As a showcase, `get_tagged_state` can now assert that the state content can be parsed into a `tagged_state`, or `DY.Lib.State.Typed.get_state` can now assert that the state content can be parsed into an `a`. Roughly, it means that we can now remove some amount of dynamic checks by proving these checks are invariants of the protocol. This may not be necessary when these checks are computable (i.e. in `bool`), but it might be useful when they are not computable (i.e. in `prop`).