### PR TITLE
Unify typeclass instance names

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,7 +99,7 @@ type f_inputs = {
 val f: f_inputs -> ...
 ```
 
-## Names for Class Instances
+## Names for Typeclass Instances
 
 Instances of a typeclass are named as "class name" followed by "type", that is the same order as in the instance declaration.
 For example:
@@ -119,6 +119,13 @@ unless there is a natural way to combine the type arguments as in
 instance map_types_pki: map_types pki_key pki_value = ...
 ```
 
+For typeclasses without arguments,
+the typeclass has to be explicitly mentioned in the instance declaration (after the `:`) and
+the name of the instance begins with the class name
+followed by some identifier:
+```fstar
+instance crypto_invariants_nsl : crypto_invariants = ...
+```
 
 # Code formatting
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,6 +99,27 @@ type f_inputs = {
 val f: f_inputs -> ...
 ```
 
+## Names for Class Instances
+
+Instances of a typeclass are named as "class name" followed by "type", that is the same order as in the instance declaration.
+For example:
+```fstar
+instance integer_encodable_usage: integer_encodable usage = ...
+instance bytes_like_bytes: bytes_like bytes = ...
+```
+
+If the typeclass has more than one type argument,
+all arguments should be explicitly specified in the name of the instance
+in the order given in the instance declaration:
+```fstar
+instance parseable_serializeable_bytes_tagged_state: parseable_serializeable bytes tagged_state = ...
+```
+unless there is a natural way to combine the type arguments as in
+```fstar
+instance map_types_pki: map_types pki_key pki_value = ...
+```
+
+
 # Code formatting
 
 Unfortunately, there is no code formatter for F\*.

--- a/examples/nsl_pk/DY.Example.NSL.Protocol.Stateful.Proof.fst
+++ b/examples/nsl_pk/DY.Example.NSL.Protocol.Stateful.Proof.fst
@@ -16,7 +16,7 @@ open DY.Example.NSL.Protocol.Stateful
 
 /// The (local) state predicate.
 
-let session_pred_nsl: local_state_predicate nsl_session = {
+let state_predicate_nsl: local_state_predicate nsl_session = {
   pred = (fun tr prin sess_id st ->
     match st with
     | InitiatorSentMsg1 bob n_a -> (
@@ -84,7 +84,7 @@ let event_predicate_nsl: event_predicate nsl_event =
 let all_sessions = [
   pki_tag_and_invariant;
   private_keys_tag_and_invariant;
-  (local_state_nsl_session.tag, local_state_predicate_to_local_bytes_state_predicate session_pred_nsl);
+  (local_state_nsl_session.tag, local_state_predicate_to_local_bytes_state_predicate state_predicate_nsl);
 ]
 
 /// List of all local event predicates.
@@ -119,7 +119,7 @@ let protocol_invariants_nsl_has_pki_invariant = all_sessions_has_all_sessions ()
 val protocol_invariants_nsl_has_private_keys_invariant: squash (has_private_keys_invariant protocol_invariants_nsl)
 let protocol_invariants_nsl_has_private_keys_invariant = all_sessions_has_all_sessions ()
 
-val protocol_invariants_nsl_has_nsl_session_invariant: squash (has_local_state_predicate protocol_invariants_nsl session_pred_nsl)
+val protocol_invariants_nsl_has_nsl_session_invariant: squash (has_local_state_predicate protocol_invariants_nsl state_predicate_nsl)
 let protocol_invariants_nsl_has_nsl_session_invariant = all_sessions_has_all_sessions ()
 
 /// Lemmas that the global event predicate contains all the local ones

--- a/examples/nsl_pk/DY.Example.NSL.Protocol.Stateful.Proof.fst
+++ b/examples/nsl_pk/DY.Example.NSL.Protocol.Stateful.Proof.fst
@@ -95,44 +95,44 @@ let all_events = [
 
 /// Create the global trace invariants.
 
-let nsl_trace_invs: trace_invariants (nsl_crypto_invs) = {
-  state_pred = mk_state_predicate nsl_crypto_invs all_sessions;
+let nsl_trace_invs: trace_invariants (crypto_invariants_nsl) = {
+  state_pred = mk_state_predicate crypto_invariants_nsl all_sessions;
   event_pred = mk_event_pred all_events;
 }
 
-instance nsl_protocol_invs: protocol_invariants = {
-  crypto_invs = nsl_crypto_invs;
+instance protocol_invariants_nsl: protocol_invariants = {
+  crypto_invs = crypto_invariants_nsl;
   trace_invs = nsl_trace_invs;
 }
 
 /// Lemmas that the global state predicate contains all the local ones
 
-val all_sessions_has_all_sessions: unit -> Lemma (norm [delta_only [`%all_sessions; `%for_allP]; iota; zeta] (for_allP (has_local_bytes_state_predicate nsl_protocol_invs) all_sessions))
+val all_sessions_has_all_sessions: unit -> Lemma (norm [delta_only [`%all_sessions; `%for_allP]; iota; zeta] (for_allP (has_local_bytes_state_predicate protocol_invariants_nsl) all_sessions))
 let all_sessions_has_all_sessions () =
   assert_norm(List.Tot.no_repeats_p (List.Tot.map fst (all_sessions)));
-  mk_global_local_bytes_state_predicate_correct nsl_protocol_invs all_sessions;
-  norm_spec [delta_only [`%all_sessions; `%for_allP]; iota; zeta] (for_allP (has_local_bytes_state_predicate nsl_protocol_invs) all_sessions)
+  mk_global_local_bytes_state_predicate_correct protocol_invariants_nsl all_sessions;
+  norm_spec [delta_only [`%all_sessions; `%for_allP]; iota; zeta] (for_allP (has_local_bytes_state_predicate protocol_invariants_nsl) all_sessions)
 
-val full_nsl_session_pred_has_pki_invariant: squash (has_pki_invariant nsl_protocol_invs)
+val full_nsl_session_pred_has_pki_invariant: squash (has_pki_invariant protocol_invariants_nsl)
 let full_nsl_session_pred_has_pki_invariant = all_sessions_has_all_sessions ()
 
-val full_nsl_session_pred_has_private_keys_invariant: squash (has_private_keys_invariant nsl_protocol_invs)
+val full_nsl_session_pred_has_private_keys_invariant: squash (has_private_keys_invariant protocol_invariants_nsl)
 let full_nsl_session_pred_has_private_keys_invariant = all_sessions_has_all_sessions ()
 
-val full_nsl_session_pred_has_nsl_invariant: squash (has_local_state_predicate nsl_protocol_invs nsl_session_pred)
+val full_nsl_session_pred_has_nsl_invariant: squash (has_local_state_predicate protocol_invariants_nsl nsl_session_pred)
 let full_nsl_session_pred_has_nsl_invariant = all_sessions_has_all_sessions ()
 
 /// Lemmas that the global event predicate contains all the local ones
 
-val all_events_has_all_events: unit -> Lemma (norm [delta_only [`%all_events; `%for_allP]; iota; zeta] (for_allP (has_compiled_event_pred nsl_protocol_invs) all_events))
+val all_events_has_all_events: unit -> Lemma (norm [delta_only [`%all_events; `%for_allP]; iota; zeta] (for_allP (has_compiled_event_pred protocol_invariants_nsl) all_events))
 let all_events_has_all_events () =
   assert_norm(List.Tot.no_repeats_p (List.Tot.map fst (all_events)));
-  mk_event_pred_correct nsl_protocol_invs all_events;
-  norm_spec [delta_only [`%all_events; `%for_allP]; iota; zeta] (for_allP (has_compiled_event_pred nsl_protocol_invs) all_events);
+  mk_event_pred_correct protocol_invariants_nsl all_events;
+  norm_spec [delta_only [`%all_events; `%for_allP]; iota; zeta] (for_allP (has_compiled_event_pred protocol_invariants_nsl) all_events);
   let dumb_lemma (x:prop) (y:prop): Lemma (requires x /\ x == y) (ensures y) = () in
-  dumb_lemma (for_allP (has_compiled_event_pred nsl_protocol_invs) all_events) (norm [delta_only [`%all_events; `%for_allP]; iota; zeta] (for_allP (has_compiled_event_pred nsl_protocol_invs) all_events))
+  dumb_lemma (for_allP (has_compiled_event_pred protocol_invariants_nsl) all_events) (norm [delta_only [`%all_events; `%for_allP]; iota; zeta] (for_allP (has_compiled_event_pred protocol_invariants_nsl) all_events))
 
-val full_nsl_event_pred_has_nsl_invariant: squash (has_event_pred nsl_protocol_invs nsl_event_pred)
+val full_nsl_event_pred_has_nsl_invariant: squash (has_event_pred protocol_invariants_nsl nsl_event_pred)
 let full_nsl_event_pred_has_nsl_invariant = all_events_has_all_events ()
 
 (*** Proofs ***)

--- a/examples/nsl_pk/DY.Example.NSL.Protocol.Stateful.Proof.fst
+++ b/examples/nsl_pk/DY.Example.NSL.Protocol.Stateful.Proof.fst
@@ -16,7 +16,7 @@ open DY.Example.NSL.Protocol.Stateful
 
 /// The (local) state predicate.
 
-let nsl_session_pred: local_state_predicate nsl_session = {
+let session_pred_nsl: local_state_predicate nsl_session = {
   pred = (fun tr prin sess_id st ->
     match st with
     | InitiatorSentMsg1 bob n_a -> (
@@ -49,7 +49,7 @@ let nsl_session_pred: local_state_predicate nsl_session = {
 
 /// The (local) event predicate.
 
-let nsl_event_pred: event_predicate nsl_event =
+let event_predicate_nsl: event_predicate nsl_event =
   fun tr prin e ->
     match e with
     | Initiate1 alice bob n_a -> (
@@ -84,25 +84,25 @@ let nsl_event_pred: event_predicate nsl_event =
 let all_sessions = [
   pki_tag_and_invariant;
   private_keys_tag_and_invariant;
-  (local_state_nsl_session.tag, local_state_predicate_to_local_bytes_state_predicate nsl_session_pred);
+  (local_state_nsl_session.tag, local_state_predicate_to_local_bytes_state_predicate session_pred_nsl);
 ]
 
 /// List of all local event predicates.
 
 let all_events = [
-  (event_nsl_event.tag, compile_event_pred nsl_event_pred)
+  (event_nsl_event.tag, compile_event_pred event_predicate_nsl)
 ]
 
 /// Create the global trace invariants.
 
-let nsl_trace_invs: trace_invariants (crypto_invariants_nsl) = {
+let trace_invariants_nsl: trace_invariants (crypto_invariants_nsl) = {
   state_pred = mk_state_predicate crypto_invariants_nsl all_sessions;
   event_pred = mk_event_pred all_events;
 }
 
 instance protocol_invariants_nsl: protocol_invariants = {
   crypto_invs = crypto_invariants_nsl;
-  trace_invs = nsl_trace_invs;
+  trace_invs = trace_invariants_nsl;
 }
 
 /// Lemmas that the global state predicate contains all the local ones
@@ -113,14 +113,14 @@ let all_sessions_has_all_sessions () =
   mk_global_local_bytes_state_predicate_correct protocol_invariants_nsl all_sessions;
   norm_spec [delta_only [`%all_sessions; `%for_allP]; iota; zeta] (for_allP (has_local_bytes_state_predicate protocol_invariants_nsl) all_sessions)
 
-val full_nsl_session_pred_has_pki_invariant: squash (has_pki_invariant protocol_invariants_nsl)
-let full_nsl_session_pred_has_pki_invariant = all_sessions_has_all_sessions ()
+val protocol_invariants_nsl_has_pki_invariant: squash (has_pki_invariant protocol_invariants_nsl)
+let protocol_invariants_nsl_has_pki_invariant = all_sessions_has_all_sessions ()
 
-val full_nsl_session_pred_has_private_keys_invariant: squash (has_private_keys_invariant protocol_invariants_nsl)
-let full_nsl_session_pred_has_private_keys_invariant = all_sessions_has_all_sessions ()
+val protocol_invariants_nsl_has_private_keys_invariant: squash (has_private_keys_invariant protocol_invariants_nsl)
+let protocol_invariants_nsl_has_private_keys_invariant = all_sessions_has_all_sessions ()
 
-val full_nsl_session_pred_has_nsl_invariant: squash (has_local_state_predicate protocol_invariants_nsl nsl_session_pred)
-let full_nsl_session_pred_has_nsl_invariant = all_sessions_has_all_sessions ()
+val protocol_invariants_nsl_has_nsl_session_invariant: squash (has_local_state_predicate protocol_invariants_nsl session_pred_nsl)
+let protocol_invariants_nsl_has_nsl_session_invariant = all_sessions_has_all_sessions ()
 
 /// Lemmas that the global event predicate contains all the local ones
 
@@ -132,8 +132,8 @@ let all_events_has_all_events () =
   let dumb_lemma (x:prop) (y:prop): Lemma (requires x /\ x == y) (ensures y) = () in
   dumb_lemma (for_allP (has_compiled_event_pred protocol_invariants_nsl) all_events) (norm [delta_only [`%all_events; `%for_allP]; iota; zeta] (for_allP (has_compiled_event_pred protocol_invariants_nsl) all_events))
 
-val full_nsl_event_pred_has_nsl_invariant: squash (has_event_pred protocol_invariants_nsl nsl_event_pred)
-let full_nsl_event_pred_has_nsl_invariant = all_events_has_all_events ()
+val protocol_invariants_nsl_has_nsl_event_invariant: squash (has_event_pred protocol_invariants_nsl event_predicate_nsl)
+let protocol_invariants_nsl_has_nsl_event_invariant = all_events_has_all_events ()
 
 (*** Proofs ***)
 

--- a/examples/nsl_pk/DY.Example.NSL.Protocol.Stateful.fst
+++ b/examples/nsl_pk/DY.Example.NSL.Protocol.Stateful.fst
@@ -23,12 +23,12 @@ type nsl_session =
 %splice [ps_nsl_session] (gen_parser (`nsl_session))
 %splice [ps_nsl_session_is_well_formed] (gen_is_well_formed_lemma (`nsl_session))
 
-instance nsl_session_parseable_serializeable: parseable_serializeable bytes nsl_session
+instance parseable_serializeable_bytes_nsl_session: parseable_serializeable bytes nsl_session
  = mk_parseable_serializeable ps_nsl_session
 
 instance local_state_nsl_session: local_state nsl_session = {
   tag = "NSL.Session";
-  format = nsl_session_parseable_serializeable;
+  format = parseable_serializeable_bytes_nsl_session;
 }
 
 (*** Event type ***)

--- a/examples/nsl_pk/DY.Example.NSL.Protocol.Total.Proof.fst
+++ b/examples/nsl_pk/DY.Example.NSL.Protocol.Total.Proof.fst
@@ -17,8 +17,8 @@ open DY.Example.NSL.Protocol.Stateful
 instance crypto_usages_nsl : crypto_usages = default_crypto_usages
 
 #push-options "--ifuel 2 --fuel 0"
-val nsl_crypto_preds: crypto_predicates crypto_usages_nsl
-let nsl_crypto_preds = {
+val crypto_predicates_nsl: crypto_predicates crypto_usages_nsl
+let crypto_predicates_nsl = {
   default_crypto_predicates crypto_usages_nsl with
 
   pkenc_pred = (fun tr pk msg ->
@@ -50,7 +50,7 @@ let nsl_crypto_preds = {
 
 instance crypto_invariants_nsl : crypto_invariants = {
   usages = crypto_usages_nsl;
-  preds = nsl_crypto_preds;
+  preds = crypto_predicates_nsl;
 }
 
 (*** Proofs ***)

--- a/examples/nsl_pk/DY.Example.NSL.Protocol.Total.Proof.fst
+++ b/examples/nsl_pk/DY.Example.NSL.Protocol.Total.Proof.fst
@@ -14,13 +14,12 @@ open DY.Example.NSL.Protocol.Stateful
 
 (*** Cryptographic invariants ***)
 
-val nsl_crypto_usages: crypto_usages
-instance nsl_crypto_usages = default_crypto_usages
+instance crypto_usages_nsl : crypto_usages = default_crypto_usages
 
 #push-options "--ifuel 2 --fuel 0"
-val nsl_crypto_preds: crypto_predicates nsl_crypto_usages
+val nsl_crypto_preds: crypto_predicates crypto_usages_nsl
 let nsl_crypto_preds = {
-  default_crypto_predicates nsl_crypto_usages with
+  default_crypto_predicates crypto_usages_nsl with
 
   pkenc_pred = (fun tr pk msg ->
     get_sk_usage pk == PkdecKey "NSL.PublicKey" /\
@@ -49,8 +48,8 @@ let nsl_crypto_preds = {
 }
 #pop-options
 
-instance nsl_crypto_invs = {
-  usages = nsl_crypto_usages;
+instance crypto_invariants_nsl : crypto_invariants = {
+  usages = crypto_usages_nsl;
   preds = nsl_crypto_preds;
 }
 

--- a/examples/nsl_pk/DY.Example.NSL.Protocol.Total.fst
+++ b/examples/nsl_pk/DY.Example.NSL.Protocol.Total.fst
@@ -64,7 +64,7 @@ type message =
 %splice [ps_message] (gen_parser (`message))
 %splice [ps_message_is_well_formed] (gen_is_well_formed_lemma (`message))
 
-instance parseable_serializeable_message: parseable_serializeable bytes message = mk_parseable_serializeable ps_message
+instance parseable_serializeable_bytes_message: parseable_serializeable bytes message = mk_parseable_serializeable ps_message
 
 (*** Message 1 ***)
 

--- a/src/lib/state/DY.Lib.State.Map.fst
+++ b/src/lib/state/DY.Lib.State.Map.fst
@@ -56,11 +56,11 @@ noeq type map (key_t:eqtype) (value_t:Type0) {|mt:map_types key_t value_t|} = {
 %splice [ps_map] (gen_parser (`map))
 %splice [ps_map_is_well_formed] (gen_is_well_formed_lemma (`map))
 
-instance parseable_serializeable_map (key_t:eqtype) (value_t:Type0) {|map_types key_t value_t|} : parseable_serializeable bytes (map key_t value_t) = mk_parseable_serializeable (ps_map key_t value_t)
+instance parseable_serializeable_bytes_map (key_t:eqtype) (value_t:Type0) {|map_types key_t value_t|} : parseable_serializeable bytes (map key_t value_t) = mk_parseable_serializeable (ps_map key_t value_t)
 
-instance map_has_local_state (key_t:eqtype) (value_t:Type0) {|mt:map_types key_t value_t|}: local_state (map key_t value_t) = {
+instance local_state_map (key_t:eqtype) (value_t:Type0) {|mt:map_types key_t value_t|}: local_state (map key_t value_t) = {
   tag = mt.tag;
-  format = (parseable_serializeable_map key_t value_t);
+  format = (parseable_serializeable_bytes_map key_t value_t);
 }
 
 val map_elem_invariant:

--- a/src/lib/state/DY.Lib.State.Tagged.fst
+++ b/src/lib/state/DY.Lib.State.Tagged.fst
@@ -20,7 +20,7 @@ type tagged_state = {
 %splice [ps_tagged_state] (gen_parser (`tagged_state))
 %splice [ps_tagged_state_is_well_formed] (gen_is_well_formed_lemma (`tagged_state))
 
-instance parseable_serializeable_tagged_state: parseable_serializeable bytes tagged_state = mk_parseable_serializeable (ps_tagged_state)
+instance parseable_serializeable_bytes_tagged_state: parseable_serializeable bytes tagged_state = mk_parseable_serializeable (ps_tagged_state)
 
 noeq
 type local_bytes_state_predicate {|crypto_invariants|} = {


### PR DESCRIPTION
Fixing https://github.com/REPROSEC/dolev-yao-star-extrinsic/issues/20.

I also changed some names in the NSL example, so that it is more consistent. (Basically, moving the `nsl_` prefixes to the end).
For example: with the new typeclass naming convention we have `crypto_invariants_nsl` but the corresponding `nsl_trace_invariants` are not a typeclass instance. Still I renamed the latter to match the `crypto_invariants`.

The only places where `nsl_` is left as prefix are: `nsl_session`, `nsl_event` and `nsl_global_sess_ids`, for which I think this is ok.