### PR TITLE
Some cleanup on states/session/version and types for session id and timestamp

### DIFF
--- a/examples/nsl_pk/DY.Example.NSL.Debug.Printing.fst
+++ b/examples/nsl_pk/DY.Example.NSL.Debug.Printing.fst
@@ -35,11 +35,11 @@ let message_to_string sk_a sk_b msg_bytes =
   | Msg3 msg3 -> Some (Printf.sprintf "PkEnc[sk=(%s), msg=(n_b=(%s))]" (bytes_to_string sk_b) (bytes_to_string msg3.n_b))
 
 
-(*** Convert NSL Sessions to String ***)
+(*** Convert NSL Versions to String ***)
 
-val session_to_string: bytes -> option string
-let session_to_string sess_bytes =
-  let? sess = parse nsl_session sess_bytes in
+val version_to_string: bytes -> option string
+let version_to_string sess_bytes =
+  let? sess = parse nsl_version sess_bytes in
   match sess with
   | InitiatorSentMsg1 b n_a -> (
     Some (Printf.sprintf "[principal=%s, n_a=(%s)]" b (bytes_to_string n_a))
@@ -81,5 +81,5 @@ val get_nsl_trace_to_string_printers: bytes -> bytes -> trace_to_string_printers
 let get_nsl_trace_to_string_printers priv_key_alice priv_key_bob = 
   trace_to_string_printers_builder 
     (message_to_string priv_key_alice priv_key_bob)
-    [(local_state_nsl_session.tag, session_to_string)]
+    [(local_version_nsl_version.tag, version_to_string)]
     [(event_nsl_event.tag, event_to_string)]

--- a/examples/nsl_pk/DY.Example.NSL.Debug.Printing.fst
+++ b/examples/nsl_pk/DY.Example.NSL.Debug.Printing.fst
@@ -35,11 +35,11 @@ let message_to_string sk_a sk_b msg_bytes =
   | Msg3 msg3 -> Some (Printf.sprintf "PkEnc[sk=(%s), msg=(n_b=(%s))]" (bytes_to_string sk_b) (bytes_to_string msg3.n_b))
 
 
-(*** Convert NSL Versions to String ***)
+(*** Convert NSL Sessions to String ***)
 
-val version_to_string: bytes -> option string
-let version_to_string sess_bytes =
-  let? sess = parse nsl_version sess_bytes in
+val session_to_string: bytes -> option string
+let session_to_string sess_bytes =
+  let? sess = parse nsl_session sess_bytes in
   match sess with
   | InitiatorSentMsg1 b n_a -> (
     Some (Printf.sprintf "[principal=%s, n_a=(%s)]" b (bytes_to_string n_a))
@@ -81,5 +81,5 @@ val get_nsl_trace_to_string_printers: bytes -> bytes -> trace_to_string_printers
 let get_nsl_trace_to_string_printers priv_key_alice priv_key_bob = 
   trace_to_string_printers_builder 
     (message_to_string priv_key_alice priv_key_bob)
-    [(local_version_nsl_version.tag, version_to_string)]
+    [(local_state_nsl_session.tag, session_to_string)]
     [(event_nsl_event.tag, event_to_string)]

--- a/examples/nsl_pk/DY.Example.NSL.Protocol.Stateful.Proof.fst
+++ b/examples/nsl_pk/DY.Example.NSL.Protocol.Stateful.Proof.fst
@@ -151,7 +151,7 @@ let prepare_msg1_proof tr alice bob =
 
 val send_msg1_proof:
   tr:trace ->
-  global_sess_id:nsl_global_sess_ids -> alice:principal -> sess_id:nat ->
+  global_sess_id:nsl_global_sess_ids -> alice:principal -> sess_id:session_id ->
   Lemma
   (requires trace_invariant tr)
   (ensures (
@@ -192,7 +192,7 @@ let prepare_msg2_proof tr global_sess_id bob msg_id =
 
 val send_msg2_proof:
   tr:trace ->
-  global_sess_id:nsl_global_sess_ids -> bob:principal -> sess_id:nat ->
+  global_sess_id:nsl_global_sess_ids -> bob:principal -> sess_id:session_id ->
   Lemma
   (requires trace_invariant tr)
   (ensures (
@@ -213,7 +213,7 @@ let send_msg2_proof tr global_sess_id bob sess_id =
 
 val prepare_msg3_proof:
   tr:trace ->
-  global_sess_id:nsl_global_sess_ids -> alice:principal -> sess_id:nat -> msg_id:nat ->
+  global_sess_id:nsl_global_sess_ids -> alice:principal -> sess_id:session_id -> msg_id:nat ->
   Lemma
   (requires trace_invariant tr)
   (ensures (
@@ -237,7 +237,7 @@ let prepare_msg3_proof tr global_sess_id alice sess_id msg_id =
 
 val send_msg3_proof:
   tr:trace ->
-  global_sess_id:nsl_global_sess_ids -> alice:principal -> sess_id:nat ->
+  global_sess_id:nsl_global_sess_ids -> alice:principal -> sess_id:session_id ->
   Lemma
   (requires trace_invariant tr)
   (ensures (
@@ -275,7 +275,7 @@ let event_respond1_injective tr alice alice' bob n_a n_a' n_b = ()
 #push-options "--z3rlimit 50"
 val prepare_msg4:
   tr:trace ->
-  global_sess_id:nsl_global_sess_ids -> bob:principal -> sess_id:nat -> msg_id:nat ->
+  global_sess_id:nsl_global_sess_ids -> bob:principal -> sess_id:session_id -> msg_id:nat ->
   Lemma
   (requires trace_invariant tr)
   (ensures (

--- a/examples/nsl_pk/DY.Example.NSL.Protocol.Stateful.Proof.fst
+++ b/examples/nsl_pk/DY.Example.NSL.Protocol.Stateful.Proof.fst
@@ -151,7 +151,7 @@ let prepare_msg1_proof tr alice bob =
 
 val send_msg1_proof:
   tr:trace ->
-  global_sess_id:nsl_global_sess_ids -> alice:principal -> sess_id:session_id ->
+  global_sess_id:nsl_global_sess_ids -> alice:principal -> sess_id:state_id ->
   Lemma
   (requires trace_invariant tr)
   (ensures (
@@ -192,7 +192,7 @@ let prepare_msg2_proof tr global_sess_id bob msg_id =
 
 val send_msg2_proof:
   tr:trace ->
-  global_sess_id:nsl_global_sess_ids -> bob:principal -> sess_id:session_id ->
+  global_sess_id:nsl_global_sess_ids -> bob:principal -> sess_id:state_id ->
   Lemma
   (requires trace_invariant tr)
   (ensures (
@@ -213,7 +213,7 @@ let send_msg2_proof tr global_sess_id bob sess_id =
 
 val prepare_msg3_proof:
   tr:trace ->
-  global_sess_id:nsl_global_sess_ids -> alice:principal -> sess_id:session_id -> msg_id:timestamp ->
+  global_sess_id:nsl_global_sess_ids -> alice:principal -> sess_id:state_id -> msg_id:timestamp ->
   Lemma
   (requires trace_invariant tr)
   (ensures (
@@ -237,7 +237,7 @@ let prepare_msg3_proof tr global_sess_id alice sess_id msg_id =
 
 val send_msg3_proof:
   tr:trace ->
-  global_sess_id:nsl_global_sess_ids -> alice:principal -> sess_id:session_id ->
+  global_sess_id:nsl_global_sess_ids -> alice:principal -> sess_id:state_id ->
   Lemma
   (requires trace_invariant tr)
   (ensures (
@@ -275,7 +275,7 @@ let event_respond1_injective tr alice alice' bob n_a n_a' n_b = ()
 #push-options "--z3rlimit 50"
 val prepare_msg4:
   tr:trace ->
-  global_sess_id:nsl_global_sess_ids -> bob:principal -> sess_id:session_id -> msg_id:timestamp ->
+  global_sess_id:nsl_global_sess_ids -> bob:principal -> sess_id:state_id -> msg_id:timestamp ->
   Lemma
   (requires trace_invariant tr)
   (ensures (

--- a/examples/nsl_pk/DY.Example.NSL.Protocol.Stateful.Proof.fst
+++ b/examples/nsl_pk/DY.Example.NSL.Protocol.Stateful.Proof.fst
@@ -16,7 +16,7 @@ open DY.Example.NSL.Protocol.Stateful
 
 /// The (local) state predicate.
 
-let state_predicate_nsl: local_state_predicate nsl_version = {
+let state_predicate_nsl: local_state_predicate nsl_session = {
   pred = (fun tr prin sess_id st ->
     match st with
     | InitiatorSentMsg1 bob n_a -> (
@@ -84,7 +84,7 @@ let event_predicate_nsl: event_predicate nsl_event =
 let all_sessions = [
   pki_tag_and_invariant;
   private_keys_tag_and_invariant;
-  (local_version_nsl_version.tag, local_state_predicate_to_local_bytes_state_predicate state_predicate_nsl);
+  (local_state_nsl_session.tag, local_state_predicate_to_local_bytes_state_predicate state_predicate_nsl);
 ]
 
 /// List of all local event predicates.
@@ -159,7 +159,7 @@ val send_msg1_proof:
     trace_invariant tr_out
   ))
 let send_msg1_proof tr global_sess_id alice sess_id =
-  match get_latest_version alice sess_id tr with
+  match get_state alice sess_id tr with
   | (Some (InitiatorSentMsg1 bob n_a), tr) -> (
     match get_public_key alice global_sess_id.pki (PkEnc "NSL.PublicKey") bob tr with
     | (None, tr) -> ()
@@ -200,7 +200,7 @@ val send_msg2_proof:
     trace_invariant tr_out
   ))
 let send_msg2_proof tr global_sess_id bob sess_id =
-  match get_latest_version bob sess_id tr with
+  match get_state bob sess_id tr with
   | (Some (ResponderSentMsg2 alice n_a n_b), tr) -> (
     match get_public_key bob global_sess_id.pki (PkEnc "NSL.PublicKey") alice tr with
     | (None, tr) -> ()
@@ -227,7 +227,7 @@ let prepare_msg3_proof tr global_sess_id alice sess_id msg_id =
     match get_private_key alice global_sess_id.private_keys (PkDec "NSL.PublicKey") tr with
     | (None, tr) -> ()
     | (Some sk_a, tr) -> (
-      match get_latest_version alice sess_id tr with
+      match get_state alice sess_id tr with
       | (Some (InitiatorSentMsg1 bob n_a), tr) -> (
         decode_message2_proof tr alice bob msg sk_a n_a
       )
@@ -245,7 +245,7 @@ val send_msg3_proof:
     trace_invariant tr_out
   ))
 let send_msg3_proof tr global_sess_id alice sess_id =
-  match get_latest_version alice sess_id tr with
+  match get_state alice sess_id tr with
   | (Some (InitiatorSentMsg3 bob n_a n_b), tr) -> (
     match get_public_key alice global_sess_id.pki (PkEnc "NSL.PublicKey") bob tr with
     | (None, tr) -> ()
@@ -289,7 +289,7 @@ let prepare_msg4 tr global_sess_id bob sess_id msg_id =
     match get_private_key bob global_sess_id.private_keys (PkDec "NSL.PublicKey") tr with
     | (None, tr) -> ()
     | (Some sk_b, tr) -> (
-      match get_latest_version bob sess_id tr with
+      match get_state bob sess_id tr with
       | (Some (ResponderSentMsg2 alice n_a n_b), tr) -> (
         decode_message3_proof tr alice bob msg sk_b n_b;
 

--- a/examples/nsl_pk/DY.Example.NSL.Protocol.Stateful.Proof.fst
+++ b/examples/nsl_pk/DY.Example.NSL.Protocol.Stateful.Proof.fst
@@ -172,7 +172,7 @@ let send_msg1_proof tr global_sess_id alice sess_id =
 
 val prepare_msg2_proof:
   tr:trace ->
-  global_sess_id:nsl_global_sess_ids -> bob:principal -> msg_id:nat ->
+  global_sess_id:nsl_global_sess_ids -> bob:principal -> msg_id:timestamp ->
   Lemma
   (requires trace_invariant tr)
   (ensures (
@@ -213,7 +213,7 @@ let send_msg2_proof tr global_sess_id bob sess_id =
 
 val prepare_msg3_proof:
   tr:trace ->
-  global_sess_id:nsl_global_sess_ids -> alice:principal -> sess_id:session_id -> msg_id:nat ->
+  global_sess_id:nsl_global_sess_ids -> alice:principal -> sess_id:session_id -> msg_id:timestamp ->
   Lemma
   (requires trace_invariant tr)
   (ensures (
@@ -275,7 +275,7 @@ let event_respond1_injective tr alice alice' bob n_a n_a' n_b = ()
 #push-options "--z3rlimit 50"
 val prepare_msg4:
   tr:trace ->
-  global_sess_id:nsl_global_sess_ids -> bob:principal -> sess_id:session_id -> msg_id:nat ->
+  global_sess_id:nsl_global_sess_ids -> bob:principal -> sess_id:session_id -> msg_id:timestamp ->
   Lemma
   (requires trace_invariant tr)
   (ensures (

--- a/examples/nsl_pk/DY.Example.NSL.Protocol.Stateful.Proof.fst
+++ b/examples/nsl_pk/DY.Example.NSL.Protocol.Stateful.Proof.fst
@@ -16,7 +16,7 @@ open DY.Example.NSL.Protocol.Stateful
 
 /// The (local) state predicate.
 
-let state_predicate_nsl: local_state_predicate nsl_session = {
+let state_predicate_nsl: local_state_predicate nsl_version = {
   pred = (fun tr prin sess_id st ->
     match st with
     | InitiatorSentMsg1 bob n_a -> (
@@ -84,7 +84,7 @@ let event_predicate_nsl: event_predicate nsl_event =
 let all_sessions = [
   pki_tag_and_invariant;
   private_keys_tag_and_invariant;
-  (local_state_nsl_session.tag, local_state_predicate_to_local_bytes_state_predicate state_predicate_nsl);
+  (local_version_nsl_version.tag, local_state_predicate_to_local_bytes_state_predicate state_predicate_nsl);
 ]
 
 /// List of all local event predicates.
@@ -159,7 +159,7 @@ val send_msg1_proof:
     trace_invariant tr_out
   ))
 let send_msg1_proof tr global_sess_id alice sess_id =
-  match get_state alice sess_id tr with
+  match get_latest_version alice sess_id tr with
   | (Some (InitiatorSentMsg1 bob n_a), tr) -> (
     match get_public_key alice global_sess_id.pki (PkEnc "NSL.PublicKey") bob tr with
     | (None, tr) -> ()
@@ -200,7 +200,7 @@ val send_msg2_proof:
     trace_invariant tr_out
   ))
 let send_msg2_proof tr global_sess_id bob sess_id =
-  match get_state bob sess_id tr with
+  match get_latest_version bob sess_id tr with
   | (Some (ResponderSentMsg2 alice n_a n_b), tr) -> (
     match get_public_key bob global_sess_id.pki (PkEnc "NSL.PublicKey") alice tr with
     | (None, tr) -> ()
@@ -227,7 +227,7 @@ let prepare_msg3_proof tr global_sess_id alice sess_id msg_id =
     match get_private_key alice global_sess_id.private_keys (PkDec "NSL.PublicKey") tr with
     | (None, tr) -> ()
     | (Some sk_a, tr) -> (
-      match get_state alice sess_id tr with
+      match get_latest_version alice sess_id tr with
       | (Some (InitiatorSentMsg1 bob n_a), tr) -> (
         decode_message2_proof tr alice bob msg sk_a n_a
       )
@@ -245,7 +245,7 @@ val send_msg3_proof:
     trace_invariant tr_out
   ))
 let send_msg3_proof tr global_sess_id alice sess_id =
-  match get_state alice sess_id tr with
+  match get_latest_version alice sess_id tr with
   | (Some (InitiatorSentMsg3 bob n_a n_b), tr) -> (
     match get_public_key alice global_sess_id.pki (PkEnc "NSL.PublicKey") bob tr with
     | (None, tr) -> ()
@@ -289,7 +289,7 @@ let prepare_msg4 tr global_sess_id bob sess_id msg_id =
     match get_private_key bob global_sess_id.private_keys (PkDec "NSL.PublicKey") tr with
     | (None, tr) -> ()
     | (Some sk_b, tr) -> (
-      match get_state bob sess_id tr with
+      match get_latest_version bob sess_id tr with
       | (Some (ResponderSentMsg2 alice n_a n_b), tr) -> (
         decode_message3_proof tr alice bob msg sk_b n_b;
 

--- a/examples/nsl_pk/DY.Example.NSL.Protocol.Stateful.fst
+++ b/examples/nsl_pk/DY.Example.NSL.Protocol.Stateful.fst
@@ -58,7 +58,7 @@ type nsl_global_sess_ids = {
   private_keys: nat;
 }
 
-val prepare_msg1: principal -> principal -> traceful nat
+val prepare_msg1: principal -> principal -> traceful session_id
 let prepare_msg1 alice bob =
   let* n_a = mk_rand NoUsage (join (principal_label alice) (principal_label bob)) 32 in
   trigger_event alice (Initiate1 alice bob n_a);*
@@ -66,7 +66,7 @@ let prepare_msg1 alice bob =
   set_version alice sess_id (InitiatorSentMsg1 bob n_a <: nsl_version);*
   return sess_id
 
-val send_msg1: nsl_global_sess_ids -> principal -> nat -> traceful (option nat)
+val send_msg1: nsl_global_sess_ids -> principal -> session_id -> traceful (option nat)
 let send_msg1 global_sess_id alice sess_id =
   let*? st: nsl_version = get_latest_version alice sess_id in
   match st with
@@ -79,7 +79,7 @@ let send_msg1 global_sess_id alice sess_id =
   )
   | _ -> return None
 
-val prepare_msg2: nsl_global_sess_ids -> principal -> nat -> traceful (option nat)
+val prepare_msg2: nsl_global_sess_ids -> principal -> session_id -> traceful (option session_id)
 let prepare_msg2 global_sess_id bob msg_id =
   let*? msg = recv_msg msg_id in
   let*? sk_b = get_private_key bob global_sess_id.private_keys (PkDec "NSL.PublicKey") in
@@ -90,7 +90,7 @@ let prepare_msg2 global_sess_id bob msg_id =
   set_version bob sess_id (ResponderSentMsg2 msg1.alice msg1.n_a n_b <: nsl_version);*
   return (Some sess_id)
 
-val send_msg2: nsl_global_sess_ids -> principal -> nat -> traceful (option nat)
+val send_msg2: nsl_global_sess_ids -> principal -> session_id -> traceful (option nat)
 let send_msg2 global_sess_id bob sess_id =
   let*? st: nsl_version = get_latest_version bob sess_id in
   match st with
@@ -103,7 +103,7 @@ let send_msg2 global_sess_id bob sess_id =
   )
   | _ -> return None
 
-val prepare_msg3: nsl_global_sess_ids -> principal -> nat -> nat -> traceful (option unit)
+val prepare_msg3: nsl_global_sess_ids -> principal -> session_id -> nat -> traceful (option unit)
 let prepare_msg3 global_sess_id alice sess_id msg_id =
   let*? msg = recv_msg msg_id in
   let*? sk_a = get_private_key alice global_sess_id.private_keys (PkDec "NSL.PublicKey") in
@@ -117,7 +117,7 @@ let prepare_msg3 global_sess_id alice sess_id msg_id =
   )
   | _ -> return None
 
-val send_msg3: nsl_global_sess_ids -> principal -> nat -> traceful (option nat)
+val send_msg3: nsl_global_sess_ids -> principal -> session_id -> traceful (option nat)
 let send_msg3 global_sess_id alice sess_id =
   let*? st: nsl_version = get_latest_version alice sess_id in
   match st with
@@ -130,7 +130,7 @@ let send_msg3 global_sess_id alice sess_id =
   )
   | _ -> return None
 
-val prepare_msg4: nsl_global_sess_ids -> principal -> nat -> nat -> traceful (option unit)
+val prepare_msg4: nsl_global_sess_ids -> principal -> session_id -> nat -> traceful (option unit)
 let prepare_msg4 global_sess_id bob sess_id msg_id =
   let*? msg = recv_msg msg_id in
   let*? sk_b = get_private_key bob global_sess_id.private_keys (PkDec "NSL.PublicKey") in

--- a/examples/nsl_pk/DY.Example.NSL.Protocol.Stateful.fst
+++ b/examples/nsl_pk/DY.Example.NSL.Protocol.Stateful.fst
@@ -9,26 +9,26 @@ open DY.Example.NSL.Protocol.Total
 /// This effectively connects the pure code of NSL to the outside world,
 /// by handling network connections, state storage, or random generation.
 
-(*** State type ***)
+(*** Version type ***)
 
 /// Type for the NSL state machine
 
 [@@ with_bytes bytes]
-type nsl_session =
-  | InitiatorSentMsg1: b:principal -> n_a:bytes -> nsl_session
-  | ResponderSentMsg2: a:principal -> n_a:bytes -> n_b:bytes -> nsl_session
-  | InitiatorSentMsg3: b:principal -> n_a:bytes -> n_b:bytes -> nsl_session
-  | ResponderReceivedMsg3: a:principal -> n_a:bytes -> n_b:bytes -> nsl_session
+type nsl_version =
+  | InitiatorSentMsg1: b:principal -> n_a:bytes -> nsl_version
+  | ResponderSentMsg2: a:principal -> n_a:bytes -> n_b:bytes -> nsl_version
+  | InitiatorSentMsg3: b:principal -> n_a:bytes -> n_b:bytes -> nsl_version
+  | ResponderReceivedMsg3: a:principal -> n_a:bytes -> n_b:bytes -> nsl_version
 
-%splice [ps_nsl_session] (gen_parser (`nsl_session))
-%splice [ps_nsl_session_is_well_formed] (gen_is_well_formed_lemma (`nsl_session))
+%splice [ps_nsl_version] (gen_parser (`nsl_version))
+%splice [ps_nsl_version_is_well_formed] (gen_is_well_formed_lemma (`nsl_version))
 
-instance parseable_serializeable_bytes_nsl_session: parseable_serializeable bytes nsl_session
- = mk_parseable_serializeable ps_nsl_session
+instance parseable_serializeable_bytes_nsl_version: parseable_serializeable bytes nsl_version
+ = mk_parseable_serializeable ps_nsl_version
 
-instance local_state_nsl_session: local_state nsl_session = {
-  tag = "NSL.Session";
-  format = parseable_serializeable_bytes_nsl_session;
+instance local_version_nsl_version: local_version nsl_version = {
+  tag = "NSL.Version";
+  format = parseable_serializeable_bytes_nsl_version;
 }
 
 (*** Event type ***)
@@ -63,12 +63,12 @@ let prepare_msg1 alice bob =
   let* n_a = mk_rand NoUsage (join (principal_label alice) (principal_label bob)) 32 in
   trigger_event alice (Initiate1 alice bob n_a);*
   let* sess_id = new_session_id alice in
-  set_state alice sess_id (InitiatorSentMsg1 bob n_a <: nsl_session);*
+  set_version alice sess_id (InitiatorSentMsg1 bob n_a <: nsl_version);*
   return sess_id
 
 val send_msg1: nsl_global_sess_ids -> principal -> nat -> traceful (option nat)
 let send_msg1 global_sess_id alice sess_id =
-  let*? st: nsl_session = get_state alice sess_id in
+  let*? st: nsl_version = get_latest_version alice sess_id in
   match st with
   | InitiatorSentMsg1 bob n_a -> (
     let*? pk_b = get_public_key alice global_sess_id.pki (PkEnc "NSL.PublicKey") bob in
@@ -87,12 +87,12 @@ let prepare_msg2 global_sess_id bob msg_id =
   let* n_b = mk_rand NoUsage (join (principal_label msg1.alice) (principal_label bob)) 32 in
   trigger_event bob (Respond1 msg1.alice bob msg1.n_a n_b);*
   let* sess_id = new_session_id bob in
-  set_state bob sess_id (ResponderSentMsg2 msg1.alice msg1.n_a n_b <: nsl_session);*
+  set_version bob sess_id (ResponderSentMsg2 msg1.alice msg1.n_a n_b <: nsl_version);*
   return (Some sess_id)
 
 val send_msg2: nsl_global_sess_ids -> principal -> nat -> traceful (option nat)
 let send_msg2 global_sess_id bob sess_id =
-  let*? st: nsl_session = get_state bob sess_id in
+  let*? st: nsl_version = get_latest_version bob sess_id in
   match st with
   | ResponderSentMsg2 alice n_a n_b -> (
     let*? pk_a = get_public_key bob global_sess_id.pki (PkEnc "NSL.PublicKey") alice in
@@ -107,19 +107,19 @@ val prepare_msg3: nsl_global_sess_ids -> principal -> nat -> nat -> traceful (op
 let prepare_msg3 global_sess_id alice sess_id msg_id =
   let*? msg = recv_msg msg_id in
   let*? sk_a = get_private_key alice global_sess_id.private_keys (PkDec "NSL.PublicKey") in
-  let*? st: nsl_session = get_state alice sess_id in
+  let*? st: nsl_version = get_latest_version alice sess_id in
   match st with
   | InitiatorSentMsg1 bob n_a -> (
     let*? msg2: message2 = return (decode_message2 alice bob msg sk_a n_a) in
     trigger_event alice (Initiate2 alice bob n_a msg2.n_b);*
-    set_state alice sess_id (InitiatorSentMsg3 bob n_a msg2.n_b <: nsl_session);*
+    set_version alice sess_id (InitiatorSentMsg3 bob n_a msg2.n_b <: nsl_version);*
     return (Some ())
   )
   | _ -> return None
 
 val send_msg3: nsl_global_sess_ids -> principal -> nat -> traceful (option nat)
 let send_msg3 global_sess_id alice sess_id =
-  let*? st: nsl_session = get_state alice sess_id in
+  let*? st: nsl_version = get_latest_version alice sess_id in
   match st with
   | InitiatorSentMsg3 bob n_a n_b -> (
     let*? pk_b = get_public_key alice global_sess_id.pki (PkEnc "NSL.PublicKey") bob in
@@ -134,12 +134,12 @@ val prepare_msg4: nsl_global_sess_ids -> principal -> nat -> nat -> traceful (op
 let prepare_msg4 global_sess_id bob sess_id msg_id =
   let*? msg = recv_msg msg_id in
   let*? sk_b = get_private_key bob global_sess_id.private_keys (PkDec "NSL.PublicKey") in
-  let*? st: nsl_session = get_state bob sess_id in
+  let*? st: nsl_version = get_latest_version bob sess_id in
   match st with
   | ResponderSentMsg2 alice n_a n_b -> (
     let*? msg3: message3 = return (decode_message3 alice bob msg sk_b n_b) in
     trigger_event bob (Respond2 alice bob n_a n_b);*
-    set_state bob sess_id (ResponderReceivedMsg3 alice n_a n_b <: nsl_session);*
+    set_version bob sess_id (ResponderReceivedMsg3 alice n_a n_b <: nsl_version);*
     return (Some ())
   )
   | _ -> return None

--- a/examples/nsl_pk/DY.Example.NSL.Protocol.Stateful.fst
+++ b/examples/nsl_pk/DY.Example.NSL.Protocol.Stateful.fst
@@ -66,7 +66,7 @@ let prepare_msg1 alice bob =
   set_version alice sess_id (InitiatorSentMsg1 bob n_a <: nsl_version);*
   return sess_id
 
-val send_msg1: nsl_global_sess_ids -> principal -> session_id -> traceful (option nat)
+val send_msg1: nsl_global_sess_ids -> principal -> session_id -> traceful (option timestamp)
 let send_msg1 global_sess_id alice sess_id =
   let*? st: nsl_version = get_latest_version alice sess_id in
   match st with
@@ -90,7 +90,7 @@ let prepare_msg2 global_sess_id bob msg_id =
   set_version bob sess_id (ResponderSentMsg2 msg1.alice msg1.n_a n_b <: nsl_version);*
   return (Some sess_id)
 
-val send_msg2: nsl_global_sess_ids -> principal -> session_id -> traceful (option nat)
+val send_msg2: nsl_global_sess_ids -> principal -> session_id -> traceful (option timestamp)
 let send_msg2 global_sess_id bob sess_id =
   let*? st: nsl_version = get_latest_version bob sess_id in
   match st with
@@ -103,7 +103,7 @@ let send_msg2 global_sess_id bob sess_id =
   )
   | _ -> return None
 
-val prepare_msg3: nsl_global_sess_ids -> principal -> session_id -> nat -> traceful (option unit)
+val prepare_msg3: nsl_global_sess_ids -> principal -> session_id -> timestamp -> traceful (option unit)
 let prepare_msg3 global_sess_id alice sess_id msg_id =
   let*? msg = recv_msg msg_id in
   let*? sk_a = get_private_key alice global_sess_id.private_keys (PkDec "NSL.PublicKey") in
@@ -117,7 +117,7 @@ let prepare_msg3 global_sess_id alice sess_id msg_id =
   )
   | _ -> return None
 
-val send_msg3: nsl_global_sess_ids -> principal -> session_id -> traceful (option nat)
+val send_msg3: nsl_global_sess_ids -> principal -> session_id -> traceful (option timestamp)
 let send_msg3 global_sess_id alice sess_id =
   let*? st: nsl_version = get_latest_version alice sess_id in
   match st with
@@ -130,7 +130,7 @@ let send_msg3 global_sess_id alice sess_id =
   )
   | _ -> return None
 
-val prepare_msg4: nsl_global_sess_ids -> principal -> session_id -> nat -> traceful (option unit)
+val prepare_msg4: nsl_global_sess_ids -> principal -> session_id -> timestamp -> traceful (option unit)
 let prepare_msg4 global_sess_id bob sess_id msg_id =
   let*? msg = recv_msg msg_id in
   let*? sk_b = get_private_key bob global_sess_id.private_keys (PkDec "NSL.PublicKey") in

--- a/examples/nsl_pk/DY.Example.NSL.Protocol.Stateful.fst
+++ b/examples/nsl_pk/DY.Example.NSL.Protocol.Stateful.fst
@@ -9,26 +9,26 @@ open DY.Example.NSL.Protocol.Total
 /// This effectively connects the pure code of NSL to the outside world,
 /// by handling network connections, state storage, or random generation.
 
-(*** Version type ***)
+(*** State type ***)
 
 /// Type for the NSL state machine
 
 [@@ with_bytes bytes]
-type nsl_version =
-  | InitiatorSentMsg1: b:principal -> n_a:bytes -> nsl_version
-  | ResponderSentMsg2: a:principal -> n_a:bytes -> n_b:bytes -> nsl_version
-  | InitiatorSentMsg3: b:principal -> n_a:bytes -> n_b:bytes -> nsl_version
-  | ResponderReceivedMsg3: a:principal -> n_a:bytes -> n_b:bytes -> nsl_version
+type nsl_session =
+  | InitiatorSentMsg1: b:principal -> n_a:bytes -> nsl_session
+  | ResponderSentMsg2: a:principal -> n_a:bytes -> n_b:bytes -> nsl_session
+  | InitiatorSentMsg3: b:principal -> n_a:bytes -> n_b:bytes -> nsl_session
+  | ResponderReceivedMsg3: a:principal -> n_a:bytes -> n_b:bytes -> nsl_session
 
-%splice [ps_nsl_version] (gen_parser (`nsl_version))
-%splice [ps_nsl_version_is_well_formed] (gen_is_well_formed_lemma (`nsl_version))
+%splice [ps_nsl_session] (gen_parser (`nsl_session))
+%splice [ps_nsl_session_is_well_formed] (gen_is_well_formed_lemma (`nsl_session))
 
-instance parseable_serializeable_bytes_nsl_version: parseable_serializeable bytes nsl_version
- = mk_parseable_serializeable ps_nsl_version
+instance parseable_serializeable_bytes_nsl_session: parseable_serializeable bytes nsl_session
+ = mk_parseable_serializeable ps_nsl_session
 
-instance local_version_nsl_version: local_version nsl_version = {
-  tag = "NSL.Version";
-  format = parseable_serializeable_bytes_nsl_version;
+instance local_state_nsl_session: local_state nsl_session = {
+  tag = "NSL.Session";
+  format = parseable_serializeable_bytes_nsl_session;
 }
 
 (*** Event type ***)
@@ -63,12 +63,12 @@ let prepare_msg1 alice bob =
   let* n_a = mk_rand NoUsage (join (principal_label alice) (principal_label bob)) 32 in
   trigger_event alice (Initiate1 alice bob n_a);*
   let* sess_id = new_session_id alice in
-  set_version alice sess_id (InitiatorSentMsg1 bob n_a <: nsl_version);*
+  set_state alice sess_id (InitiatorSentMsg1 bob n_a <: nsl_session);*
   return sess_id
 
 val send_msg1: nsl_global_sess_ids -> principal -> session_id -> traceful (option timestamp)
 let send_msg1 global_sess_id alice sess_id =
-  let*? st: nsl_version = get_latest_version alice sess_id in
+  let*? st: nsl_session = get_state alice sess_id in
   match st with
   | InitiatorSentMsg1 bob n_a -> (
     let*? pk_b = get_public_key alice global_sess_id.pki (PkEnc "NSL.PublicKey") bob in
@@ -87,12 +87,12 @@ let prepare_msg2 global_sess_id bob msg_id =
   let* n_b = mk_rand NoUsage (join (principal_label msg1.alice) (principal_label bob)) 32 in
   trigger_event bob (Respond1 msg1.alice bob msg1.n_a n_b);*
   let* sess_id = new_session_id bob in
-  set_version bob sess_id (ResponderSentMsg2 msg1.alice msg1.n_a n_b <: nsl_version);*
+  set_state bob sess_id (ResponderSentMsg2 msg1.alice msg1.n_a n_b <: nsl_session);*
   return (Some sess_id)
 
 val send_msg2: nsl_global_sess_ids -> principal -> session_id -> traceful (option timestamp)
 let send_msg2 global_sess_id bob sess_id =
-  let*? st: nsl_version = get_latest_version bob sess_id in
+  let*? st: nsl_session = get_state bob sess_id in
   match st with
   | ResponderSentMsg2 alice n_a n_b -> (
     let*? pk_a = get_public_key bob global_sess_id.pki (PkEnc "NSL.PublicKey") alice in
@@ -107,19 +107,19 @@ val prepare_msg3: nsl_global_sess_ids -> principal -> session_id -> timestamp ->
 let prepare_msg3 global_sess_id alice sess_id msg_id =
   let*? msg = recv_msg msg_id in
   let*? sk_a = get_private_key alice global_sess_id.private_keys (PkDec "NSL.PublicKey") in
-  let*? st: nsl_version = get_latest_version alice sess_id in
+  let*? st: nsl_session = get_state alice sess_id in
   match st with
   | InitiatorSentMsg1 bob n_a -> (
     let*? msg2: message2 = return (decode_message2 alice bob msg sk_a n_a) in
     trigger_event alice (Initiate2 alice bob n_a msg2.n_b);*
-    set_version alice sess_id (InitiatorSentMsg3 bob n_a msg2.n_b <: nsl_version);*
+    set_state alice sess_id (InitiatorSentMsg3 bob n_a msg2.n_b <: nsl_session);*
     return (Some ())
   )
   | _ -> return None
 
 val send_msg3: nsl_global_sess_ids -> principal -> session_id -> traceful (option timestamp)
 let send_msg3 global_sess_id alice sess_id =
-  let*? st: nsl_version = get_latest_version alice sess_id in
+  let*? st: nsl_session = get_state alice sess_id in
   match st with
   | InitiatorSentMsg3 bob n_a n_b -> (
     let*? pk_b = get_public_key alice global_sess_id.pki (PkEnc "NSL.PublicKey") bob in
@@ -134,12 +134,12 @@ val prepare_msg4: nsl_global_sess_ids -> principal -> session_id -> timestamp ->
 let prepare_msg4 global_sess_id bob sess_id msg_id =
   let*? msg = recv_msg msg_id in
   let*? sk_b = get_private_key bob global_sess_id.private_keys (PkDec "NSL.PublicKey") in
-  let*? st: nsl_version = get_latest_version bob sess_id in
+  let*? st: nsl_session = get_state bob sess_id in
   match st with
   | ResponderSentMsg2 alice n_a n_b -> (
     let*? msg3: message3 = return (decode_message3 alice bob msg sk_b n_b) in
     trigger_event bob (Respond2 alice bob n_a n_b);*
-    set_version bob sess_id (ResponderReceivedMsg3 alice n_a n_b <: nsl_version);*
+    set_state bob sess_id (ResponderReceivedMsg3 alice n_a n_b <: nsl_session);*
     return (Some ())
   )
   | _ -> return None

--- a/examples/nsl_pk/DY.Example.NSL.Protocol.Stateful.fst
+++ b/examples/nsl_pk/DY.Example.NSL.Protocol.Stateful.fst
@@ -54,11 +54,11 @@ instance event_nsl_event: event nsl_event = {
 (*** Stateful code ***)
 
 type nsl_global_sess_ids = {
-  pki: nat;
-  private_keys: nat;
+  pki: state_id;
+  private_keys: state_id;
 }
 
-val prepare_msg1: principal -> principal -> traceful session_id
+val prepare_msg1: principal -> principal -> traceful state_id
 let prepare_msg1 alice bob =
   let* n_a = mk_rand NoUsage (join (principal_label alice) (principal_label bob)) 32 in
   trigger_event alice (Initiate1 alice bob n_a);*
@@ -66,7 +66,7 @@ let prepare_msg1 alice bob =
   set_state alice sess_id (InitiatorSentMsg1 bob n_a <: nsl_session);*
   return sess_id
 
-val send_msg1: nsl_global_sess_ids -> principal -> session_id -> traceful (option timestamp)
+val send_msg1: nsl_global_sess_ids -> principal -> state_id -> traceful (option timestamp)
 let send_msg1 global_sess_id alice sess_id =
   let*? st: nsl_session = get_state alice sess_id in
   match st with
@@ -79,7 +79,7 @@ let send_msg1 global_sess_id alice sess_id =
   )
   | _ -> return None
 
-val prepare_msg2: nsl_global_sess_ids -> principal -> session_id -> traceful (option session_id)
+val prepare_msg2: nsl_global_sess_ids -> principal -> timestamp -> traceful (option state_id)
 let prepare_msg2 global_sess_id bob msg_id =
   let*? msg = recv_msg msg_id in
   let*? sk_b = get_private_key bob global_sess_id.private_keys (PkDec "NSL.PublicKey") in
@@ -90,7 +90,7 @@ let prepare_msg2 global_sess_id bob msg_id =
   set_state bob sess_id (ResponderSentMsg2 msg1.alice msg1.n_a n_b <: nsl_session);*
   return (Some sess_id)
 
-val send_msg2: nsl_global_sess_ids -> principal -> session_id -> traceful (option timestamp)
+val send_msg2: nsl_global_sess_ids -> principal -> state_id -> traceful (option timestamp)
 let send_msg2 global_sess_id bob sess_id =
   let*? st: nsl_session = get_state bob sess_id in
   match st with
@@ -103,7 +103,7 @@ let send_msg2 global_sess_id bob sess_id =
   )
   | _ -> return None
 
-val prepare_msg3: nsl_global_sess_ids -> principal -> session_id -> timestamp -> traceful (option unit)
+val prepare_msg3: nsl_global_sess_ids -> principal -> state_id -> timestamp -> traceful (option unit)
 let prepare_msg3 global_sess_id alice sess_id msg_id =
   let*? msg = recv_msg msg_id in
   let*? sk_a = get_private_key alice global_sess_id.private_keys (PkDec "NSL.PublicKey") in
@@ -117,7 +117,7 @@ let prepare_msg3 global_sess_id alice sess_id msg_id =
   )
   | _ -> return None
 
-val send_msg3: nsl_global_sess_ids -> principal -> session_id -> traceful (option timestamp)
+val send_msg3: nsl_global_sess_ids -> principal -> state_id -> traceful (option timestamp)
 let send_msg3 global_sess_id alice sess_id =
   let*? st: nsl_session = get_state alice sess_id in
   match st with
@@ -130,7 +130,7 @@ let send_msg3 global_sess_id alice sess_id =
   )
   | _ -> return None
 
-val prepare_msg4: nsl_global_sess_ids -> principal -> session_id -> timestamp -> traceful (option unit)
+val prepare_msg4: nsl_global_sess_ids -> principal -> state_id -> timestamp -> traceful (option unit)
 let prepare_msg4 global_sess_id bob sess_id msg_id =
   let*? msg = recv_msg msg_id in
   let*? sk_b = get_private_key bob global_sess_id.private_keys (PkDec "NSL.PublicKey") in

--- a/examples/nsl_pk/DY.Example.NSL.SecurityProperties.fst
+++ b/examples/nsl_pk/DY.Example.NSL.SecurityProperties.fst
@@ -22,7 +22,7 @@ open DY.Example.NSL.Protocol.Stateful.Proof
 /// unless the attacker corrupted Alice or Bob.
 
 val initiator_authentication:
-  tr:trace -> i:nat ->
+  tr:trace -> i:timestamp ->
   alice:principal -> bob:principal -> n_a:bytes -> n_b:bytes ->
   Lemma
   (requires
@@ -40,7 +40,7 @@ let initiator_authentication tr i alice bob n_a n_b = ()
 /// unless the attacker corrupted Alice or Bob.
 
 val responder_authentication:
-  tr:trace -> i:nat ->
+  tr:trace -> i:timestamp ->
   alice:principal -> bob:principal -> n_a:bytes -> n_b:bytes ->
   Lemma
   (requires

--- a/examples/nsl_pk/DY.Example.NSL.SecurityProperties.fst
+++ b/examples/nsl_pk/DY.Example.NSL.SecurityProperties.fst
@@ -62,9 +62,9 @@ val n_a_secrecy:
   (requires
     attacker_knows tr n_a /\
     trace_invariant tr /\ (
-      (exists sess_id. version_was_set tr alice sess_id (InitiatorSentMsg1 bob n_a)) \/
-      (exists sess_id n_b. version_was_set tr alice sess_id (InitiatorSentMsg3 bob n_a n_b)) \/
-      (exists sess_id n_b. version_was_set tr bob sess_id (ResponderReceivedMsg3 alice n_a n_b))
+      (exists sess_id. state_was_set tr alice sess_id (InitiatorSentMsg1 bob n_a)) \/
+      (exists sess_id n_b. state_was_set tr alice sess_id (InitiatorSentMsg3 bob n_a n_b)) \/
+      (exists sess_id n_b. state_was_set tr bob sess_id (ResponderReceivedMsg3 alice n_a n_b))
     )
   )
   (ensures is_corrupt tr (principal_label alice) \/ is_corrupt tr (principal_label bob))
@@ -80,9 +80,9 @@ val n_b_secrecy:
   (requires
     attacker_knows tr n_b /\
     trace_invariant tr /\ (
-      (exists sess_id n_a. version_was_set tr bob sess_id (ResponderSentMsg2 alice n_a n_b)) \/
-      (exists sess_id n_a. version_was_set tr bob sess_id (ResponderReceivedMsg3 alice n_a n_b)) \/
-      (exists sess_id n_a. version_was_set tr alice sess_id (InitiatorSentMsg3 bob n_a n_b))
+      (exists sess_id n_a. state_was_set tr bob sess_id (ResponderSentMsg2 alice n_a n_b)) \/
+      (exists sess_id n_a. state_was_set tr bob sess_id (ResponderReceivedMsg3 alice n_a n_b)) \/
+      (exists sess_id n_a. state_was_set tr alice sess_id (InitiatorSentMsg3 bob n_a n_b))
     )
   )
   (ensures is_corrupt tr (principal_label alice) \/ is_corrupt tr (principal_label bob))

--- a/examples/nsl_pk/DY.Example.NSL.SecurityProperties.fst
+++ b/examples/nsl_pk/DY.Example.NSL.SecurityProperties.fst
@@ -62,9 +62,9 @@ val n_a_secrecy:
   (requires
     attacker_knows tr n_a /\
     trace_invariant tr /\ (
-      (exists sess_id. state_was_set tr alice sess_id (InitiatorSentMsg1 bob n_a)) \/
-      (exists sess_id n_b. state_was_set tr alice sess_id (InitiatorSentMsg3 bob n_a n_b)) \/
-      (exists sess_id n_b. state_was_set tr bob sess_id (ResponderReceivedMsg3 alice n_a n_b))
+      (exists sess_id. version_was_set tr alice sess_id (InitiatorSentMsg1 bob n_a)) \/
+      (exists sess_id n_b. version_was_set tr alice sess_id (InitiatorSentMsg3 bob n_a n_b)) \/
+      (exists sess_id n_b. version_was_set tr bob sess_id (ResponderReceivedMsg3 alice n_a n_b))
     )
   )
   (ensures is_corrupt tr (principal_label alice) \/ is_corrupt tr (principal_label bob))
@@ -80,9 +80,9 @@ val n_b_secrecy:
   (requires
     attacker_knows tr n_b /\
     trace_invariant tr /\ (
-      (exists sess_id n_a. state_was_set tr bob sess_id (ResponderSentMsg2 alice n_a n_b)) \/
-      (exists sess_id n_a. state_was_set tr bob sess_id (ResponderReceivedMsg3 alice n_a n_b)) \/
-      (exists sess_id n_a. state_was_set tr alice sess_id (InitiatorSentMsg3 bob n_a n_b))
+      (exists sess_id n_a. version_was_set tr bob sess_id (ResponderSentMsg2 alice n_a n_b)) \/
+      (exists sess_id n_a. version_was_set tr bob sess_id (ResponderReceivedMsg3 alice n_a n_b)) \/
+      (exists sess_id n_a. version_was_set tr alice sess_id (InitiatorSentMsg3 bob n_a n_b))
     )
   )
   (ensures is_corrupt tr (principal_label alice) \/ is_corrupt tr (principal_label bob))

--- a/src/core/DY.Core.Attacker.Knowledge.fst
+++ b/src/core/DY.Core.Attacker.Knowledge.fst
@@ -154,7 +154,7 @@ let move_requires_4 #a #b #c #d #p #q pf x y z w =
 
 val corrupted_state_is_publishable:
   {|protocol_invariants|} ->
-  tr:trace -> prin:principal -> sess_id:session_id -> content:bytes ->
+  tr:trace -> prin:principal -> sess_id:state_id -> content:bytes ->
   Lemma
   (requires
     is_corrupt tr (principal_state_label prin sess_id) /\

--- a/src/core/DY.Core.Attacker.Knowledge.fst
+++ b/src/core/DY.Core.Attacker.Knowledge.fst
@@ -159,7 +159,7 @@ let move_requires_4 #a #b #c #d #p #q pf x y z w =
 // (So: any version of a corrupted session is publishable.)
 val corrupted_session_is_publishable:
   {|protocol_invariants|} ->
-  tr:trace -> prin:principal -> sess_id:nat -> content:bytes ->
+  tr:trace -> prin:principal -> sess_id:session_id -> content:bytes ->
   Lemma
   (requires
     is_corrupt tr (principal_state_label prin sess_id) /\

--- a/src/core/DY.Core.Attacker.Knowledge.fst
+++ b/src/core/DY.Core.Attacker.Knowledge.fst
@@ -36,7 +36,7 @@ let rec attacker_knows_aux step tr msg =
     (
       exists prin sess_id.
         is_corrupt tr (principal_state_label prin sess_id) /\
-        version_was_set tr prin sess_id msg
+        state_was_set tr prin sess_id msg
     ) \/
     // - public literals
     (
@@ -152,23 +152,18 @@ let move_requires_4 #a #b #c #d #p #q pf x y z w =
 /// bytestrings that the attacker obtained by corruption
 /// are publishable.
 
-// TODO: currently this says: 
-// if the session sess_id is corrupt,
-// and the version content is stored in that session,
-// then the version is publishable.
-// (So: any version of a corrupted session is publishable.)
-val corrupted_session_is_publishable:
+val corrupted_state_is_publishable:
   {|protocol_invariants|} ->
   tr:trace -> prin:principal -> sess_id:session_id -> content:bytes ->
   Lemma
   (requires
     is_corrupt tr (principal_state_label prin sess_id) /\
-    version_was_set tr prin sess_id content /\
+    state_was_set tr prin sess_id content /\
     trace_invariant tr
   )
   (ensures is_publishable tr content)
-let corrupted_session_is_publishable #invs tr prin sess_id content =
-  version_is_knowable_by tr prin sess_id content
+let corrupted_state_is_publishable #invs tr prin sess_id content =
+  state_is_knowable_by tr prin sess_id content
 
 #push-options "--z3rlimit 25"
 val attacker_only_knows_publishable_values_aux:
@@ -184,7 +179,7 @@ let rec attacker_only_knows_publishable_values_aux #invs step tr msg =
   if step = 0 then (
     FStar.Classical.forall_intro   (FStar.Classical.move_requires   (msg_sent_on_network_are_publishable tr));
     FStar.Classical.forall_intro   (FStar.Classical.move_requires   (msg_sent_on_network_are_publishable tr));
-    FStar.Classical.forall_intro_3 (FStar.Classical.move_requires_3 (corrupted_session_is_publishable tr));
+    FStar.Classical.forall_intro_3 (FStar.Classical.move_requires_3 (corrupted_state_is_publishable tr));
     FStar.Classical.forall_intro   (FStar.Classical.move_requires   (literal_to_bytes_is_publishable tr))
   ) else (
     FStar.Classical.forall_intro   (FStar.Classical.move_requires   (attacker_only_knows_publishable_values_aux (step-1) tr));

--- a/src/core/DY.Core.Label.Type.fst
+++ b/src/core/DY.Core.Label.Type.fst
@@ -8,6 +8,10 @@ module DY.Core.Label.Type
 
 type principal = string
 
+/// Type for session identifiers
+
+type state_id = { the_id: nat; }
+
 /// Pre-labels are used to refer to a particular state of a principal that may be compromised by the attacker,
 /// that is, a principal name and a session id (the `S` constructor).
 ///
@@ -31,7 +35,7 @@ type principal = string
 
 type pre_label =
   | P: principal -> pre_label
-  | S: principal -> nat -> pre_label
+  | S: principal -> state_id -> pre_label
 
 /// Labels are roughly a free lattice on pre-labels,
 /// with lower bound (meet) and upper bound (join),
@@ -50,7 +54,7 @@ instance integer_encodable_pre_label: integer_encodable pre_label = {
   encode = (fun x ->
     match x with
     | P p -> 0::(encode p)
-    | S p s -> 1::(encode [encode p; encode s])
+    | S p s -> 1::(encode [encode p; encode s.the_id])
   );
   encode_inj = (fun x y ->
     encode_inj_forall (list (list int)) ();

--- a/src/core/DY.Core.Label.fst
+++ b/src/core/DY.Core.Label.fst
@@ -41,7 +41,7 @@ let get_principal l =
   | P p -> Some p
   | S p _ -> Some p
 
-val get_session: pre_label -> option nat
+val get_session: pre_label -> option state_id
 let get_session l =
   match l with
   | P _ -> None
@@ -146,7 +146,7 @@ let principal_label prin =
   State (P prin)
 
 [@@"opaque_to_smt"]
-val principal_state_label: principal -> nat -> label
+val principal_state_label: principal -> state_id -> label
 let principal_state_label prin sess_id =
   State (S prin sess_id)
 
@@ -172,7 +172,7 @@ let principal_label_injective p =
   normalize_term_spec principal_label
 
 val principal_state_label_injective:
-  p:principal -> s:nat ->
+  p:principal -> s:state_id ->
   Lemma (extract_pre_label (principal_state_label p s) == Some (S p s))
   [SMTPat (principal_state_label p s)]
 let principal_state_label_injective p s =
@@ -273,7 +273,7 @@ let flow_to_public_eq tr prin =
 /// A principal flows to a particular state of this principal.
 
 val principal_flow_to_principal_state:
-  tr:trace -> prin:principal -> sess_id:nat ->
+  tr:trace -> prin:principal -> sess_id:state_id ->
   Lemma
   (ensures (principal_label prin) `can_flow tr` (principal_state_label prin sess_id))
   [SMTPat ((principal_label prin) `can_flow tr` (principal_state_label prin sess_id))]

--- a/src/core/DY.Core.Trace.Invariant.fst
+++ b/src/core/DY.Core.Trace.Invariant.fst
@@ -87,8 +87,8 @@ let trace_event_invariant #invs tr event =
   | MsgSent msg ->
     // Messages sent on the network are publishable
     is_publishable tr msg
-  | SetState prin sess_id content -> (
-    // Stored states satisfy the custom state predicate
+  | SetVersion prin sess_id content -> (
+    // Stored versions satisfy the custom state predicate
     invs.trace_invs.state_pred.pred tr prin sess_id content
   )
   | Event prin tag content -> (
@@ -155,41 +155,41 @@ let msg_sent_on_network_are_publishable #invs tr msg =
     event_at_implies_trace_event_invariant tr i (MsgSent msg)
   )
 
-/// States stored satisfy the custom state predicate.
+/// Versions stored satisfy the custom state predicate.
 
-val state_was_set_implies_pred:
+val version_was_set_implies_pred:
   {|protocol_invariants|} -> tr:trace ->
   prin:principal -> sess_id:nat -> content:bytes ->
   Lemma
   (requires
     trace_invariant tr /\
-    state_was_set tr prin sess_id content
+    version_was_set tr prin sess_id content
   )
   (ensures state_pred tr prin sess_id content)
-  [SMTPat (state_was_set tr prin sess_id content);
+  [SMTPat (version_was_set tr prin sess_id content);
    SMTPat (trace_invariant tr);
   ]
-let state_was_set_implies_pred #invs tr prin sess_id content =
-  eliminate exists i. event_at tr i (SetState prin sess_id content)
+let version_was_set_implies_pred #invs tr prin sess_id content =
+  eliminate exists i. event_at tr i (SetVersion prin sess_id content)
   returns invs.trace_invs.state_pred.pred tr prin sess_id content
   with _. (
-    event_at_implies_trace_event_invariant tr i (SetState prin sess_id content);
+    event_at_implies_trace_event_invariant tr i (SetVersion prin sess_id content);
     invs.trace_invs.state_pred.pred_later (prefix tr i) tr prin sess_id content
   )
 
-/// States stored are knowable by the corresponding principal and state identifier.
+/// Versions stored are knowable by the corresponding principal and session identifier.
 // (This is a key lemma for attacker theorem.)
 
-val state_is_knowable_by:
+val version_is_knowable_by:
   {|protocol_invariants|} -> tr:trace ->
   prin:principal -> sess_id:nat -> content:bytes ->
   Lemma
   (requires
     trace_invariant tr /\
-    state_was_set tr prin sess_id content
+    version_was_set tr prin sess_id content
   )
   (ensures is_knowable_by (principal_state_label prin sess_id) tr content)
-let state_is_knowable_by #invs tr prin sess_id content =
+let version_is_knowable_by #invs tr prin sess_id content =
   state_pred_knowable tr prin sess_id content
 
 /// Triggered protocol events satisfy the event predicate.

--- a/src/core/DY.Core.Trace.Invariant.fst
+++ b/src/core/DY.Core.Trace.Invariant.fst
@@ -117,7 +117,7 @@ let rec trace_invariant #invs tr =
 
 val event_at_implies_trace_event_invariant:
   {|protocol_invariants|} ->
-  tr:trace -> i:nat -> event:trace_event ->
+  tr:trace -> i:timestamp -> event:trace_event ->
   Lemma
   (requires
     event_at tr i event /\
@@ -196,7 +196,7 @@ let version_is_knowable_by #invs tr prin sess_id content =
 
 val event_triggered_at_implies_pred:
   {|protocol_invariants|} -> tr:trace ->
-  i:nat -> prin:principal -> tag:string -> content:bytes ->
+  i:timestamp -> prin:principal -> tag:string -> content:bytes ->
   Lemma
   (requires
     event_triggered_at tr i prin tag content /\

--- a/src/core/DY.Core.Trace.Invariant.fst
+++ b/src/core/DY.Core.Trace.Invariant.fst
@@ -87,8 +87,8 @@ let trace_event_invariant #invs tr event =
   | MsgSent msg ->
     // Messages sent on the network are publishable
     is_publishable tr msg
-  | SetVersion prin sess_id content -> (
-    // Stored versions satisfy the custom state predicate
+  | SetState prin sess_id content -> (
+    // Stored states satisfy the custom state predicate
     invs.trace_invs.state_pred.pred tr prin sess_id content
   )
   | Event prin tag content -> (
@@ -155,41 +155,41 @@ let msg_sent_on_network_are_publishable #invs tr msg =
     event_at_implies_trace_event_invariant tr i (MsgSent msg)
   )
 
-/// Versions stored satisfy the custom state predicate.
+/// States stored satisfy the custom state predicate.
 
-val version_was_set_implies_pred:
+val state_was_set_implies_pred:
   {|protocol_invariants|} -> tr:trace ->
   prin:principal -> sess_id:session_id -> content:bytes ->
   Lemma
   (requires
     trace_invariant tr /\
-    version_was_set tr prin sess_id content
+    state_was_set tr prin sess_id content
   )
   (ensures state_pred tr prin sess_id content)
-  [SMTPat (version_was_set tr prin sess_id content);
+  [SMTPat (state_was_set tr prin sess_id content);
    SMTPat (trace_invariant tr);
   ]
-let version_was_set_implies_pred #invs tr prin sess_id content =
-  eliminate exists i. event_at tr i (SetVersion prin sess_id content)
+let state_was_set_implies_pred #invs tr prin sess_id content =
+  eliminate exists i. event_at tr i (SetState prin sess_id content)
   returns invs.trace_invs.state_pred.pred tr prin sess_id content
   with _. (
-    event_at_implies_trace_event_invariant tr i (SetVersion prin sess_id content);
+    event_at_implies_trace_event_invariant tr i (SetState prin sess_id content);
     invs.trace_invs.state_pred.pred_later (prefix tr i) tr prin sess_id content
   )
 
-/// Versions stored are knowable by the corresponding principal and session identifier.
+/// States stored are knowable by the corresponding principal and state identifier.
 // (This is a key lemma for attacker theorem.)
 
-val version_is_knowable_by:
+val state_is_knowable_by:
   {|protocol_invariants|} -> tr:trace ->
   prin:principal -> sess_id:session_id -> content:bytes ->
   Lemma
   (requires
     trace_invariant tr /\
-    version_was_set tr prin sess_id content
+    state_was_set tr prin sess_id content
   )
   (ensures is_knowable_by (principal_state_label prin sess_id) tr content)
-let version_is_knowable_by #invs tr prin sess_id content =
+let state_is_knowable_by #invs tr prin sess_id content =
   state_pred_knowable tr prin sess_id content
 
 /// Triggered protocol events satisfy the event predicate.

--- a/src/core/DY.Core.Trace.Invariant.fst
+++ b/src/core/DY.Core.Trace.Invariant.fst
@@ -29,18 +29,18 @@ open DY.Core.Label
 
 noeq
 type state_predicate (cinvs:crypto_invariants) = {
-  pred: trace -> principal -> session_id -> bytes -> prop;
+  pred: trace -> principal -> state_id -> bytes -> prop;
   // TODO: Do we want the later lemma?
   pred_later:
     tr1:trace -> tr2:trace ->
-    prin:principal -> sess_id:session_id -> content:bytes ->
+    prin:principal -> sess_id:state_id -> content:bytes ->
     Lemma
     (requires pred tr1 prin sess_id content /\ tr1 <$ tr2)
     (ensures pred tr2 prin sess_id content)
   ;
   pred_knowable:
     tr:trace ->
-    prin:principal -> sess_id:session_id -> content:bytes ->
+    prin:principal -> sess_id:state_id -> content:bytes ->
     Lemma
     (requires pred tr prin sess_id content)
     (ensures
@@ -159,7 +159,7 @@ let msg_sent_on_network_are_publishable #invs tr msg =
 
 val state_was_set_implies_pred:
   {|protocol_invariants|} -> tr:trace ->
-  prin:principal -> sess_id:session_id -> content:bytes ->
+  prin:principal -> sess_id:state_id -> content:bytes ->
   Lemma
   (requires
     trace_invariant tr /\
@@ -182,7 +182,7 @@ let state_was_set_implies_pred #invs tr prin sess_id content =
 
 val state_is_knowable_by:
   {|protocol_invariants|} -> tr:trace ->
-  prin:principal -> sess_id:session_id -> content:bytes ->
+  prin:principal -> sess_id:state_id -> content:bytes ->
   Lemma
   (requires
     trace_invariant tr /\

--- a/src/core/DY.Core.Trace.Invariant.fst
+++ b/src/core/DY.Core.Trace.Invariant.fst
@@ -29,18 +29,18 @@ open DY.Core.Label
 
 noeq
 type state_predicate (cinvs:crypto_invariants) = {
-  pred: trace -> principal -> nat -> bytes -> prop;
+  pred: trace -> principal -> session_id -> bytes -> prop;
   // TODO: Do we want the later lemma?
   pred_later:
     tr1:trace -> tr2:trace ->
-    prin:principal -> sess_id:nat -> content:bytes ->
+    prin:principal -> sess_id:session_id -> content:bytes ->
     Lemma
     (requires pred tr1 prin sess_id content /\ tr1 <$ tr2)
     (ensures pred tr2 prin sess_id content)
   ;
   pred_knowable:
     tr:trace ->
-    prin:principal -> sess_id:nat -> content:bytes ->
+    prin:principal -> sess_id:session_id -> content:bytes ->
     Lemma
     (requires pred tr prin sess_id content)
     (ensures
@@ -159,7 +159,7 @@ let msg_sent_on_network_are_publishable #invs tr msg =
 
 val version_was_set_implies_pred:
   {|protocol_invariants|} -> tr:trace ->
-  prin:principal -> sess_id:nat -> content:bytes ->
+  prin:principal -> sess_id:session_id -> content:bytes ->
   Lemma
   (requires
     trace_invariant tr /\
@@ -182,7 +182,7 @@ let version_was_set_implies_pred #invs tr prin sess_id content =
 
 val version_is_knowable_by:
   {|protocol_invariants|} -> tr:trace ->
-  prin:principal -> sess_id:nat -> content:bytes ->
+  prin:principal -> sess_id:session_id -> content:bytes ->
   Lemma
   (requires
     trace_invariant tr /\

--- a/src/core/DY.Core.Trace.Manipulation.fst
+++ b/src/core/DY.Core.Trace.Manipulation.fst
@@ -127,7 +127,7 @@ let add_event_invariant #invs e tr =
 
 /// Get the current time (i.e. trace length).
 
-val get_time: traceful nat
+val get_time: traceful timestamp
 let get_time =
   let* tr = get_trace in
   return (DY.Core.Trace.Type.length tr)
@@ -137,7 +137,7 @@ let get_time =
 /// Send a message on the network.
 
 [@@ "opaque_to_smt"]
-val send_msg: bytes -> traceful nat
+val send_msg: bytes -> traceful timestamp
 let send_msg msg =
   let* time = get_time in
   add_event (MsgSent msg);*
@@ -167,7 +167,7 @@ let send_msg_invariant #invs msg tr =
 /// Receive a message from the network.
 
 [@@ "opaque_to_smt"]
-val recv_msg: nat -> traceful (option bytes)
+val recv_msg: timestamp -> traceful (option bytes)
 let recv_msg i =
   let* tr = get_trace in
   if i < DY.Core.Trace.Type.length tr then
@@ -182,7 +182,7 @@ let recv_msg i =
 
 val recv_msg_invariant:
   {|protocol_invariants|} ->
-  i:nat -> tr:trace ->
+  i:timestamp -> tr:trace ->
   Lemma
   (requires trace_invariant tr)
   (ensures (

--- a/src/core/DY.Core.Trace.Manipulation.fst
+++ b/src/core/DY.Core.Trace.Manipulation.fst
@@ -313,37 +313,12 @@ let mk_rand_get_usage #invs usg lab len tr =
 
 (*** State ***)
 
-/// We have the following state model:
-/// * every principal has a (full) state
-/// * a state is a(n unordered) collection of sessions
-/// * a session is an ordered collection of versions
-/// * a version is a collection of fields that hold information
-///
-/// For example:
-/// a state of a principal may contain sessions for different purposes:
-/// * sessions storing private keys,
-/// * other sessions storing public keys,
-/// * sessions representing the state machine of one of (possibly several) protocol executions.
-///
-/// Sessions are append-only, the current version of a session is the latest entry.
-/// This models, keeping the whole history of sessions,
-/// which is useful in particular for protocol sessions.
-///
-/// On the trace, we only have entries for storing a single version (`SetVersion`).
-/// These entries contain the principal, the content of the version information and an identifier of the session to which this version belongs.
-/// The session and the state of a principal can be computed from those trace entries.
-/// (For example, the session of principal P with identifier x
-/// is the ordered collection of all `SetVersion` entries on the trace
-/// with P as principal and x as session identifier.)
-/// 
-
-
-/// Set a version of a given session of a principal.
+/// Set the state of a principal at a given state identifier.
 
 [@@ "opaque_to_smt"]
-val set_version: principal -> session_id -> bytes -> traceful unit
-let set_version prin session_id content =
-  add_event (SetVersion prin session_id content)
+val set_state: principal -> session_id -> bytes -> traceful unit
+let set_state prin session_id content =
+  add_event (SetState prin session_id content)
 
 val max: int -> int -> int
 let max x y =
@@ -359,7 +334,7 @@ let rec compute_new_session_id prin tr =
   | Nil -> 0
   | Snoc tr_init evt -> (
     match evt with
-    | SetVersion prin' sess_id _ ->
+    | SetState prin' sess_id _ ->
       if prin = prin' then
         max (sess_id+1) (compute_new_session_id prin tr_init)
       else
@@ -372,19 +347,19 @@ val compute_new_session_id_correct:
   prin:principal -> tr:trace ->
   sess_id:session_id -> version_content:bytes ->
   Lemma
-  (requires event_exists tr (SetVersion prin sess_id version_content))
+  (requires event_exists tr (SetState prin sess_id state_content))
   (ensures sess_id < compute_new_session_id prin tr)
-let rec compute_new_session_id_correct prin tr sess_id version_content =
+let rec compute_new_session_id_correct prin tr sess_id state_content =
   match tr with
   | Nil -> ()
   | Snoc tr_init evt -> (
-    if evt = SetVersion prin sess_id version_content then ()
+    if evt = SetState prin sess_id state_content then ()
     else (
-      compute_new_session_id_correct prin tr_init sess_id version_content
+      compute_new_session_id_correct prin tr_init sess_id state_content
     )
   )
 
-/// Compute a fresh session identifier for a principal.
+/// Compute a fresh state identifier for a principal.
 
 [@@ "opaque_to_smt"]
 val new_session_id: principal -> traceful session_id
@@ -392,30 +367,28 @@ let new_session_id prin =
   let* tr = get_trace in
   return (compute_new_session_id prin tr)
 
-
-val get_latest_version_aux: principal -> session_id -> trace -> option bytes
-let rec get_latest_version_aux prin sess_id tr =
+val get_state_aux: principal -> session_id -> trace -> option bytes
+let rec get_state_aux prin sess_id tr =
   match tr with
   | Nil -> None
-  | Snoc tr_init (SetVersion prin' sess_id' content) -> (
+  | Snoc tr_init (SetState prin' sess_id' content) -> (
     if prin = prin' && sess_id = sess_id' then
       Some content
     else
-      get_latest_version_aux prin sess_id tr_init
+      get_state_aux prin sess_id tr_init
   )
   | Snoc tr_init _ ->
-      get_latest_version_aux prin sess_id tr_init
+      get_state_aux prin sess_id tr_init
 
-/// Retrieve the **latest** version of a specific session
-/// stored by a principal.
+/// Retrieve the state stored by a principal at some state identifier.
 
 [@@ "opaque_to_smt"]
-val get_latest_version: principal -> session_id -> traceful (option bytes)
-let get_latest_version prin sess_id =
+val get_state: principal -> session_id -> traceful (option bytes)
+let get_state prin sess_id =
   let* tr = get_trace in
-  return (get_latest_version_aux prin sess_id tr)
+  return (get_state_aux prin sess_id tr)
 
-/// Obtaining a new session identifier does not change the trace.
+/// Obtaining a new state identifier do not change the trace.
 
 val new_session_id_invariant:
   prin:principal -> tr:trace ->
@@ -428,11 +401,11 @@ val new_session_id_invariant:
 let new_session_id_invariant prin tr =
   normalize_term_spec new_session_id
 
-/// Storing a version preserves the trace invariant
-/// when the version satisfies the state predicate.
+/// Storing a state preserves the trace invariant
+/// when the state satisfy the state predicate.
 
 #push-options "--z3rlimit 15"
-val set_version_invariant:
+val set_state_invariant:
   {|protocol_invariants|} ->
   prin:principal -> sess_id:session_id -> content:bytes -> tr:trace ->
   Lemma
@@ -441,17 +414,17 @@ val set_version_invariant:
     trace_invariant tr
   )
   (ensures (
-    let ((), tr_out) = set_version prin sess_id content tr in
+    let ((), tr_out) = set_state prin sess_id content tr in
     trace_invariant tr_out /\
-    version_was_set tr_out prin sess_id content
+    state_was_set tr_out prin sess_id content
   ))
-  [SMTPat (set_version prin sess_id content tr); SMTPat (trace_invariant tr)]
-let set_version_invariant #invs prin sess_id content tr =
-  add_event_invariant (SetVersion prin sess_id content) tr;
-  normalize_term_spec set_version
+  [SMTPat (set_state prin sess_id content tr); SMTPat (trace_invariant tr)]
+let set_state_invariant #invs prin sess_id content tr =
+  add_event_invariant (SetState prin sess_id content) tr;
+  normalize_term_spec set_state
 #pop-options
 
-val get_latest_version_aux_state_invariant:
+val get_state_aux_state_invariant:
   {|protocol_invariants|} ->
   prin:principal -> sess_id:session_id -> tr:trace ->
   Lemma
@@ -459,36 +432,36 @@ val get_latest_version_aux_state_invariant:
     trace_invariant tr
   )
   (ensures (
-    match get_latest_version_aux prin sess_id tr with
+    match get_state_aux prin sess_id tr with
     | None -> True
     | Some content -> state_pred tr prin sess_id content
   ))
-let rec get_latest_version_aux_state_invariant #invs prin sess_id tr =
+let rec get_state_aux_state_invariant #invs prin sess_id tr =
   reveal_opaque (`%grows) (grows);
   norm_spec [zeta; delta_only [`%trace_invariant]] (trace_invariant);
   norm_spec [zeta; delta_only [`%prefix]] (prefix);
   match tr with
   | Nil -> ()
-  | Snoc tr_init (SetVersion prin' sess_id' content) -> (
+  | Snoc tr_init (SetState prin' sess_id' content) -> (
     if prin = prin' && sess_id = sess_id' then (
       state_pred_later tr_init tr prin sess_id content
     ) else (
-      get_latest_version_aux_state_invariant prin sess_id tr_init;
-      match get_latest_version_aux prin sess_id tr_init with
+      get_state_aux_state_invariant prin sess_id tr_init;
+      match get_state_aux prin sess_id tr_init with
       | None -> ()
       | Some content -> state_pred_later tr_init tr prin sess_id content
     )
   )
   | Snoc tr_init _ ->
-    get_latest_version_aux_state_invariant prin sess_id tr_init;
-    match get_latest_version_aux prin sess_id tr_init with
+    get_state_aux_state_invariant prin sess_id tr_init;
+    match get_state_aux prin sess_id tr_init with
     | None -> ()
     | Some content -> state_pred_later tr_init tr prin sess_id content
 
 /// When the trace invariant holds,
-/// retrieved versions satisfy the state predicate.
+/// retrieved states satisfy the state predicate.
 
-val get_latest_version_state_invariant:
+val get_state_state_invariant:
   {|protocol_invariants|} ->
   prin:principal -> sess_id:session_id -> tr:trace ->
   Lemma
@@ -496,17 +469,17 @@ val get_latest_version_state_invariant:
     trace_invariant tr
   )
   (ensures (
-    let (opt_content, tr_out) = get_latest_version prin sess_id tr in
+    let (opt_content, tr_out) = get_state prin sess_id tr in
     tr == tr_out /\ (
       match opt_content with
       | None -> True
       | Some content -> state_pred tr prin sess_id content
     )
   ))
-  [SMTPat (get_latest_version prin sess_id tr); SMTPat (trace_invariant tr)]
-let get_latest_version_state_invariant #invs prin sess_id tr =
-  normalize_term_spec get_latest_version;
-  get_latest_version_aux_state_invariant prin sess_id tr
+  [SMTPat (get_state prin sess_id tr); SMTPat (trace_invariant tr)]
+let get_state_state_invariant #invs prin sess_id tr =
+  normalize_term_spec get_state;
+  get_state_aux_state_invariant prin sess_id tr
 
 (*** Event triggering ***)
 

--- a/src/core/DY.Core.Trace.Manipulation.fst
+++ b/src/core/DY.Core.Trace.Manipulation.fst
@@ -345,7 +345,7 @@ let rec compute_new_session_id prin tr =
 // Sanity check
 val compute_new_session_id_correct:
   prin:principal -> tr:trace ->
-  sess_id:session_id -> version_content:bytes ->
+  sess_id:session_id -> state_content:bytes ->
   Lemma
   (requires event_exists tr (SetState prin sess_id state_content))
   (ensures sess_id < compute_new_session_id prin tr)

--- a/src/core/DY.Core.Trace.Type.fst
+++ b/src/core/DY.Core.Trace.Type.fst
@@ -28,8 +28,12 @@ open DY.Core.Label.Type
 ///   if Alice has finished a handshake with Bob,
 ///   then Bob must have initiated a handshake with Alice.
 
-/// The type for events in the trace.
+/// Type for session identifiers (see Trace.Manipulation for an explanation of our state model)
+
 type session_id = nat
+
+
+/// The type for events in the trace.
 
 type trace_event =
   // A message has been sent on the network.

--- a/src/core/DY.Core.Trace.Type.fst
+++ b/src/core/DY.Core.Trace.Type.fst
@@ -28,10 +28,6 @@ open DY.Core.Label.Type
 ///   if Alice has finished a handshake with Bob,
 ///   then Bob must have initiated a handshake with Alice.
 
-/// Type for session identifiers (see Trace.Manipulation for an explanation of our state model)
-
-type session_id = nat
-
 
 /// The type for events in the trace.
 
@@ -41,9 +37,9 @@ type trace_event =
   // A random number has been generated, with some usage and label.
   | RandGen: usg:usage -> lab:label -> len:nat{len <> 0} -> trace_event
   // A state of a principal has been corrupt.
-  | Corrupt: prin:principal -> sess_id:nat -> trace_event
+  | Corrupt: prin:principal -> sess_id:state_id -> trace_event
   // A principal stored some state.
-  | SetState: prin:principal -> sess_id:nat -> content:bytes -> trace_event
+  | SetState: prin:principal -> sess_id:state_id -> content:bytes -> trace_event
   // A custom and protocol-specific event has been triggered by a principal.
   | Event: prin:principal -> tag:string -> content:bytes -> trace_event
 
@@ -267,13 +263,13 @@ let msg_sent_on_network tr msg =
 
 /// Has some state been stored by a principal?
 
-val state_was_set: trace -> principal -> session_id -> bytes -> prop
+val state_was_set: trace -> principal -> state_id -> bytes -> prop
 let state_was_set tr prin sess_id content =
   event_exists tr (SetState prin sess_id content)
 
 /// Has a principal been corrupt?
 
-val was_corrupt: trace -> principal -> session_id -> prop
+val was_corrupt: trace -> principal -> state_id -> prop
 let was_corrupt tr prin sess_id =
   event_exists tr (Corrupt prin sess_id)
 

--- a/src/core/DY.Core.Trace.Type.fst
+++ b/src/core/DY.Core.Trace.Type.fst
@@ -40,10 +40,10 @@ type trace_event =
   | MsgSent: bytes -> trace_event
   // A random number has been generated, with some usage and label.
   | RandGen: usg:usage -> lab:label -> len:nat{len <> 0} -> trace_event
-  // A version of a specific session of a principal has been corrupt.
-  | Corrupt: prin:principal -> sess_id:session_id -> trace_event
-  // A principal stored a version of a specific sesson.
-  | SetVersion: prin:principal -> sess_id:session_id -> content:bytes -> trace_event
+  // A state of a principal has been corrupt.
+  | Corrupt: prin:principal -> sess_id:nat -> trace_event
+  // A principal stored some state.
+  | SetState: prin:principal -> sess_id:nat -> content:bytes -> trace_event
   // A custom and protocol-specific event has been triggered by a principal.
   | Event: prin:principal -> tag:string -> content:bytes -> trace_event
 
@@ -265,13 +265,13 @@ val msg_sent_on_network: trace -> bytes -> prop
 let msg_sent_on_network tr msg =
   event_exists tr (MsgSent msg)
 
-/// Has a version of a session been stored by a principal?
+/// Has some state been stored by a principal?
 
-val version_was_set: trace -> principal -> session_id -> bytes -> prop
-let version_was_set tr prin sess_id content =
-  event_exists tr (SetVersion prin sess_id content)
+val state_was_set: trace -> principal -> session_id -> bytes -> prop
+let state_was_set tr prin sess_id content =
+  event_exists tr (SetState prin sess_id content)
 
-/// Has a session of a principal been corrupt?
+/// Has a principal been corrupt?
 
 val was_corrupt: trace -> principal -> session_id -> prop
 let was_corrupt tr prin sess_id =

--- a/src/core/DY.Core.Trace.Type.fst
+++ b/src/core/DY.Core.Trace.Type.fst
@@ -29,6 +29,7 @@ open DY.Core.Label.Type
 ///   then Bob must have initiated a handshake with Alice.
 
 /// The type for events in the trace.
+type session_id = nat
 
 type trace_event =
   // A message has been sent on the network.
@@ -36,9 +37,9 @@ type trace_event =
   // A random number has been generated, with some usage and label.
   | RandGen: usg:usage -> lab:label -> len:nat{len <> 0} -> trace_event
   // A version of a specific session of a principal has been corrupt.
-  | Corrupt: prin:principal -> sess_id:nat -> trace_event
+  | Corrupt: prin:principal -> sess_id:session_id -> trace_event
   // A principal stored a version of a specific sesson.
-  | SetVersion: prin:principal -> sess_id:nat -> content:bytes -> trace_event
+  | SetVersion: prin:principal -> sess_id:session_id -> content:bytes -> trace_event
   // A custom and protocol-specific event has been triggered by a principal.
   | Event: prin:principal -> tag:string -> content:bytes -> trace_event
 
@@ -258,13 +259,13 @@ let msg_sent_on_network tr msg =
 
 /// Has a version of a session been stored by a principal?
 
-val version_was_set: trace -> principal -> nat -> bytes -> prop
+val version_was_set: trace -> principal -> session_id -> bytes -> prop
 let version_was_set tr prin sess_id content =
   event_exists tr (SetVersion prin sess_id content)
 
 /// Has a session of a principal been corrupt?
 
-val was_corrupt: trace -> principal -> nat -> prop
+val was_corrupt: trace -> principal -> session_id -> prop
 let was_corrupt tr prin sess_id =
   event_exists tr (Corrupt prin sess_id)
 

--- a/src/core/DY.Core.Trace.Type.fst
+++ b/src/core/DY.Core.Trace.Type.fst
@@ -35,10 +35,10 @@ type trace_event =
   | MsgSent: bytes -> trace_event
   // A random number has been generated, with some usage and label.
   | RandGen: usg:usage -> lab:label -> len:nat{len <> 0} -> trace_event
-  // A state of a principal has been corrupt.
+  // A version of a specific session of a principal has been corrupt.
   | Corrupt: prin:principal -> sess_id:nat -> trace_event
-  // A principal stored some state.
-  | SetState: prin:principal -> sess_id:nat -> content:bytes -> trace_event
+  // A principal stored a version of a specific sesson.
+  | SetVersion: prin:principal -> sess_id:nat -> content:bytes -> trace_event
   // A custom and protocol-specific event has been triggered by a principal.
   | Event: prin:principal -> tag:string -> content:bytes -> trace_event
 
@@ -256,13 +256,13 @@ val msg_sent_on_network: trace -> bytes -> prop
 let msg_sent_on_network tr msg =
   event_exists tr (MsgSent msg)
 
-/// Has some state been stored by a principal?
+/// Has a version of a session been stored by a principal?
 
-val state_was_set: trace -> principal -> nat -> bytes -> prop
-let state_was_set tr prin sess_id content =
-  event_exists tr (SetState prin sess_id content)
+val version_was_set: trace -> principal -> nat -> bytes -> prop
+let version_was_set tr prin sess_id content =
+  event_exists tr (SetVersion prin sess_id content)
 
-/// Has a principal been corrupt?
+/// Has a session of a principal been corrupt?
 
 val was_corrupt: trace -> principal -> nat -> prop
 let was_corrupt tr prin sess_id =

--- a/src/lib/event/DY.Lib.Event.Typed.fst
+++ b/src/lib/event/DY.Lib.Event.Typed.fst
@@ -120,7 +120,7 @@ let trigger_event #a #ev prin e =
 [@@ "opaque_to_smt"]
 val event_triggered_at:
   #a:Type -> {|event a|} ->
-  trace -> nat -> principal -> a ->
+  trace -> timestamp -> principal -> a ->
   prop
 let event_triggered_at #a #ev tr i prin e =
   DY.Core.event_triggered_at tr i prin ev.tag (serialize a e)
@@ -160,7 +160,7 @@ val event_triggered_at_implies_pred:
   {|invs:protocol_invariants|} ->
   #a:Type -> {|ev:event a|} ->
   epred:event_predicate a -> tr:trace ->
-  i:nat -> prin:principal -> e:a ->
+  i:timestamp -> prin:principal -> e:a ->
   Lemma
   (requires
     event_triggered_at tr i prin e /\
@@ -190,7 +190,7 @@ let event_triggered_grows #a #ev tr1 tr2 prin e =
 
 val event_triggered_at_implies_trace_event_at:
   #a:Type -> {|ev:event a|} ->
-  tr:trace -> i:nat -> prin:principal -> e:a  ->
+  tr:trace -> i:timestamp -> prin:principal -> e:a  ->
   Lemma
   (requires event_triggered_at tr i prin e)
   (ensures

--- a/src/lib/state/DY.Lib.State.Map.fst
+++ b/src/lib/state/DY.Lib.State.Map.fst
@@ -25,12 +25,12 @@ class map_types (key_t:eqtype) (value_t:Type0) = {
 /// The map predicate relates a key and its associated value.
 
 noeq type map_predicate {|crypto_invariants|} (key_t:eqtype) (value_t:Type0) {|mt:map_types key_t value_t|} = {
-  pred: trace -> principal -> session_id -> key_t -> value_t -> prop;
-  pred_later: tr1:trace -> tr2:trace -> prin:principal -> sess_id:session_id -> key:key_t -> value:value_t -> Lemma
+  pred: trace -> principal -> state_id -> key_t -> value_t -> prop;
+  pred_later: tr1:trace -> tr2:trace -> prin:principal -> sess_id:state_id -> key:key_t -> value:value_t -> Lemma
     (requires pred tr1 prin sess_id key value /\ tr1 <$ tr2)
     (ensures pred tr2 prin sess_id key value)
   ;
-  pred_knowable: tr:trace -> prin:principal -> sess_id:session_id -> key:key_t -> value:value_t -> Lemma
+  pred_knowable: tr:trace -> prin:principal -> sess_id:state_id -> key:key_t -> value:value_t -> Lemma
     (requires pred tr prin sess_id key value)
     (ensures is_well_formed_prefix mt.ps_key_t (is_knowable_by (principal_state_label prin sess_id) tr) key /\ is_well_formed_prefix mt.ps_value_t (is_knowable_by (principal_state_label prin sess_id) tr) value)
   ;
@@ -67,7 +67,7 @@ val map_elem_invariant:
   {|crypto_invariants|} ->
   #key_t:eqtype -> #value_t:Type0 -> {|map_types key_t value_t|} ->
   map_predicate key_t value_t ->
-  trace -> principal -> session_id -> map_elem key_t value_t ->
+  trace -> principal -> state_id -> map_elem key_t value_t ->
   prop
 let map_elem_invariant #cinvs #key_t #value_t #mt mpred tr prin sess_id x =
   mpred.pred tr prin sess_id x.key x.value
@@ -76,7 +76,7 @@ val map_invariant:
   {|crypto_invariants|} ->
   #key_t:eqtype -> #value_t:Type0 -> {|map_types key_t value_t|} ->
   map_predicate key_t value_t ->
-  trace -> principal -> session_id -> map key_t value_t ->
+  trace -> principal -> state_id -> map key_t value_t ->
   prop
 let map_invariant #cinvs #key_t #value_t #mt mpred tr prin sess_id st =
   for_allP (map_elem_invariant mpred tr prin sess_id) st.key_values
@@ -85,7 +85,7 @@ val map_invariant_eq:
   {|crypto_invariants|} ->
   #key_t:eqtype -> #value_t:Type0 -> {|map_types key_t value_t|} ->
   mpred:map_predicate key_t value_t ->
-  tr:trace -> prin:principal -> sess_id:session_id -> st:map key_t value_t ->
+  tr:trace -> prin:principal -> sess_id:state_id -> st:map key_t value_t ->
   Lemma
   (map_invariant mpred tr prin sess_id st <==> (forall x. List.Tot.memP x st.key_values ==> map_elem_invariant mpred tr prin sess_id x))
 let map_invariant_eq #cinvs #key_t #value_t #mt mpred tr prin sess_id st =
@@ -129,7 +129,7 @@ val initialize_map:
   key_t:eqtype -> value_t:Type0 ->
   {|map_types key_t value_t|} ->
   prin:principal ->
-  traceful session_id
+  traceful state_id
 let initialize_map key_t value_t #mt prin =
   let* sess_id = new_session_id prin in
   let session: map key_t value_t = { key_values = [] } in
@@ -139,7 +139,7 @@ let initialize_map key_t value_t #mt prin =
 [@@ "opaque_to_smt"]
 val add_key_value:
   #key_t:eqtype -> #value_t:Type0 -> {|map_types key_t value_t|} ->
-  prin:principal -> sess_id:session_id ->
+  prin:principal -> sess_id:state_id ->
   key:key_t -> value:value_t ->
   traceful (option unit)
 let add_key_value #key_t #value_t #mt prin sess_id key value =
@@ -174,7 +174,7 @@ let rec find_value_aux #key_t #value_t #mt key l =
 [@@ "opaque_to_smt"]
 val find_value:
   #key_t:eqtype -> #value_t:Type0 -> {|map_types key_t value_t|} ->
-  prin:principal -> sess_id:session_id ->
+  prin:principal -> sess_id:state_id ->
   key:key_t ->
   traceful (option value_t)
 let find_value #key_t #value_t #mt prin sess_id key =
@@ -210,7 +210,7 @@ val add_key_value_invariant:
   {|invs:protocol_invariants|} ->
   #key_t:eqtype -> #value_t:Type0 -> {|map_types key_t value_t|} ->
   mpred:map_predicate key_t value_t ->
-  prin:principal -> sess_id:session_id ->
+  prin:principal -> sess_id:state_id ->
   key:key_t -> value:value_t ->
   tr:trace ->
   Lemma
@@ -235,7 +235,7 @@ val find_value_invariant:
   {|invs:protocol_invariants|} ->
   #key_t:eqtype -> #value_t:Type0 -> {|map_types key_t value_t|} ->
   mpred:map_predicate key_t value_t ->
-  prin:principal -> sess_id:session_id ->
+  prin:principal -> sess_id:state_id ->
   key:key_t ->
   tr:trace ->
   Lemma

--- a/src/lib/state/DY.Lib.State.Map.fst
+++ b/src/lib/state/DY.Lib.State.Map.fst
@@ -25,12 +25,12 @@ class map_types (key_t:eqtype) (value_t:Type0) = {
 /// The map predicate relates a key and its associated value.
 
 noeq type map_predicate {|crypto_invariants|} (key_t:eqtype) (value_t:Type0) {|mt:map_types key_t value_t|} = {
-  pred: trace -> principal -> nat -> key_t -> value_t -> prop;
-  pred_later: tr1:trace -> tr2:trace -> prin:principal -> sess_id:nat -> key:key_t -> value:value_t -> Lemma
+  pred: trace -> principal -> session_id -> key_t -> value_t -> prop;
+  pred_later: tr1:trace -> tr2:trace -> prin:principal -> sess_id:session_id -> key:key_t -> value:value_t -> Lemma
     (requires pred tr1 prin sess_id key value /\ tr1 <$ tr2)
     (ensures pred tr2 prin sess_id key value)
   ;
-  pred_knowable: tr:trace -> prin:principal -> sess_id:nat -> key:key_t -> value:value_t -> Lemma
+  pred_knowable: tr:trace -> prin:principal -> sess_id:session_id -> key:key_t -> value:value_t -> Lemma
     (requires pred tr prin sess_id key value)
     (ensures is_well_formed_prefix mt.ps_key_t (is_knowable_by (principal_state_label prin sess_id) tr) key /\ is_well_formed_prefix mt.ps_value_t (is_knowable_by (principal_state_label prin sess_id) tr) value)
   ;
@@ -67,7 +67,7 @@ val map_elem_invariant:
   {|crypto_invariants|} ->
   #key_t:eqtype -> #value_t:Type0 -> {|map_types key_t value_t|} ->
   map_predicate key_t value_t ->
-  trace -> principal -> nat -> map_elem key_t value_t ->
+  trace -> principal -> session_id -> map_elem key_t value_t ->
   prop
 let map_elem_invariant #cinvs #key_t #value_t #mt mpred tr prin sess_id x =
   mpred.pred tr prin sess_id x.key x.value
@@ -76,7 +76,7 @@ val map_invariant:
   {|crypto_invariants|} ->
   #key_t:eqtype -> #value_t:Type0 -> {|map_types key_t value_t|} ->
   map_predicate key_t value_t ->
-  trace -> principal -> nat -> map key_t value_t ->
+  trace -> principal -> session_id -> map key_t value_t ->
   prop
 let map_invariant #cinvs #key_t #value_t #mt mpred tr prin sess_id st =
   for_allP (map_elem_invariant mpred tr prin sess_id) st.key_values
@@ -85,7 +85,7 @@ val map_invariant_eq:
   {|crypto_invariants|} ->
   #key_t:eqtype -> #value_t:Type0 -> {|map_types key_t value_t|} ->
   mpred:map_predicate key_t value_t ->
-  tr:trace -> prin:principal -> sess_id:nat -> st:map key_t value_t ->
+  tr:trace -> prin:principal -> sess_id:session_id -> st:map key_t value_t ->
   Lemma
   (map_invariant mpred tr prin sess_id st <==> (forall x. List.Tot.memP x st.key_values ==> map_elem_invariant mpred tr prin sess_id x))
 let map_invariant_eq #cinvs #key_t #value_t #mt mpred tr prin sess_id st =
@@ -129,7 +129,7 @@ val initialize_map:
   key_t:eqtype -> value_t:Type0 ->
   {|map_types key_t value_t|} ->
   prin:principal ->
-  traceful nat
+  traceful session_id
 let initialize_map key_t value_t #mt prin =
   let* sess_id = new_session_id prin in
   let version: map key_t value_t = { key_values = [] } in
@@ -139,7 +139,7 @@ let initialize_map key_t value_t #mt prin =
 [@@ "opaque_to_smt"]
 val add_key_value:
   #key_t:eqtype -> #value_t:Type0 -> {|map_types key_t value_t|} ->
-  prin:principal -> sess_id:nat ->
+  prin:principal -> sess_id:session_id ->
   key:key_t -> value:value_t ->
   traceful (option unit)
 let add_key_value #key_t #value_t #mt prin sess_id key value =
@@ -174,7 +174,7 @@ let rec find_value_aux #key_t #value_t #mt key l =
 [@@ "opaque_to_smt"]
 val find_value:
   #key_t:eqtype -> #value_t:Type0 -> {|map_types key_t value_t|} ->
-  prin:principal -> sess_id:nat ->
+  prin:principal -> sess_id:session_id ->
   key:key_t ->
   traceful (option value_t)
 let find_value #key_t #value_t #mt prin sess_id key =
@@ -210,7 +210,7 @@ val add_key_value_invariant:
   {|invs:protocol_invariants|} ->
   #key_t:eqtype -> #value_t:Type0 -> {|map_types key_t value_t|} ->
   mpred:map_predicate key_t value_t ->
-  prin:principal -> sess_id:nat ->
+  prin:principal -> sess_id:session_id ->
   key:key_t -> value:value_t ->
   tr:trace ->
   Lemma
@@ -235,7 +235,7 @@ val find_value_invariant:
   {|invs:protocol_invariants|} ->
   #key_t:eqtype -> #value_t:Type0 -> {|map_types key_t value_t|} ->
   mpred:map_predicate key_t value_t ->
-  prin:principal -> sess_id:nat ->
+  prin:principal -> sess_id:session_id ->
   key:key_t ->
   tr:trace ->
   Lemma

--- a/src/lib/state/DY.Lib.State.Map.fst
+++ b/src/lib/state/DY.Lib.State.Map.fst
@@ -7,11 +7,11 @@ open DY.Lib.State.Typed
 
 #set-options "--fuel 0 --ifuel 0"
 
-/// This module defines a generic state for maps.
+/// This module defines a generic version for maps.
 /// It will be used by DY.Lib.State.PKI or DY.Lib.State.PrivateKeys,
 /// but can also be useful when specifying a protocol.
 
-(*** Map state & invariants ***)
+(*** Map version & invariants ***)
 
 /// The parameters necessary to define the map functions.
 
@@ -58,7 +58,7 @@ noeq type map (key_t:eqtype) (value_t:Type0) {|mt:map_types key_t value_t|} = {
 
 instance parseable_serializeable_bytes_map (key_t:eqtype) (value_t:Type0) {|map_types key_t value_t|} : parseable_serializeable bytes (map key_t value_t) = mk_parseable_serializeable (ps_map key_t value_t)
 
-instance local_state_map (key_t:eqtype) (value_t:Type0) {|mt:map_types key_t value_t|}: local_state (map key_t value_t) = {
+instance local_version_map (key_t:eqtype) (value_t:Type0) {|mt:map_types key_t value_t|}: local_version (map key_t value_t) = {
   tag = mt.tag;
   format = (parseable_serializeable_bytes_map key_t value_t);
 }
@@ -91,12 +91,12 @@ val map_invariant_eq:
 let map_invariant_eq #cinvs #key_t #value_t #mt mpred tr prin sess_id st =
   for_allP_eq (map_elem_invariant mpred tr prin sess_id) st.key_values
 
-val map_session_invariant:
+val map_state_predicate:
   {|crypto_invariants|} ->
   #key_t:eqtype -> #value_t:Type0 -> {|map_types key_t value_t|} ->
   mpred:map_predicate key_t value_t ->
   local_state_predicate (map key_t value_t)
-let map_session_invariant #cinvs #key_t #value_t #mt mpred = {
+let map_state_predicate #cinvs #key_t #value_t #mt mpred = {
   pred = (fun tr prin sess_id content -> map_invariant mpred tr prin sess_id content);
   pred_later = (fun tr1 tr2 prin sess_id content ->
     map_invariant_eq mpred tr1 prin sess_id content;
@@ -116,11 +116,11 @@ let map_session_invariant #cinvs #key_t #value_t #mt mpred = {
   );
 }
 
-val has_map_session_invariant:
+val has_map_state_predicate:
   #key_t:eqtype -> #value_t:Type0 -> {|map_types key_t value_t|} ->
   protocol_invariants -> map_predicate key_t value_t -> prop
-let has_map_session_invariant #key_t #value_t #mt invs mpred =
-  has_local_state_predicate invs (map_session_invariant mpred)
+let has_map_state_predicate #key_t #value_t #mt invs mpred =
+  has_local_state_predicate invs (map_state_predicate mpred)
 
 (*** Map API ***)
 
@@ -132,8 +132,8 @@ val initialize_map:
   traceful nat
 let initialize_map key_t value_t #mt prin =
   let* sess_id = new_session_id prin in
-  let session: map key_t value_t = { key_values = [] } in
-  set_state prin sess_id session;*
+  let version: map key_t value_t = { key_values = [] } in
+  set_version prin sess_id version;*
   return sess_id
 
 [@@ "opaque_to_smt"]
@@ -143,9 +143,9 @@ val add_key_value:
   key:key_t -> value:value_t ->
   traceful (option unit)
 let add_key_value #key_t #value_t #mt prin sess_id key value =
-  let*? the_map = get_state prin sess_id in
+  let*? the_map = get_latest_version prin sess_id in
   let new_elem = {key; value;} in
-  set_state prin sess_id { key_values = new_elem::the_map.key_values };*
+  set_version prin sess_id { key_values = new_elem::the_map.key_values };*
   return (Some ())
 
 #push-options "--fuel 1 --ifuel 1"
@@ -178,7 +178,7 @@ val find_value:
   key:key_t ->
   traceful (option value_t)
 let find_value #key_t #value_t #mt prin sess_id key =
-  let*? the_map = get_state prin sess_id in
+  let*? the_map = get_latest_version prin sess_id in
   return (find_value_aux key the_map.key_values)
 
 #push-options "--fuel 1"
@@ -191,14 +191,14 @@ val initialize_map_invariant:
   Lemma
   (requires
     trace_invariant tr /\
-    has_map_session_invariant invs mpred
+    has_map_state_predicate invs mpred
   )
   (ensures (
     let (_, tr_out) = initialize_map key_t value_t prin tr in
     trace_invariant tr_out
   ))
   [SMTPat (initialize_map key_t value_t prin tr);
-   SMTPat (has_map_session_invariant invs mpred);
+   SMTPat (has_map_state_predicate invs mpred);
    SMTPat (trace_invariant tr)
   ]
 let initialize_map_invariant #invs #key_t #value_t #mt mpred prin tr =
@@ -217,14 +217,14 @@ val add_key_value_invariant:
   (requires
     mpred.pred tr prin sess_id key value /\
     trace_invariant tr /\
-    has_map_session_invariant invs mpred
+    has_map_state_predicate invs mpred
   )
   (ensures (
     let (_, tr_out) = add_key_value prin sess_id key value tr in
     trace_invariant tr_out
   ))
   [SMTPat (add_key_value prin sess_id key value tr);
-   SMTPat (has_map_session_invariant invs mpred);
+   SMTPat (has_map_state_predicate invs mpred);
    SMTPat (trace_invariant tr)
   ]
 let add_key_value_invariant #invs #key_t #value_t #mt mpred prin sess_id key value tr =
@@ -241,7 +241,7 @@ val find_value_invariant:
   Lemma
   (requires
     trace_invariant tr /\
-    has_map_session_invariant invs mpred
+    has_map_state_predicate invs mpred
   )
   (ensures (
     let (opt_value, tr_out) = find_value prin sess_id key tr in
@@ -254,12 +254,12 @@ val find_value_invariant:
     )
   ))
   [SMTPat (find_value #key_t #value_t prin sess_id key tr);
-   SMTPat (has_map_session_invariant invs mpred);
+   SMTPat (has_map_state_predicate invs mpred);
    SMTPat (trace_invariant tr);
   ]
 let find_value_invariant #invs #key_t #value_t #mt mpred prin sess_id key tr =
   reveal_opaque (`%find_value) (find_value #key_t #value_t);
-  let (opt_the_map, tr) = get_state prin sess_id tr in
+  let (opt_the_map, tr) = get_latest_version prin sess_id tr in
   match opt_the_map with
   | None -> ()
   | Some the_map -> (

--- a/src/lib/state/DY.Lib.State.PKI.fst
+++ b/src/lib/state/DY.Lib.State.PKI.fst
@@ -86,16 +86,16 @@ let pki_tag_and_invariant #ci = (map_types_pki.tag, local_state_predicate_to_loc
 (*** PKI API ***)
 
 [@@ "opaque_to_smt"]
-val initialize_pki: prin:principal -> traceful session_id
+val initialize_pki: prin:principal -> traceful state_id
 let initialize_pki = initialize_map pki_key pki_value #_ // another workaround for FStarLang/FStar#3286
 
 [@@ "opaque_to_smt"]
-val install_public_key: principal -> session_id -> public_key_type -> principal -> bytes -> traceful (option unit)
+val install_public_key: principal -> state_id -> public_key_type -> principal -> bytes -> traceful (option unit)
 let install_public_key prin sess_id pk_type who pk =
   add_key_value prin sess_id ({ty = pk_type; who;}) ({public_key = pk;})
 
 [@@ "opaque_to_smt"]
-val get_public_key: principal -> session_id -> public_key_type -> principal -> traceful (option bytes)
+val get_public_key: principal -> state_id -> public_key_type -> principal -> traceful (option bytes)
 let get_public_key prin sess_id pk_type who =
   let*? res = find_value prin sess_id ({ty = pk_type; who;}) in
   return (Some res.public_key)
@@ -120,7 +120,7 @@ let initialize_pki_invariant #invs prin tr =
 
 val install_public_key_invariant:
   {|invs:protocol_invariants|} ->
-  prin:principal -> sess_id:session_id -> pk_type:public_key_type -> who:principal -> pk:bytes -> tr:trace ->
+  prin:principal -> sess_id:state_id -> pk_type:public_key_type -> who:principal -> pk:bytes -> tr:trace ->
   Lemma
   (requires
     is_public_key_for tr pk pk_type who /\
@@ -139,7 +139,7 @@ let install_public_key_invariant #invs prin sess_id pk_type who pk tr =
 
 val get_public_key_invariant:
   {|invs:protocol_invariants|} ->
-  prin:principal -> sess_id:session_id -> pk_type:public_key_type -> who:principal -> tr:trace ->
+  prin:principal -> sess_id:state_id -> pk_type:public_key_type -> who:principal -> tr:trace ->
   Lemma
   (requires
     trace_invariant tr /\

--- a/src/lib/state/DY.Lib.State.PKI.fst
+++ b/src/lib/state/DY.Lib.State.PKI.fst
@@ -78,10 +78,10 @@ let pki_pred #cinvs = {
 
 val has_pki_invariant: protocol_invariants -> prop
 let has_pki_invariant invs =
-  has_map_state_predicate invs pki_pred
+  has_map_session_invariant invs pki_pred
 
 val pki_tag_and_invariant: {|crypto_invariants|} -> string & local_bytes_state_predicate
-let pki_tag_and_invariant #ci = (map_types_pki.tag, local_state_predicate_to_local_bytes_state_predicate (map_state_predicate pki_pred))
+let pki_tag_and_invariant #ci = (map_types_pki.tag, local_state_predicate_to_local_bytes_state_predicate (map_session_invariant pki_pred))
 
 (*** PKI API ***)
 

--- a/src/lib/state/DY.Lib.State.PKI.fst
+++ b/src/lib/state/DY.Lib.State.PKI.fst
@@ -78,10 +78,10 @@ let pki_pred #cinvs = {
 
 val has_pki_invariant: protocol_invariants -> prop
 let has_pki_invariant invs =
-  has_map_session_invariant invs pki_pred
+  has_map_state_predicate invs pki_pred
 
 val pki_tag_and_invariant: {|crypto_invariants|} -> string & local_bytes_state_predicate
-let pki_tag_and_invariant #ci = (map_types_pki.tag, local_state_predicate_to_local_bytes_state_predicate (map_session_invariant pki_pred))
+let pki_tag_and_invariant #ci = (map_types_pki.tag, local_state_predicate_to_local_bytes_state_predicate (map_state_predicate pki_pred))
 
 (*** PKI API ***)
 

--- a/src/lib/state/DY.Lib.State.PKI.fst
+++ b/src/lib/state/DY.Lib.State.PKI.fst
@@ -86,16 +86,16 @@ let pki_tag_and_invariant #ci = (map_types_pki.tag, local_state_predicate_to_loc
 (*** PKI API ***)
 
 [@@ "opaque_to_smt"]
-val initialize_pki: prin:principal -> traceful nat
+val initialize_pki: prin:principal -> traceful session_id
 let initialize_pki = initialize_map pki_key pki_value #_ // another workaround for FStarLang/FStar#3286
 
 [@@ "opaque_to_smt"]
-val install_public_key: principal -> nat -> public_key_type -> principal -> bytes -> traceful (option unit)
+val install_public_key: principal -> session_id -> public_key_type -> principal -> bytes -> traceful (option unit)
 let install_public_key prin sess_id pk_type who pk =
   add_key_value prin sess_id ({ty = pk_type; who;}) ({public_key = pk;})
 
 [@@ "opaque_to_smt"]
-val get_public_key: principal -> nat -> public_key_type -> principal -> traceful (option bytes)
+val get_public_key: principal -> session_id -> public_key_type -> principal -> traceful (option bytes)
 let get_public_key prin sess_id pk_type who =
   let*? res = find_value prin sess_id ({ty = pk_type; who;}) in
   return (Some res.public_key)
@@ -120,7 +120,7 @@ let initialize_pki_invariant #invs prin tr =
 
 val install_public_key_invariant:
   {|invs:protocol_invariants|} ->
-  prin:principal -> sess_id:nat -> pk_type:public_key_type -> who:principal -> pk:bytes -> tr:trace ->
+  prin:principal -> sess_id:session_id -> pk_type:public_key_type -> who:principal -> pk:bytes -> tr:trace ->
   Lemma
   (requires
     is_public_key_for tr pk pk_type who /\
@@ -139,7 +139,7 @@ let install_public_key_invariant #invs prin sess_id pk_type who pk tr =
 
 val get_public_key_invariant:
   {|invs:protocol_invariants|} ->
-  prin:principal -> sess_id:nat -> pk_type:public_key_type -> who:principal -> tr:trace ->
+  prin:principal -> sess_id:session_id -> pk_type:public_key_type -> who:principal -> tr:trace ->
   Lemma
   (requires
     trace_invariant tr /\

--- a/src/lib/state/DY.Lib.State.PrivateKeys.fst
+++ b/src/lib/state/DY.Lib.State.PrivateKeys.fst
@@ -86,17 +86,17 @@ let private_key_type_to_usage sk_type =
 (*** Private Keys API ***)
 
 [@@ "opaque_to_smt"]
-val initialize_private_keys: prin:principal -> traceful nat
+val initialize_private_keys: prin:principal -> traceful session_id
 let initialize_private_keys = initialize_map private_key_key private_key_value #_ // another workaround for FStarLang/FStar#3286
 
 [@@ "opaque_to_smt"]
-val generate_private_key: principal -> nat -> private_key_type -> traceful (option unit)
+val generate_private_key: principal -> session_id -> private_key_type -> traceful (option unit)
 let generate_private_key prin sess_id sk_type =
   let* sk = mk_rand (private_key_type_to_usage sk_type) (principal_label prin) 64 in //TODO
   add_key_value prin sess_id ({ty = sk_type}) ({private_key = sk;})
 
 [@@ "opaque_to_smt"]
-val get_private_key: principal -> nat -> private_key_type -> traceful (option bytes)
+val get_private_key: principal -> session_id -> private_key_type -> traceful (option bytes)
 let get_private_key prin sess_id sk_type =
   let*? res = find_value prin sess_id ({ty = sk_type}) in
   return (Some res.private_key)
@@ -121,7 +121,7 @@ let initialize_private_keys_invariant #invs prin tr =
 
 val generate_private_key_invariant:
   {|invs:protocol_invariants|} ->
-  prin:principal -> sess_id:nat -> sk_type:private_key_type -> tr:trace ->
+  prin:principal -> sess_id:session_id -> sk_type:private_key_type -> tr:trace ->
   Lemma
   (requires
     trace_invariant tr /\
@@ -139,7 +139,7 @@ let generate_private_key_invariant #invs prin sess_id sk_type tr =
 
 val get_private_key_invariant:
   {|invs:protocol_invariants|} ->
-  prin:principal -> sess_id:nat -> pk_type:private_key_type -> tr:trace ->
+  prin:principal -> sess_id:session_id -> pk_type:private_key_type -> tr:trace ->
   Lemma
   (requires
     trace_invariant tr /\

--- a/src/lib/state/DY.Lib.State.PrivateKeys.fst
+++ b/src/lib/state/DY.Lib.State.PrivateKeys.fst
@@ -10,7 +10,7 @@ open DY.Lib.State.Map
 
 #set-options "--fuel 1 --ifuel 1"
 
-/// This module defines a state to store private keys for a principal.
+/// This module defines a version to store private keys for a principal.
 /// Private keys can be generated with `generate_private_key`
 /// and obtained back with `get_private_key`.
 
@@ -70,10 +70,10 @@ let private_keys_pred #cinvs = {
 
 val has_private_keys_invariant: protocol_invariants -> prop
 let has_private_keys_invariant invs =
-  has_map_session_invariant invs private_keys_pred
+  has_map_state_predicate invs private_keys_pred
 
 val private_keys_tag_and_invariant: {|crypto_invariants|} -> string & local_bytes_state_predicate
-let private_keys_tag_and_invariant #ci = (map_types_private_keys.tag, local_state_predicate_to_local_bytes_state_predicate (map_session_invariant private_keys_pred))
+let private_keys_tag_and_invariant #ci = (map_types_private_keys.tag, local_state_predicate_to_local_bytes_state_predicate (map_state_predicate private_keys_pred))
 
 val private_key_type_to_usage:
   private_key_type ->

--- a/src/lib/state/DY.Lib.State.PrivateKeys.fst
+++ b/src/lib/state/DY.Lib.State.PrivateKeys.fst
@@ -10,7 +10,7 @@ open DY.Lib.State.Map
 
 #set-options "--fuel 1 --ifuel 1"
 
-/// This module defines a version to store private keys for a principal.
+/// This module defines a state to store private keys for a principal.
 /// Private keys can be generated with `generate_private_key`
 /// and obtained back with `get_private_key`.
 
@@ -70,10 +70,10 @@ let private_keys_pred #cinvs = {
 
 val has_private_keys_invariant: protocol_invariants -> prop
 let has_private_keys_invariant invs =
-  has_map_state_predicate invs private_keys_pred
+  has_map_session_invariant invs private_keys_pred
 
 val private_keys_tag_and_invariant: {|crypto_invariants|} -> string & local_bytes_state_predicate
-let private_keys_tag_and_invariant #ci = (map_types_private_keys.tag, local_state_predicate_to_local_bytes_state_predicate (map_state_predicate private_keys_pred))
+let private_keys_tag_and_invariant #ci = (map_types_private_keys.tag, local_state_predicate_to_local_bytes_state_predicate (map_session_invariant private_keys_pred))
 
 val private_key_type_to_usage:
   private_key_type ->

--- a/src/lib/state/DY.Lib.State.PrivateKeys.fst
+++ b/src/lib/state/DY.Lib.State.PrivateKeys.fst
@@ -86,17 +86,17 @@ let private_key_type_to_usage sk_type =
 (*** Private Keys API ***)
 
 [@@ "opaque_to_smt"]
-val initialize_private_keys: prin:principal -> traceful session_id
+val initialize_private_keys: prin:principal -> traceful state_id
 let initialize_private_keys = initialize_map private_key_key private_key_value #_ // another workaround for FStarLang/FStar#3286
 
 [@@ "opaque_to_smt"]
-val generate_private_key: principal -> session_id -> private_key_type -> traceful (option unit)
+val generate_private_key: principal -> state_id -> private_key_type -> traceful (option unit)
 let generate_private_key prin sess_id sk_type =
   let* sk = mk_rand (private_key_type_to_usage sk_type) (principal_label prin) 64 in //TODO
   add_key_value prin sess_id ({ty = sk_type}) ({private_key = sk;})
 
 [@@ "opaque_to_smt"]
-val get_private_key: principal -> session_id -> private_key_type -> traceful (option bytes)
+val get_private_key: principal -> state_id -> private_key_type -> traceful (option bytes)
 let get_private_key prin sess_id sk_type =
   let*? res = find_value prin sess_id ({ty = sk_type}) in
   return (Some res.private_key)
@@ -121,7 +121,7 @@ let initialize_private_keys_invariant #invs prin tr =
 
 val generate_private_key_invariant:
   {|invs:protocol_invariants|} ->
-  prin:principal -> sess_id:session_id -> sk_type:private_key_type -> tr:trace ->
+  prin:principal -> sess_id:state_id -> sk_type:private_key_type -> tr:trace ->
   Lemma
   (requires
     trace_invariant tr /\
@@ -139,7 +139,7 @@ let generate_private_key_invariant #invs prin sess_id sk_type tr =
 
 val get_private_key_invariant:
   {|invs:protocol_invariants|} ->
-  prin:principal -> sess_id:session_id -> pk_type:private_key_type -> tr:trace ->
+  prin:principal -> sess_id:state_id -> pk_type:private_key_type -> tr:trace ->
   Lemma
   (requires
     trace_invariant tr /\

--- a/src/lib/state/DY.Lib.State.Tagged.fst
+++ b/src/lib/state/DY.Lib.State.Tagged.fst
@@ -140,7 +140,7 @@ let mk_state_predicate cinvs lpreds =
 (*** Predicates on trace ***)
 
 [@@ "opaque_to_smt"]
-val tagged_state_was_set: trace -> string -> principal -> sess_id -> bytes -> prop
+val tagged_state_was_set: trace -> string -> principal -> session_id -> bytes -> prop
 let tagged_state_was_set tr tag prin sess_id content =
   let full_content = {tag; content;} in
   let full_content_bytes = serialize tagged_state full_content in

--- a/src/lib/state/DY.Lib.State.Tagged.fst
+++ b/src/lib/state/DY.Lib.State.Tagged.fst
@@ -11,16 +11,16 @@ open DY.Lib.Comparse.Parsers
 (*** Tagged state predicates ***)
 
 [@@ with_bytes bytes]
-type tagged_version = {
+type tagged_state = {
   [@@@ with_parser #bytes ps_string]
   tag: string;
   content: bytes;
 }
 
-%splice [ps_tagged_version] (gen_parser (`tagged_version))
-%splice [ps_tagged_version_is_well_formed] (gen_is_well_formed_lemma (`tagged_version))
+%splice [ps_tagged_state] (gen_parser (`tagged_state))
+%splice [ps_tagged_state_is_well_formed] (gen_is_well_formed_lemma (`tagged_state))
 
-instance parseable_serializeable_bytes_tagged_version: parseable_serializeable bytes tagged_version = mk_parseable_serializeable (ps_tagged_version)
+instance parseable_serializeable_bytes_tagged_state: parseable_serializeable bytes tagged_state = mk_parseable_serializeable (ps_tagged_state)
 
 noeq
 type local_bytes_state_predicate {|crypto_invariants|} = {
@@ -47,7 +47,7 @@ let split_local_bytes_state_predicate_func {|crypto_invariants|} : split_predica
   raw_data_t = trace & principal & session_id & bytes;
 
   decode_tagged_data = (fun (tr, prin, sess_id, sess_content) -> (
-    match parse tagged_version sess_content with
+    match parse tagged_state sess_content with
     | Some ({tag; content}) -> Some (tag, (tr, prin, sess_id, content))
     | None -> None
   ));
@@ -125,8 +125,8 @@ let mk_global_local_bytes_state_predicate_knowable cinvs lpreds tr prin sess_id 
   with _. (
     let Some (tag, (_, _, _, content)) = split_local_bytes_state_predicate_func.decode_tagged_data (tr, prin, sess_id, full_content) in
     lpred.pred_knowable tr prin sess_id content;
-    serialize_parse_inv_lemma tagged_version full_content;
-    serialize_wf_lemma tagged_version (is_knowable_by (principal_state_label prin sess_id) tr) ({tag; content})
+    serialize_parse_inv_lemma tagged_state full_content;
+    serialize_wf_lemma tagged_state (is_knowable_by (principal_state_label prin sess_id) tr) ({tag; content})
   )
 
 val mk_state_predicate: cinvs:crypto_invariants -> list (string & local_bytes_state_predicate) -> state_predicate cinvs
@@ -140,32 +140,32 @@ let mk_state_predicate cinvs lpreds =
 (*** Predicates on trace ***)
 
 [@@ "opaque_to_smt"]
-val tagged_version_was_set: trace -> string -> principal -> session_id -> bytes -> prop
-let tagged_version_was_set tr tag prin sess_id content =
+val tagged_state_was_set: trace -> string -> principal -> sess_id -> bytes -> prop
+let tagged_state_was_set tr tag prin sess_id content =
   let full_content = {tag; content;} in
-  let full_content_bytes = serialize tagged_version full_content in
-  version_was_set tr prin sess_id full_content_bytes
+  let full_content_bytes = serialize tagged_state full_content in
+  state_was_set tr prin sess_id full_content_bytes
 
-(*** API for tagged versions ***)
+(*** API for tagged sessions ***)
 
 [@@ "opaque_to_smt"]
-val set_tagged_version: string -> principal -> session_id -> bytes -> traceful unit
-let set_tagged_version tag prin sess_id content =
+val set_tagged_state: string -> principal -> session_id -> bytes -> traceful unit
+let set_tagged_state tag prin sess_id content =
   let full_content = {tag; content;} in
-  let full_content_bytes = serialize tagged_version full_content in
-  set_version prin sess_id full_content_bytes
+  let full_content_bytes = serialize tagged_state full_content in
+  set_state prin sess_id full_content_bytes
 
 [@@ "opaque_to_smt"]
-val get_latest_tagged_version: string -> principal -> session_id -> traceful (option bytes)
-let get_latest_tagged_version the_tag prin sess_id =
-  let*? full_content_bytes = get_latest_version prin sess_id in
-  match parse tagged_version full_content_bytes with
+val get_tagged_state: string -> principal -> session_id -> traceful (option bytes)
+let get_tagged_state the_tag prin sess_id =
+  let*? full_content_bytes = get_state prin sess_id in
+  match parse tagged_state full_content_bytes with
     | None -> return None
     | Some ({tag; content;}) ->
       if tag = the_tag then return (Some content)
       else return None
 
-val set_tagged_version_invariant:
+val set_tagged_state_invariant:
   invs:protocol_invariants ->
   tag:string -> spred:local_bytes_state_predicate ->
   prin:principal -> sess_id:session_id -> content:bytes -> tr:trace ->
@@ -176,21 +176,21 @@ val set_tagged_version_invariant:
     has_local_bytes_state_predicate invs (tag, spred)
   )
   (ensures (
-    let ((), tr_out) = set_tagged_version tag prin sess_id content tr in
+    let ((), tr_out) = set_tagged_state tag prin sess_id content tr in
     trace_invariant tr_out /\
-    tagged_version_was_set tr_out tag prin sess_id content
+    tagged_state_was_set tr_out tag prin sess_id content
   ))
-  [SMTPat (set_tagged_version tag prin sess_id content tr);
+  [SMTPat (set_tagged_state tag prin sess_id content tr);
    SMTPat (trace_invariant tr);
    SMTPat (has_local_bytes_state_predicate invs (tag, spred))]
-let set_tagged_version_invariant invs tag spred prin sess_id content tr =
-  reveal_opaque (`%set_tagged_version) (set_tagged_version);
-  reveal_opaque (`%tagged_version_was_set) (tagged_version_was_set);
+let set_tagged_state_invariant invs tag spred prin sess_id content tr =
+  reveal_opaque (`%set_tagged_state) (set_tagged_state);
+  reveal_opaque (`%tagged_state_was_set) (tagged_state_was_set);
   let full_content = {tag; content;} in
-  parse_serialize_inv_lemma #bytes tagged_version full_content;
+  parse_serialize_inv_lemma #bytes tagged_state full_content;
   local_eq_global_lemma split_local_bytes_state_predicate_func state_pred tag spred (tr, prin, sess_id, serialize _ full_content) (tr, prin, sess_id, content)
 
-val get_latest_tagged_version_invariant:
+val get_tagged_state_invariant:
   invs:protocol_invariants ->
   tag:string -> spred:local_bytes_state_predicate ->
   prin:principal -> sess_id:session_id -> tr:trace ->
@@ -200,7 +200,7 @@ val get_latest_tagged_version_invariant:
     has_local_bytes_state_predicate invs (tag, spred)
   )
   (ensures (
-    let (opt_content, tr_out) = get_latest_tagged_version tag prin sess_id tr in
+    let (opt_content, tr_out) = get_tagged_state tag prin sess_id tr in
     tr == tr_out /\ (
       match opt_content with
       | None -> True
@@ -209,38 +209,38 @@ val get_latest_tagged_version_invariant:
       )
     )
   ))
-  [SMTPat (get_latest_tagged_version tag prin sess_id tr);
+  [SMTPat (get_tagged_state tag prin sess_id tr);
    SMTPat (trace_invariant tr);
    SMTPat (has_local_bytes_state_predicate invs (tag, spred))]
-let get_latest_tagged_version_invariant invs tag spred prin sess_id tr =
-  reveal_opaque (`%get_latest_tagged_version) (get_latest_tagged_version);
-  let (opt_content, tr_out) = get_latest_tagged_version tag prin sess_id tr in
+let get_tagged_state_invariant invs tag spred prin sess_id tr =
+  reveal_opaque (`%get_tagged_state) (get_tagged_state);
+  let (opt_content, tr_out) = get_tagged_state tag prin sess_id tr in
   match opt_content with
   | None -> ()
   | Some content ->
-    let (Some full_content_bytes, tr) = get_latest_version prin sess_id tr in
+    let (Some full_content_bytes, tr) = get_state prin sess_id tr in
     local_eq_global_lemma split_local_bytes_state_predicate_func state_pred tag spred (tr, prin, sess_id, full_content_bytes) (tr, prin, sess_id, content)
 
 (*** Theorem ***)
 
-val tagged_version_was_set_implies_pred:
+val tagged_state_was_set_implies_pred:
   invs:protocol_invariants -> tr:trace ->
   tag:string -> spred:local_bytes_state_predicate ->
   prin:principal -> sess_id:session_id -> content:bytes ->
   Lemma
   (requires
-    tagged_version_was_set tr tag prin sess_id content /\
+    tagged_state_was_set tr tag prin sess_id content /\
     trace_invariant tr /\
     has_local_bytes_state_predicate invs (tag, spred)
   )
   (ensures spred.pred tr prin sess_id content)
-  [SMTPat (tagged_version_was_set tr tag prin sess_id content);
+  [SMTPat (tagged_state_was_set tr tag prin sess_id content);
    SMTPat (trace_invariant tr);
    SMTPat (has_local_bytes_state_predicate invs (tag, spred));
   ]
-let tagged_version_was_set_implies_pred invs tr tag spred prin sess_id content =
-  reveal_opaque (`%tagged_version_was_set) (tagged_version_was_set);
+let tagged_state_was_set_implies_pred invs tr tag spred prin sess_id content =
+  reveal_opaque (`%tagged_state_was_set) (tagged_state_was_set);
   let full_content = {tag; content;} in
-  parse_serialize_inv_lemma #bytes tagged_version full_content;
-  let full_content_bytes: bytes = serialize tagged_version full_content in
+  parse_serialize_inv_lemma #bytes tagged_state full_content;
+  let full_content_bytes: bytes = serialize tagged_state full_content in
   local_eq_global_lemma split_local_bytes_state_predicate_func state_pred tag spred (tr, prin, sess_id, full_content_bytes) (tr, prin, sess_id, content)

--- a/src/lib/state/DY.Lib.State.Tagged.fst
+++ b/src/lib/state/DY.Lib.State.Tagged.fst
@@ -24,16 +24,16 @@ instance parseable_serializeable_bytes_tagged_state: parseable_serializeable byt
 
 noeq
 type local_bytes_state_predicate {|crypto_invariants|} = {
-  pred: trace -> principal -> session_id -> bytes -> prop;
+  pred: trace -> principal -> state_id -> bytes -> prop;
   pred_later:
     tr1:trace -> tr2:trace ->
-    prin:principal -> sess_id:session_id -> content:bytes ->
+    prin:principal -> sess_id:state_id -> content:bytes ->
     Lemma
     (requires pred tr1 prin sess_id content /\ tr1 <$ tr2)
     (ensures pred tr2 prin sess_id content)
   ;
   pred_knowable:
-    tr:trace -> prin:principal -> sess_id:session_id -> content:bytes ->
+    tr:trace -> prin:principal -> sess_id:state_id -> content:bytes ->
     Lemma
     (requires pred tr prin sess_id content)
     (ensures is_knowable_by (principal_state_label prin sess_id) tr content)
@@ -41,10 +41,10 @@ type local_bytes_state_predicate {|crypto_invariants|} = {
 }
 
 let split_local_bytes_state_predicate_func {|crypto_invariants|} : split_predicate_input_values = {
-  tagged_data_t = trace & principal & session_id & bytes;
+  tagged_data_t = trace & principal & state_id & bytes;
   tag_t = string;
   encoded_tag_t = string;
-  raw_data_t = trace & principal & session_id & bytes;
+  raw_data_t = trace & principal & state_id & bytes;
 
   decode_tagged_data = (fun (tr, prin, sess_id, sess_content) -> (
     match parse tagged_state sess_content with
@@ -56,7 +56,7 @@ let split_local_bytes_state_predicate_func {|crypto_invariants|} : split_predica
   encode_tag_inj = (fun l1 l2 -> ());
 
   local_pred = local_bytes_state_predicate;
-  global_pred = trace -> principal -> session_id -> bytes -> prop;
+  global_pred = trace -> principal -> state_id -> bytes -> prop;
 
   apply_local_pred = (fun spred (tr, prin, sess_id, content) ->
     spred.pred tr prin sess_id content
@@ -76,7 +76,7 @@ let has_local_bytes_state_predicate invs (tag, spred) =
 
 (*** Global tagged state predicate builder ***)
 
-val mk_global_local_bytes_state_predicate: {|crypto_invariants|} -> list (string & local_bytes_state_predicate) -> trace -> principal -> session_id -> bytes -> prop
+val mk_global_local_bytes_state_predicate: {|crypto_invariants|} -> list (string & local_bytes_state_predicate) -> trace -> principal -> state_id -> bytes -> prop
 let mk_global_local_bytes_state_predicate #cinvs l =
   mk_global_pred split_local_bytes_state_predicate_func l
 
@@ -92,7 +92,7 @@ let mk_global_local_bytes_state_predicate_correct invs lpreds =
 
 val mk_global_local_bytes_state_predicate_later:
   cinvs:crypto_invariants -> lpreds:list (string & local_bytes_state_predicate) ->
-  tr1:trace -> tr2:trace -> prin:principal -> sess_id:session_id -> full_content:bytes -> Lemma
+  tr1:trace -> tr2:trace -> prin:principal -> sess_id:state_id -> full_content:bytes -> Lemma
   (requires mk_global_local_bytes_state_predicate lpreds tr1 prin sess_id full_content /\ tr1 <$ tr2)
   (ensures mk_global_local_bytes_state_predicate lpreds tr2 prin sess_id full_content)
 let mk_global_local_bytes_state_predicate_later cinvs lpreds tr1 tr2 prin sess_id full_content =
@@ -111,7 +111,7 @@ let mk_global_local_bytes_state_predicate_later cinvs lpreds tr1 tr2 prin sess_i
 
 val mk_global_local_bytes_state_predicate_knowable:
   cinvs:crypto_invariants -> lpreds:list (string & local_bytes_state_predicate) ->
-  tr:trace -> prin:principal -> sess_id:session_id -> full_content:bytes ->
+  tr:trace -> prin:principal -> sess_id:state_id -> full_content:bytes ->
   Lemma
   (requires mk_global_local_bytes_state_predicate lpreds tr prin sess_id full_content)
   (ensures is_knowable_by (principal_state_label prin sess_id) tr full_content)
@@ -140,7 +140,7 @@ let mk_state_predicate cinvs lpreds =
 (*** Predicates on trace ***)
 
 [@@ "opaque_to_smt"]
-val tagged_state_was_set: trace -> string -> principal -> session_id -> bytes -> prop
+val tagged_state_was_set: trace -> string -> principal -> state_id -> bytes -> prop
 let tagged_state_was_set tr tag prin sess_id content =
   let full_content = {tag; content;} in
   let full_content_bytes = serialize tagged_state full_content in
@@ -149,14 +149,14 @@ let tagged_state_was_set tr tag prin sess_id content =
 (*** API for tagged sessions ***)
 
 [@@ "opaque_to_smt"]
-val set_tagged_state: string -> principal -> session_id -> bytes -> traceful unit
+val set_tagged_state: string -> principal -> state_id -> bytes -> traceful unit
 let set_tagged_state tag prin sess_id content =
   let full_content = {tag; content;} in
   let full_content_bytes = serialize tagged_state full_content in
   set_state prin sess_id full_content_bytes
 
 [@@ "opaque_to_smt"]
-val get_tagged_state: string -> principal -> session_id -> traceful (option bytes)
+val get_tagged_state: string -> principal -> state_id -> traceful (option bytes)
 let get_tagged_state the_tag prin sess_id =
   let*? full_content_bytes = get_state prin sess_id in
   match parse tagged_state full_content_bytes with
@@ -168,7 +168,7 @@ let get_tagged_state the_tag prin sess_id =
 val set_tagged_state_invariant:
   invs:protocol_invariants ->
   tag:string -> spred:local_bytes_state_predicate ->
-  prin:principal -> sess_id:session_id -> content:bytes -> tr:trace ->
+  prin:principal -> sess_id:state_id -> content:bytes -> tr:trace ->
   Lemma
   (requires
     spred.pred tr prin sess_id content /\
@@ -193,7 +193,7 @@ let set_tagged_state_invariant invs tag spred prin sess_id content tr =
 val get_tagged_state_invariant:
   invs:protocol_invariants ->
   tag:string -> spred:local_bytes_state_predicate ->
-  prin:principal -> sess_id:session_id -> tr:trace ->
+  prin:principal -> sess_id:state_id -> tr:trace ->
   Lemma
   (requires
     trace_invariant tr /\
@@ -226,7 +226,7 @@ let get_tagged_state_invariant invs tag spred prin sess_id tr =
 val tagged_state_was_set_implies_pred:
   invs:protocol_invariants -> tr:trace ->
   tag:string -> spred:local_bytes_state_predicate ->
-  prin:principal -> sess_id:session_id -> content:bytes ->
+  prin:principal -> sess_id:state_id -> content:bytes ->
   Lemma
   (requires
     tagged_state_was_set tr tag prin sess_id content /\

--- a/src/lib/state/DY.Lib.State.Typed.fst
+++ b/src/lib/state/DY.Lib.State.Typed.fst
@@ -70,7 +70,7 @@ let has_local_state_predicate #a #ls invs spred =
 [@@ "opaque_to_smt"]
 val state_was_set:
   #a:Type -> {|local_state a|} ->
-  trace -> principal -> sess_id -> a ->
+  trace -> principal -> session_id -> a ->
   prop
 let state_was_set #a #ls tr prin sess_id content =
   tagged_state_was_set tr ls.tag prin sess_id (serialize _ content)
@@ -78,7 +78,7 @@ let state_was_set #a #ls tr prin sess_id content =
 [@@ "opaque_to_smt"]
 val set_state:
   #a:Type -> {|local_state a|} ->
-  principal -> sess_id -> a -> traceful unit
+  principal -> session_id -> a -> traceful unit
 let set_state #a #ls prin sess_id content =
   set_tagged_state ls.tag prin sess_id (serialize _ content)
 

--- a/src/lib/state/DY.Lib.State.Typed.fst
+++ b/src/lib/state/DY.Lib.State.Typed.fst
@@ -21,16 +21,16 @@ let mk_local_state_instance #a #format tag = {
 
 noeq
 type local_state_predicate {|crypto_invariants|} (a:Type) {|parseable_serializeable bytes a|} = {
-  pred: trace -> principal -> session_id -> a -> prop;
+  pred: trace -> principal -> state_id -> a -> prop;
   pred_later:
     tr1:trace -> tr2:trace ->
-    prin:principal -> sess_id:session_id -> content:a ->
+    prin:principal -> sess_id:state_id -> content:a ->
     Lemma
     (requires pred tr1 prin sess_id content /\ tr1 <$ tr2)
     (ensures pred tr2 prin sess_id content)
   ;
   pred_knowable:
-    tr:trace -> prin:principal -> sess_id:session_id -> content:a ->
+    tr:trace -> prin:principal -> sess_id:state_id -> content:a ->
     Lemma
     (requires pred tr prin sess_id content)
     (ensures is_well_formed _ (is_knowable_by (principal_state_label prin sess_id) tr) content)
@@ -70,7 +70,7 @@ let has_local_state_predicate #a #ls invs spred =
 [@@ "opaque_to_smt"]
 val state_was_set:
   #a:Type -> {|local_state a|} ->
-  trace -> principal -> session_id -> a ->
+  trace -> principal -> state_id -> a ->
   prop
 let state_was_set #a #ls tr prin sess_id content =
   tagged_state_was_set tr ls.tag prin sess_id (serialize _ content)
@@ -78,14 +78,14 @@ let state_was_set #a #ls tr prin sess_id content =
 [@@ "opaque_to_smt"]
 val set_state:
   #a:Type -> {|local_state a|} ->
-  principal -> session_id -> a -> traceful unit
+  principal -> state_id -> a -> traceful unit
 let set_state #a #ls prin sess_id content =
   set_tagged_state ls.tag prin sess_id (serialize _ content)
 
 [@@ "opaque_to_smt"]
 val get_state:
   #a:Type -> {|local_state a|} ->
-  principal -> session_id -> traceful (option a)
+  principal -> state_id -> traceful (option a)
 let get_state #a #ls prin sess_id =
   let*? content_bytes = get_tagged_state ls.tag prin sess_id in
   match parse a content_bytes with
@@ -96,7 +96,7 @@ val set_state_invariant:
   #a:Type -> {|local_state a|} ->
   {|invs:protocol_invariants|} ->
   spred:local_state_predicate a ->
-  prin:principal -> sess_id:session_id -> content:a -> tr:trace ->
+  prin:principal -> sess_id:state_id -> content:a -> tr:trace ->
   Lemma
   (requires
     spred.pred tr prin sess_id content /\
@@ -120,7 +120,7 @@ val get_state_invariant:
   #a:Type -> {|local_state a|} ->
   {|invs:protocol_invariants|} ->
   spred:local_state_predicate a ->
-  prin:principal -> sess_id:session_id -> tr:trace ->
+  prin:principal -> sess_id:state_id -> tr:trace ->
   Lemma
   (requires
     trace_invariant tr /\
@@ -146,7 +146,7 @@ val state_was_set_implies_pred:
   #a:Type -> {|local_state a|} ->
   invs:protocol_invariants -> tr:trace ->
   spred:local_state_predicate a ->
-  prin:principal -> sess_id:session_id -> content:a ->
+  prin:principal -> sess_id:state_id -> content:a ->
   Lemma
   (requires
     state_was_set tr prin sess_id content /\

--- a/src/lib/state/DY.Lib.State.Typed.fst
+++ b/src/lib/state/DY.Lib.State.Typed.fst
@@ -5,16 +5,16 @@ open DY.Core
 open DY.Lib.Comparse.Glue
 open DY.Lib.State.Tagged
 
-class local_state (a:Type0) = {
+class local_version (a:Type0) = {
   tag: string;
   [@@@FStar.Tactics.Typeclasses.tcinstance]
   format: parseable_serializeable bytes a;
 }
 
-val mk_local_state_instance:
+val mk_local_version_instance:
   #a:Type0 -> {|parseable_serializeable bytes a|} -> string ->
-  local_state a
-let mk_local_state_instance #a #format tag = {
+  local_version a
+let mk_local_version_instance #a #format tag = {
   tag;
   format;
 }
@@ -61,39 +61,39 @@ let local_state_predicate_to_local_bytes_state_predicate #cinvs #a #ps_a tspred 
   }
 
 val has_local_state_predicate:
-  #a:Type -> {|local_state a|} ->
+  #a:Type -> {|local_version a|} ->
   invs:protocol_invariants -> local_state_predicate a ->
   prop
 let has_local_state_predicate #a #ls invs spred =
   has_local_bytes_state_predicate invs (ls.tag, (local_state_predicate_to_local_bytes_state_predicate spred))
 
 [@@ "opaque_to_smt"]
-val state_was_set:
-  #a:Type -> {|local_state a|} ->
+val version_was_set:
+  #a:Type -> {|local_version a|} ->
   trace -> principal -> nat -> a ->
   prop
-let state_was_set #a #ls tr prin sess_id content =
-  tagged_state_was_set tr ls.tag prin sess_id (serialize _ content)
+let version_was_set #a #ls tr prin sess_id content =
+  tagged_version_was_set tr ls.tag prin sess_id (serialize _ content)
 
 [@@ "opaque_to_smt"]
-val set_state:
-  #a:Type -> {|local_state a|} ->
+val set_version:
+  #a:Type -> {|local_version a|} ->
   principal -> nat -> a -> traceful unit
-let set_state #a #ls prin sess_id content =
-  set_tagged_state ls.tag prin sess_id (serialize _ content)
+let set_version #a #ls prin sess_id content =
+  set_tagged_version ls.tag prin sess_id (serialize _ content)
 
 [@@ "opaque_to_smt"]
-val get_state:
-  #a:Type -> {|local_state a|} ->
+val get_latest_version:
+  #a:Type -> {|local_version a|} ->
   principal -> nat -> traceful (option a)
-let get_state #a #ls prin sess_id =
-  let*? content_bytes = get_tagged_state ls.tag prin sess_id in
+let get_latest_version #a #ls prin sess_id =
+  let*? content_bytes = get_latest_tagged_version ls.tag prin sess_id in
   match parse a content_bytes with
   | None -> return None
   | Some content -> return (Some content)
 
-val set_state_invariant:
-  #a:Type -> {|local_state a|} ->
+val set_version_invariant:
+  #a:Type -> {|local_version a|} ->
   {|invs:protocol_invariants|} ->
   spred:local_state_predicate a ->
   prin:principal -> sess_id:nat -> content:a -> tr:trace ->
@@ -104,20 +104,20 @@ val set_state_invariant:
     has_local_state_predicate invs spred
   )
   (ensures (
-    let ((), tr_out) = set_state prin sess_id content tr in
+    let ((), tr_out) = set_version prin sess_id content tr in
     trace_invariant tr_out /\
-    state_was_set tr_out prin sess_id content
+    version_was_set tr_out prin sess_id content
   ))
-  [SMTPat (set_state prin sess_id content tr);
+  [SMTPat (set_version prin sess_id content tr);
    SMTPat (trace_invariant tr);
    SMTPat (has_local_state_predicate invs spred)]
-let set_state_invariant #a #ls #invs spred prin sess_id content tr =
-  reveal_opaque (`%set_state) (set_state #a);
-  reveal_opaque (`%state_was_set) (state_was_set #a);
+let set_version_invariant #a #ls #invs spred prin sess_id content tr =
+  reveal_opaque (`%set_version) (set_version #a);
+  reveal_opaque (`%version_was_set) (version_was_set #a);
   parse_serialize_inv_lemma #bytes a content
 
-val get_state_invariant:
-  #a:Type -> {|local_state a|} ->
+val get_latest_version_invariant:
+  #a:Type -> {|local_version a|} ->
   {|invs:protocol_invariants|} ->
   spred:local_state_predicate a ->
   prin:principal -> sess_id:nat -> tr:trace ->
@@ -127,7 +127,7 @@ val get_state_invariant:
     has_local_state_predicate invs spred
   )
   (ensures (
-    let (opt_content, tr_out) = get_state prin sess_id tr in
+    let (opt_content, tr_out) = get_latest_version prin sess_id tr in
     tr == tr_out /\ (
       match opt_content with
       | None -> True
@@ -136,28 +136,28 @@ val get_state_invariant:
       )
     )
   ))
-  [SMTPat (get_state #a prin sess_id tr);
+  [SMTPat (get_latest_version #a prin sess_id tr);
    SMTPat (trace_invariant tr);
    SMTPat (has_local_state_predicate invs spred)]
-let get_state_invariant #a #ls #invs spred prin sess_id tr =
-  reveal_opaque (`%get_state) (get_state #a)
+let get_latest_version_invariant #a #ls #invs spred prin sess_id tr =
+  reveal_opaque (`%get_latest_version) (get_latest_version #a)
 
-val state_was_set_implies_pred:
-  #a:Type -> {|local_state a|} ->
+val version_was_set_implies_pred:
+  #a:Type -> {|local_version a|} ->
   invs:protocol_invariants -> tr:trace ->
   spred:local_state_predicate a ->
   prin:principal -> sess_id:nat -> content:a ->
   Lemma
   (requires
-    state_was_set tr prin sess_id content /\
+    version_was_set tr prin sess_id content /\
     trace_invariant tr /\
     has_local_state_predicate invs spred
   )
   (ensures spred.pred tr prin sess_id content)
-  [SMTPat (state_was_set tr prin sess_id content);
+  [SMTPat (version_was_set tr prin sess_id content);
    SMTPat (trace_invariant tr);
    SMTPat (has_local_state_predicate invs spred);
   ]
-let state_was_set_implies_pred #a #ls invs tr spred prin sess_id content =
+let version_was_set_implies_pred #a #ls invs tr spred prin sess_id content =
   parse_serialize_inv_lemma #bytes a content;
-  reveal_opaque (`%state_was_set) (state_was_set #a)
+  reveal_opaque (`%version_was_set) (version_was_set #a)

--- a/src/lib/state/DY.Lib.State.Typed.fst
+++ b/src/lib/state/DY.Lib.State.Typed.fst
@@ -21,16 +21,16 @@ let mk_local_version_instance #a #format tag = {
 
 noeq
 type local_state_predicate {|crypto_invariants|} (a:Type) {|parseable_serializeable bytes a|} = {
-  pred: trace -> principal -> nat -> a -> prop;
+  pred: trace -> principal -> session_id -> a -> prop;
   pred_later:
     tr1:trace -> tr2:trace ->
-    prin:principal -> sess_id:nat -> content:a ->
+    prin:principal -> sess_id:session_id -> content:a ->
     Lemma
     (requires pred tr1 prin sess_id content /\ tr1 <$ tr2)
     (ensures pred tr2 prin sess_id content)
   ;
   pred_knowable:
-    tr:trace -> prin:principal -> sess_id:nat -> content:a ->
+    tr:trace -> prin:principal -> sess_id:session_id -> content:a ->
     Lemma
     (requires pred tr prin sess_id content)
     (ensures is_well_formed _ (is_knowable_by (principal_state_label prin sess_id) tr) content)
@@ -70,7 +70,7 @@ let has_local_state_predicate #a #ls invs spred =
 [@@ "opaque_to_smt"]
 val version_was_set:
   #a:Type -> {|local_version a|} ->
-  trace -> principal -> nat -> a ->
+  trace -> principal -> session_id -> a ->
   prop
 let version_was_set #a #ls tr prin sess_id content =
   tagged_version_was_set tr ls.tag prin sess_id (serialize _ content)
@@ -78,14 +78,14 @@ let version_was_set #a #ls tr prin sess_id content =
 [@@ "opaque_to_smt"]
 val set_version:
   #a:Type -> {|local_version a|} ->
-  principal -> nat -> a -> traceful unit
+  principal -> session_id -> a -> traceful unit
 let set_version #a #ls prin sess_id content =
   set_tagged_version ls.tag prin sess_id (serialize _ content)
 
 [@@ "opaque_to_smt"]
 val get_latest_version:
   #a:Type -> {|local_version a|} ->
-  principal -> nat -> traceful (option a)
+  principal -> session_id -> traceful (option a)
 let get_latest_version #a #ls prin sess_id =
   let*? content_bytes = get_latest_tagged_version ls.tag prin sess_id in
   match parse a content_bytes with
@@ -96,7 +96,7 @@ val set_version_invariant:
   #a:Type -> {|local_version a|} ->
   {|invs:protocol_invariants|} ->
   spred:local_state_predicate a ->
-  prin:principal -> sess_id:nat -> content:a -> tr:trace ->
+  prin:principal -> sess_id:session_id -> content:a -> tr:trace ->
   Lemma
   (requires
     spred.pred tr prin sess_id content /\
@@ -120,7 +120,7 @@ val get_latest_version_invariant:
   #a:Type -> {|local_version a|} ->
   {|invs:protocol_invariants|} ->
   spred:local_state_predicate a ->
-  prin:principal -> sess_id:nat -> tr:trace ->
+  prin:principal -> sess_id:session_id -> tr:trace ->
   Lemma
   (requires
     trace_invariant tr /\
@@ -146,7 +146,7 @@ val version_was_set_implies_pred:
   #a:Type -> {|local_version a|} ->
   invs:protocol_invariants -> tr:trace ->
   spred:local_state_predicate a ->
-  prin:principal -> sess_id:nat -> content:a ->
+  prin:principal -> sess_id:session_id -> content:a ->
   Lemma
   (requires
     version_was_set tr prin sess_id content /\

--- a/src/lib/state/DY.Lib.State.Typed.fst
+++ b/src/lib/state/DY.Lib.State.Typed.fst
@@ -5,16 +5,16 @@ open DY.Core
 open DY.Lib.Comparse.Glue
 open DY.Lib.State.Tagged
 
-class local_version (a:Type0) = {
+class local_state (a:Type0) = {
   tag: string;
   [@@@FStar.Tactics.Typeclasses.tcinstance]
   format: parseable_serializeable bytes a;
 }
 
-val mk_local_version_instance:
+val mk_local_state_instance:
   #a:Type0 -> {|parseable_serializeable bytes a|} -> string ->
-  local_version a
-let mk_local_version_instance #a #format tag = {
+  local_state a
+let mk_local_state_instance #a #format tag = {
   tag;
   format;
 }
@@ -61,39 +61,39 @@ let local_state_predicate_to_local_bytes_state_predicate #cinvs #a #ps_a tspred 
   }
 
 val has_local_state_predicate:
-  #a:Type -> {|local_version a|} ->
+  #a:Type -> {|local_state a|} ->
   invs:protocol_invariants -> local_state_predicate a ->
   prop
 let has_local_state_predicate #a #ls invs spred =
   has_local_bytes_state_predicate invs (ls.tag, (local_state_predicate_to_local_bytes_state_predicate spred))
 
 [@@ "opaque_to_smt"]
-val version_was_set:
-  #a:Type -> {|local_version a|} ->
-  trace -> principal -> session_id -> a ->
+val state_was_set:
+  #a:Type -> {|local_state a|} ->
+  trace -> principal -> sess_id -> a ->
   prop
-let version_was_set #a #ls tr prin sess_id content =
-  tagged_version_was_set tr ls.tag prin sess_id (serialize _ content)
+let state_was_set #a #ls tr prin sess_id content =
+  tagged_state_was_set tr ls.tag prin sess_id (serialize _ content)
 
 [@@ "opaque_to_smt"]
-val set_version:
-  #a:Type -> {|local_version a|} ->
-  principal -> session_id -> a -> traceful unit
-let set_version #a #ls prin sess_id content =
-  set_tagged_version ls.tag prin sess_id (serialize _ content)
+val set_state:
+  #a:Type -> {|local_state a|} ->
+  principal -> sess_id -> a -> traceful unit
+let set_state #a #ls prin sess_id content =
+  set_tagged_state ls.tag prin sess_id (serialize _ content)
 
 [@@ "opaque_to_smt"]
-val get_latest_version:
-  #a:Type -> {|local_version a|} ->
+val get_state:
+  #a:Type -> {|local_state a|} ->
   principal -> session_id -> traceful (option a)
-let get_latest_version #a #ls prin sess_id =
-  let*? content_bytes = get_latest_tagged_version ls.tag prin sess_id in
+let get_state #a #ls prin sess_id =
+  let*? content_bytes = get_tagged_state ls.tag prin sess_id in
   match parse a content_bytes with
   | None -> return None
   | Some content -> return (Some content)
 
-val set_version_invariant:
-  #a:Type -> {|local_version a|} ->
+val set_state_invariant:
+  #a:Type -> {|local_state a|} ->
   {|invs:protocol_invariants|} ->
   spred:local_state_predicate a ->
   prin:principal -> sess_id:session_id -> content:a -> tr:trace ->
@@ -104,20 +104,20 @@ val set_version_invariant:
     has_local_state_predicate invs spred
   )
   (ensures (
-    let ((), tr_out) = set_version prin sess_id content tr in
+    let ((), tr_out) = set_state prin sess_id content tr in
     trace_invariant tr_out /\
-    version_was_set tr_out prin sess_id content
+    state_was_set tr_out prin sess_id content
   ))
-  [SMTPat (set_version prin sess_id content tr);
+  [SMTPat (set_state prin sess_id content tr);
    SMTPat (trace_invariant tr);
    SMTPat (has_local_state_predicate invs spred)]
-let set_version_invariant #a #ls #invs spred prin sess_id content tr =
-  reveal_opaque (`%set_version) (set_version #a);
-  reveal_opaque (`%version_was_set) (version_was_set #a);
+let set_state_invariant #a #ls #invs spred prin sess_id content tr =
+  reveal_opaque (`%set_state) (set_state #a);
+  reveal_opaque (`%state_was_set) (state_was_set #a);
   parse_serialize_inv_lemma #bytes a content
 
-val get_latest_version_invariant:
-  #a:Type -> {|local_version a|} ->
+val get_state_invariant:
+  #a:Type -> {|local_state a|} ->
   {|invs:protocol_invariants|} ->
   spred:local_state_predicate a ->
   prin:principal -> sess_id:session_id -> tr:trace ->
@@ -127,7 +127,7 @@ val get_latest_version_invariant:
     has_local_state_predicate invs spred
   )
   (ensures (
-    let (opt_content, tr_out) = get_latest_version prin sess_id tr in
+    let (opt_content, tr_out) = get_state prin sess_id tr in
     tr == tr_out /\ (
       match opt_content with
       | None -> True
@@ -136,28 +136,28 @@ val get_latest_version_invariant:
       )
     )
   ))
-  [SMTPat (get_latest_version #a prin sess_id tr);
+  [SMTPat (get_state #a prin sess_id tr);
    SMTPat (trace_invariant tr);
    SMTPat (has_local_state_predicate invs spred)]
-let get_latest_version_invariant #a #ls #invs spred prin sess_id tr =
-  reveal_opaque (`%get_latest_version) (get_latest_version #a)
+let get_state_invariant #a #ls #invs spred prin sess_id tr =
+  reveal_opaque (`%get_state) (get_state #a)
 
-val version_was_set_implies_pred:
-  #a:Type -> {|local_version a|} ->
+val state_was_set_implies_pred:
+  #a:Type -> {|local_state a|} ->
   invs:protocol_invariants -> tr:trace ->
   spred:local_state_predicate a ->
   prin:principal -> sess_id:session_id -> content:a ->
   Lemma
   (requires
-    version_was_set tr prin sess_id content /\
+    state_was_set tr prin sess_id content /\
     trace_invariant tr /\
     has_local_state_predicate invs spred
   )
   (ensures spred.pred tr prin sess_id content)
-  [SMTPat (version_was_set tr prin sess_id content);
+  [SMTPat (state_was_set tr prin sess_id content);
    SMTPat (trace_invariant tr);
    SMTPat (has_local_state_predicate invs spred);
   ]
-let version_was_set_implies_pred #a #ls invs tr spred prin sess_id content =
+let state_was_set_implies_pred #a #ls invs tr spred prin sess_id content =
   parse_serialize_inv_lemma #bytes a content;
-  reveal_opaque (`%version_was_set) (version_was_set #a)
+  reveal_opaque (`%state_was_set) (state_was_set #a)

--- a/src/lib/utils/DY.Lib.Printing.fst
+++ b/src/lib/utils/DY.Lib.Printing.fst
@@ -22,7 +22,7 @@ let rec label_to_string l =
   | State pre_label -> (
     match pre_label with
     | P p -> Printf.sprintf "Principal %s" p
-    | S p s -> Printf.sprintf "Principal %s state %d" p s
+    | S p s -> Printf.sprintf "Principal %s state %d" p s.the_id
   ) 
   | Meet l1 l2 -> Printf.sprintf "Meet [%s; %s]" (label_to_string l1) (label_to_string l2)
   | Join l1 l2 -> Printf.sprintf "Join [%s; %s]" (label_to_string l1) (label_to_string l2)
@@ -202,7 +202,7 @@ let trace_event_to_string printers tr_event i =
   | SetState prin sess_id full_content -> (
     let content_str = state_to_string printers.state_to_string full_content in
     Printf.sprintf "{\"TraceID\": %d, \"Type\": \"Session\", \"SessionID\": %d, \"Principal\": \"%s\", \"Content\": \"%s\"}\n"
-      i sess_id prin content_str
+      i sess_id.the_id prin content_str
   )
   | Event prin tag content -> (
     let printer = find_printer printers.event_to_string tag in

--- a/src/lib/utils/DY.Lib.Printing.fst
+++ b/src/lib/utils/DY.Lib.Printing.fst
@@ -22,7 +22,7 @@ let rec label_to_string l =
   | State pre_label -> (
     match pre_label with
     | P p -> Printf.sprintf "Principal %s" p
-    | S p s -> Printf.sprintf "Principal %s session %d" p s
+    | S p s -> Printf.sprintf "Principal %s state %d" p s
   ) 
   | Meet l1 l2 -> Printf.sprintf "Meet [%s; %s]" (label_to_string l1) (label_to_string l2)
   | Join l1 l2 -> Printf.sprintf "Join [%s; %s]" (label_to_string l1) (label_to_string l2)
@@ -163,7 +163,7 @@ let option_to_string parse_fn elem =
 
 val state_to_string: list (string & (bytes -> option string)) -> bytes -> string
 let state_to_string printer_list full_content_bytes =
-  let full_content = parse tagged_version full_content_bytes in
+  let full_content = parse tagged_state full_content_bytes in
   match full_content with
   | Some ({tag; content}) -> (
     let parser = find_printer printer_list tag in
@@ -199,9 +199,9 @@ let trace_event_to_string printers tr_event i =
     i (usage_to_string usg) (label_to_string lab)
   )
   | Corrupt prin sess_id -> ""
-  | SetVersion prin sess_id full_content -> (
+  | SetState prin sess_id full_content -> (
     let content_str = state_to_string printers.state_to_string full_content in
-    Printf.sprintf "{\"TraceID\": %d, \"Type\": \"Version\", \"SessionID\": %d, \"Principal\": \"%s\", \"Content\": \"%s\"}\n"
+    Printf.sprintf "{\"TraceID\": %d, \"Type\": \"Session\", \"SessionID\": %d, \"Principal\": \"%s\", \"Content\": \"%s\"}\n"
       i sess_id prin content_str
   )
   | Event prin tag content -> (

--- a/src/lib/utils/DY.Lib.Printing.fst
+++ b/src/lib/utils/DY.Lib.Printing.fst
@@ -185,7 +185,7 @@ noeq type trace_to_string_printers = {
 
 val trace_event_to_string: 
   trace_to_string_printers -> 
-  trace_event -> nat -> 
+  trace_event -> timestamp -> 
   string
 let trace_event_to_string printers tr_event i =
   match tr_event with

--- a/src/lib/utils/DY.Lib.Printing.fst
+++ b/src/lib/utils/DY.Lib.Printing.fst
@@ -22,7 +22,7 @@ let rec label_to_string l =
   | State pre_label -> (
     match pre_label with
     | P p -> Printf.sprintf "Principal %s" p
-    | S p s -> Printf.sprintf "Principal %s state %d" p s
+    | S p s -> Printf.sprintf "Principal %s session %d" p s
   ) 
   | Meet l1 l2 -> Printf.sprintf "Meet [%s; %s]" (label_to_string l1) (label_to_string l2)
   | Join l1 l2 -> Printf.sprintf "Join [%s; %s]" (label_to_string l1) (label_to_string l2)
@@ -163,7 +163,7 @@ let option_to_string parse_fn elem =
 
 val state_to_string: list (string & (bytes -> option string)) -> bytes -> string
 let state_to_string printer_list full_content_bytes =
-  let full_content = parse tagged_state full_content_bytes in
+  let full_content = parse tagged_version full_content_bytes in
   match full_content with
   | Some ({tag; content}) -> (
     let parser = find_printer printer_list tag in
@@ -199,9 +199,9 @@ let trace_event_to_string printers tr_event i =
     i (usage_to_string usg) (label_to_string lab)
   )
   | Corrupt prin sess_id -> ""
-  | SetState prin sess_id full_content -> (
+  | SetVersion prin sess_id full_content -> (
     let content_str = state_to_string printers.state_to_string full_content in
-    Printf.sprintf "{\"TraceID\": %d, \"Type\": \"Session\", \"SessionID\": %d, \"Principal\": \"%s\", \"Content\": \"%s\"}\n"
+    Printf.sprintf "{\"TraceID\": %d, \"Type\": \"Version\", \"SessionID\": %d, \"Principal\": \"%s\", \"Content\": \"%s\"}\n"
       i sess_id prin content_str
   )
   | Event prin tag content -> (


### PR DESCRIPTION
Fixing https://github.com/REPROSEC/dolev-yao-star-extrinsic/issues/6: renamed occurrences of "state" and "session" to "version" and added a comment explaining the state model. 
There are no actual changes to the implementation. In particular, there is no new version id. The current version is just the latest `SetVersion` entry on the trace. I think, that matches what we previously had: There could have been several `SetState` entries with the same session id and only the last one was relevant.
Predicates/invariants are still called "state_predicate", since we are about to change some of those to support invariants for sessions and full states in the context of https://github.com/REPROSEC/dolev-yao-star-extrinsic/issues/9.
One thing left to discuss is corruption/attacker knowledge. Currently, we only corrupt whole sessions. With this, [`corrupted_state_is_publishable`](https://github.com/REPROSEC/dolev-yao-star-extrinsic/blob/07c8e3f07509c8a933cde446e48eaefc9eb9a695/src/core/DY.Core.Attacker.Knowledge.fst#L155-L164) says that any content stored under a corrupted session id is publishable. We have to discuss, whether this is what we want. This is related to https://github.com/REPROSEC/dolev-yao-star-extrinsic/issues/21 and should be resolved there.

Partially addressing https://github.com/REPROSEC/dolev-yao-star-extrinsic/issues/30: I introduced types for session id and timestamps (and used those in the functions). The session_id type should be hidden behind an interface file. The timestamp type maybe not.