### PR TITLE
fix: correct typos in `bytes_invariant_vk` and `bytes_invariant_sign`

### DIFF
--- a/src/core/DY.Core.Bytes.fst
+++ b/src/core/DY.Core.Bytes.fst
@@ -1234,8 +1234,8 @@ val bytes_invariant_vk:
   sk:bytes ->
   Lemma
   (requires bytes_invariant tr sk)
-  (ensures bytes_invariant tr (pk sk))
-  [SMTPat (bytes_invariant tr (pk sk))]
+  (ensures bytes_invariant tr (vk sk))
+  [SMTPat (bytes_invariant tr (vk sk))]
 let bytes_invariant_vk #cinvs tr sk =
   normalize_term_spec vk;
   normalize_term_spec bytes_invariant
@@ -1286,7 +1286,6 @@ val bytes_invariant_sign:
     bytes_invariant tr sk /\
     bytes_invariant tr nonce /\
     bytes_invariant tr msg /\
-    bytes_invariant tr sk /\
     SigKey? (get_usage sk) /\
     SigNonce? (get_usage nonce) /\
     sign_pred tr (vk sk) msg /\


### PR DESCRIPTION
I noticed that the theorem `bytes_invariant_vk` was stating properties on `pk` instead of `vk`. This means that we couldn't prove honest uses of `vk`, the malicious uses of `vk` were correctly captured by `vk_preserves_publishability` and the attacker theorem in DY.Core.Attacker.Knowledge, so this typo did not impact the soundness of DY*.

I also noticed a redundant hypothesis in `bytes_invariant_sign` so I removed it.