### PR TITLE
cleanup: reduce boilerplate to merge local predicates

### DIFF
--- a/examples/iso_dh/DY.Example.DH.Protocol.Stateful.Proof.fst
+++ b/examples/iso_dh/DY.Example.DH.Protocol.Stateful.Proof.fst
@@ -100,7 +100,6 @@ let all_sessions = [
 
 let all_events = [
   (dh_event_instance.tag, compile_event_pred dh_event_pred);
-  ("__dummy__", (fun _ _ _ -> False)) // workaround
 ]
 
 /// Create the global trace invariants.
@@ -125,11 +124,13 @@ let all_sessions_has_all_sessions =
 
 /// Lemmas that the global event predicate contains all the local ones
 
+#push-options "--fuel 1" // fuel is a workaround for FStarLang/FStar#3360
 val all_events_has_all_events: squash (norm [delta_only [`%all_events; `%for_allP]; iota; zeta] (for_allP (has_compiled_event_pred dh_protocol_invs) all_events))
 let all_events_has_all_events =
   assert_norm(List.Tot.no_repeats_p (List.Tot.map fst (all_events)));
   mk_event_pred_correct dh_protocol_invs all_events;
   norm_spec [delta_only [`%all_events; `%for_allP]; iota; zeta] (for_allP (has_compiled_event_pred dh_protocol_invs) all_events)
+#pop-options
 
 (*** Proofs ****)
 

--- a/examples/iso_dh/DY.Example.DH.Protocol.Stateful.Proof.fst
+++ b/examples/iso_dh/DY.Example.DH.Protocol.Stateful.Proof.fst
@@ -99,7 +99,8 @@ let all_sessions = [
 /// List of all local event predicates.
 
 let all_events = [
-  (dh_event_instance.tag, compile_event_pred dh_event_pred)
+  (dh_event_instance.tag, compile_event_pred dh_event_pred);
+  ("__dummy__", (fun _ _ _ -> False)) // workaround
 ]
 
 /// Create the global trace invariants.
@@ -116,33 +117,19 @@ instance dh_protocol_invs: protocol_invariants = {
 
 /// Lemmas that the global state predicate contains all the local ones
 
-val all_sessions_has_all_sessions: unit -> Lemma (norm [delta_only [`%all_sessions; `%for_allP]; iota; zeta] (for_allP (has_local_bytes_state_predicate dh_protocol_invs) all_sessions))
-let all_sessions_has_all_sessions () =
+val all_sessions_has_all_sessions: squash (norm [delta_only [`%all_sessions; `%for_allP]; iota; zeta] (for_allP (has_local_bytes_state_predicate dh_protocol_invs) all_sessions))
+let all_sessions_has_all_sessions =
   assert_norm(List.Tot.no_repeats_p (List.Tot.map fst (all_sessions)));
   mk_global_local_bytes_state_predicate_correct dh_protocol_invs all_sessions;
   norm_spec [delta_only [`%all_sessions; `%for_allP]; iota; zeta] (for_allP (has_local_bytes_state_predicate dh_protocol_invs) all_sessions)
 
-val full_dh_session_pred_has_pki_invariant: squash (has_pki_invariant dh_protocol_invs)
-let full_dh_session_pred_has_pki_invariant = all_sessions_has_all_sessions ()
-
-val full_dh_session_pred_has_private_keys_invariant: squash (has_private_keys_invariant dh_protocol_invs)
-let full_dh_session_pred_has_private_keys_invariant = all_sessions_has_all_sessions ()
-
-val full_dh_session_pred_has_dh_invariant: squash (has_local_state_predicate dh_protocol_invs dh_session_pred)
-let full_dh_session_pred_has_dh_invariant = all_sessions_has_all_sessions ()
-
 /// Lemmas that the global event predicate contains all the local ones
 
-val all_events_has_all_events: unit -> Lemma (norm [delta_only [`%all_events; `%for_allP]; iota; zeta] (for_allP (has_compiled_event_pred dh_protocol_invs) all_events))
-let all_events_has_all_events () =
+val all_events_has_all_events: squash (norm [delta_only [`%all_events; `%for_allP]; iota; zeta] (for_allP (has_compiled_event_pred dh_protocol_invs) all_events))
+let all_events_has_all_events =
   assert_norm(List.Tot.no_repeats_p (List.Tot.map fst (all_events)));
   mk_event_pred_correct dh_protocol_invs all_events;
-  norm_spec [delta_only [`%all_events; `%for_allP]; iota; zeta] (for_allP (has_compiled_event_pred dh_protocol_invs) all_events);
-  let dumb_lemma (x:prop) (y:prop): Lemma (requires x /\ x == y) (ensures y) = () in
-  dumb_lemma (for_allP (has_compiled_event_pred dh_protocol_invs) all_events) (norm [delta_only [`%all_events; `%for_allP]; iota; zeta] (for_allP (has_compiled_event_pred dh_protocol_invs) all_events))
-
-val full_dh_event_pred_has_dh_invariant: squash (has_event_pred dh_protocol_invs dh_event_pred)
-let full_dh_event_pred_has_dh_invariant = all_events_has_all_events ()
+  norm_spec [delta_only [`%all_events; `%for_allP]; iota; zeta] (for_allP (has_compiled_event_pred dh_protocol_invs) all_events)
 
 (*** Proofs ****)
 

--- a/examples/iso_dh/DY.Example.DH.Protocol.Stateful.fst
+++ b/examples/iso_dh/DY.Example.DH.Protocol.Stateful.fst
@@ -17,9 +17,6 @@ type dh_session =
 %splice [ps_dh_session] (gen_parser (`dh_session))
 %splice [ps_dh_session_is_well_formed] (gen_is_well_formed_lemma (`dh_session))
 
-instance dh_session_parseable_serializeable: parseable_serializeable bytes dh_session
- = mk_parseable_serializeable ps_dh_session
-
 (*** Definition of events ***)
 [@@ with_bytes bytes]
 type dh_event =
@@ -146,4 +143,3 @@ let verify_msg3 global_sess_id alice bob msg_id bob_si =
     return (Some ())
   )
   | _ -> return None
-    

--- a/examples/nsl_pk/DY.Example.NSL.Protocol.Stateful.Proof.fst
+++ b/examples/nsl_pk/DY.Example.NSL.Protocol.Stateful.Proof.fst
@@ -91,7 +91,6 @@ let all_sessions = [
 
 let all_events = [
   (event_nsl_event.tag, compile_event_pred event_predicate_nsl);
-  ("__dummy__", (fun _ _ _ -> False)) // workaround
 ]
 
 /// Create the global trace invariants.
@@ -116,11 +115,13 @@ let all_sessions_has_all_sessions =
 
 /// Lemmas that the global event predicate contains all the local ones
 
+#push-options "--fuel 1" // fuel is a workaround for FStarLang/FStar#3360
 val all_events_has_all_events: squash (norm [delta_only [`%all_events; `%for_allP]; iota; zeta] (for_allP (has_compiled_event_pred protocol_invariants_nsl) all_events))
 let all_events_has_all_events =
   assert_norm(List.Tot.no_repeats_p (List.Tot.map fst (all_events)));
   mk_event_pred_correct protocol_invariants_nsl all_events;
   norm_spec [delta_only [`%all_events; `%for_allP]; iota; zeta] (for_allP (has_compiled_event_pred protocol_invariants_nsl) all_events)
+#pop-options
 
 (*** Proofs ***)
 

--- a/examples/nsl_pk/DY.Example.NSL.Protocol.Stateful.Proof.fst
+++ b/examples/nsl_pk/DY.Example.NSL.Protocol.Stateful.Proof.fst
@@ -90,7 +90,8 @@ let all_sessions = [
 /// List of all local event predicates.
 
 let all_events = [
-  (event_nsl_event.tag, compile_event_pred event_predicate_nsl)
+  (event_nsl_event.tag, compile_event_pred event_predicate_nsl);
+  ("__dummy__", (fun _ _ _ -> False)) // workaround
 ]
 
 /// Create the global trace invariants.
@@ -107,33 +108,19 @@ instance protocol_invariants_nsl: protocol_invariants = {
 
 /// Lemmas that the global state predicate contains all the local ones
 
-val all_sessions_has_all_sessions: unit -> Lemma (norm [delta_only [`%all_sessions; `%for_allP]; iota; zeta] (for_allP (has_local_bytes_state_predicate protocol_invariants_nsl) all_sessions))
-let all_sessions_has_all_sessions () =
+val all_sessions_has_all_sessions: squash (norm [delta_only [`%all_sessions; `%for_allP]; iota; zeta] (for_allP (has_local_bytes_state_predicate protocol_invariants_nsl) all_sessions))
+let all_sessions_has_all_sessions =
   assert_norm(List.Tot.no_repeats_p (List.Tot.map fst (all_sessions)));
   mk_global_local_bytes_state_predicate_correct protocol_invariants_nsl all_sessions;
   norm_spec [delta_only [`%all_sessions; `%for_allP]; iota; zeta] (for_allP (has_local_bytes_state_predicate protocol_invariants_nsl) all_sessions)
 
-val protocol_invariants_nsl_has_pki_invariant: squash (has_pki_invariant protocol_invariants_nsl)
-let protocol_invariants_nsl_has_pki_invariant = all_sessions_has_all_sessions ()
-
-val protocol_invariants_nsl_has_private_keys_invariant: squash (has_private_keys_invariant protocol_invariants_nsl)
-let protocol_invariants_nsl_has_private_keys_invariant = all_sessions_has_all_sessions ()
-
-val protocol_invariants_nsl_has_nsl_session_invariant: squash (has_local_state_predicate protocol_invariants_nsl state_predicate_nsl)
-let protocol_invariants_nsl_has_nsl_session_invariant = all_sessions_has_all_sessions ()
-
 /// Lemmas that the global event predicate contains all the local ones
 
-val all_events_has_all_events: unit -> Lemma (norm [delta_only [`%all_events; `%for_allP]; iota; zeta] (for_allP (has_compiled_event_pred protocol_invariants_nsl) all_events))
-let all_events_has_all_events () =
+val all_events_has_all_events: squash (norm [delta_only [`%all_events; `%for_allP]; iota; zeta] (for_allP (has_compiled_event_pred protocol_invariants_nsl) all_events))
+let all_events_has_all_events =
   assert_norm(List.Tot.no_repeats_p (List.Tot.map fst (all_events)));
   mk_event_pred_correct protocol_invariants_nsl all_events;
-  norm_spec [delta_only [`%all_events; `%for_allP]; iota; zeta] (for_allP (has_compiled_event_pred protocol_invariants_nsl) all_events);
-  let dumb_lemma (x:prop) (y:prop): Lemma (requires x /\ x == y) (ensures y) = () in
-  dumb_lemma (for_allP (has_compiled_event_pred protocol_invariants_nsl) all_events) (norm [delta_only [`%all_events; `%for_allP]; iota; zeta] (for_allP (has_compiled_event_pred protocol_invariants_nsl) all_events))
-
-val protocol_invariants_nsl_has_nsl_event_invariant: squash (has_event_pred protocol_invariants_nsl event_predicate_nsl)
-let protocol_invariants_nsl_has_nsl_event_invariant = all_events_has_all_events ()
+  norm_spec [delta_only [`%all_events; `%for_allP]; iota; zeta] (for_allP (has_compiled_event_pred protocol_invariants_nsl) all_events)
 
 (*** Proofs ***)
 

--- a/examples/nsl_pk/DY.Example.NSL.Protocol.Stateful.fst
+++ b/examples/nsl_pk/DY.Example.NSL.Protocol.Stateful.fst
@@ -23,12 +23,9 @@ type nsl_session =
 %splice [ps_nsl_session] (gen_parser (`nsl_session))
 %splice [ps_nsl_session_is_well_formed] (gen_is_well_formed_lemma (`nsl_session))
 
-instance parseable_serializeable_bytes_nsl_session: parseable_serializeable bytes nsl_session
- = mk_parseable_serializeable ps_nsl_session
-
 instance local_state_nsl_session: local_state nsl_session = {
   tag = "NSL.Session";
-  format = parseable_serializeable_bytes_nsl_session;
+  format = mk_parseable_serializeable ps_nsl_session;
 }
 
 (*** Event type ***)

--- a/flake.lock
+++ b/flake.lock
@@ -46,11 +46,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1708956704,
-        "narHash": "sha256-xT0V7oQwR0Zns9g/MvV30ILlAX6tcp92SqWPwej1+sI=",
+        "lastModified": 1721275414,
+        "narHash": "sha256-WyV22bJ3W4CqThhawifTmC0jPn9MAaueLmLeM119dW8=",
         "owner": "FStarLang",
         "repo": "FStar",
-        "rev": "a48722f90e14be69b850f093b41fbbdfee7f6eb9",
+        "rev": "3ed3c98d39ce028c31c5908a38bc68ad5098f563",
         "type": "github"
       },
       "original": {

--- a/src/lib/event/DY.Lib.Event.Typed.fst
+++ b/src/lib/event/DY.Lib.Event.Typed.fst
@@ -85,6 +85,7 @@ val has_compiled_event_pred:
 let has_compiled_event_pred invs (tag, epred) =
   has_local_pred split_event_pred_func event_pred (tag, epred)
 
+unfold
 val has_event_pred:
   #a:Type0 -> {|event a|} ->
   protocol_invariants -> event_predicate a -> prop

--- a/src/lib/state/DY.Lib.State.Map.fst
+++ b/src/lib/state/DY.Lib.State.Map.fst
@@ -56,11 +56,9 @@ noeq type map (key_t:eqtype) (value_t:Type0) {|mt:map_types key_t value_t|} = {
 %splice [ps_map] (gen_parser (`map))
 %splice [ps_map_is_well_formed] (gen_is_well_formed_lemma (`map))
 
-instance parseable_serializeable_bytes_map (key_t:eqtype) (value_t:Type0) {|map_types key_t value_t|} : parseable_serializeable bytes (map key_t value_t) = mk_parseable_serializeable (ps_map key_t value_t)
-
 instance local_state_map (key_t:eqtype) (value_t:Type0) {|mt:map_types key_t value_t|}: local_state (map key_t value_t) = {
   tag = mt.tag;
-  format = (parseable_serializeable_bytes_map key_t value_t);
+  format = mk_parseable_serializeable (ps_map key_t value_t);
 }
 
 val map_elem_invariant:
@@ -116,6 +114,7 @@ let map_session_invariant #cinvs #key_t #value_t #mt mpred = {
   );
 }
 
+unfold
 val has_map_session_invariant:
   #key_t:eqtype -> #value_t:Type0 -> {|map_types key_t value_t|} ->
   protocol_invariants -> map_predicate key_t value_t -> prop

--- a/src/lib/state/DY.Lib.State.PKI.fst
+++ b/src/lib/state/DY.Lib.State.PKI.fst
@@ -76,12 +76,13 @@ let pki_pred #cinvs = {
   pred_knowable = (fun tr prin sess_id key value -> ());
 }
 
+unfold
 val has_pki_invariant: protocol_invariants -> prop
 let has_pki_invariant invs =
   has_map_session_invariant invs pki_pred
 
 val pki_tag_and_invariant: {|crypto_invariants|} -> string & local_bytes_state_predicate
-let pki_tag_and_invariant #ci = (map_types_pki.tag, local_state_predicate_to_local_bytes_state_predicate (map_session_invariant pki_pred))
+let pki_tag_and_invariant #ci = ((local_state_map pki_key pki_value #map_types_pki).tag, local_state_predicate_to_local_bytes_state_predicate (map_session_invariant pki_pred))
 
 (*** PKI API ***)
 

--- a/src/lib/state/DY.Lib.State.PrivateKeys.fst
+++ b/src/lib/state/DY.Lib.State.PrivateKeys.fst
@@ -68,12 +68,13 @@ let private_keys_pred #cinvs = {
   pred_knowable = (fun tr prin sess_id key value -> ());
 }
 
+unfold
 val has_private_keys_invariant: protocol_invariants -> prop
 let has_private_keys_invariant invs =
   has_map_session_invariant invs private_keys_pred
 
 val private_keys_tag_and_invariant: {|crypto_invariants|} -> string & local_bytes_state_predicate
-let private_keys_tag_and_invariant #ci = (map_types_private_keys.tag, local_state_predicate_to_local_bytes_state_predicate (map_session_invariant private_keys_pred))
+let private_keys_tag_and_invariant #ci = ((local_state_map private_key_key private_key_value #map_types_private_keys).tag, local_state_predicate_to_local_bytes_state_predicate (map_session_invariant private_keys_pred))
 
 val private_key_type_to_usage:
   private_key_type ->

--- a/src/lib/state/DY.Lib.State.Typed.fst
+++ b/src/lib/state/DY.Lib.State.Typed.fst
@@ -60,6 +60,7 @@ let local_state_predicate_to_local_bytes_state_predicate #cinvs #a #ps_a tspred 
     );
   }
 
+unfold
 val has_local_state_predicate:
   #a:Type -> {|local_state a|} ->
   invs:protocol_invariants -> local_state_predicate a ->


### PR DESCRIPTION
Fixes #37 .

Writing a thorough explanation of what is happening because this is quite subtle!

### Adding unfolds

The main problem we had is that the correctness theorem for merging local predicates ensures the `has_local_bytes_state_predicate` property on the protocol invariants.

https://github.com/REPROSEC/dolev-yao-star-extrinsic/blob/f8a8c8bdc3317abead8c06697461666d8d7aac02/src/lib/state/DY.Lib.State.Tagged.fst#L83-L88

However, the property we have in SMT patterns is `has_local_state_predicate` https://github.com/REPROSEC/dolev-yao-star-extrinsic/blob/f8a8c8bdc3317abead8c06697461666d8d7aac02/src/lib/state/DY.Lib.State.Typed.fst#L113
or `has_pki_invariant` https://github.com/REPROSEC/dolev-yao-star-extrinsic/blob/f8a8c8bdc3317abead8c06697461666d8d7aac02/src/lib/state/DY.Lib.State.PKI.fst#L116

These higher-level properties on the global protocol invariants are ultimately defined using `has_local_bytes_state_predicate`, e.g. https://github.com/REPROSEC/dolev-yao-star-extrinsic/blob/f8a8c8bdc3317abead8c06697461666d8d7aac02/src/lib/state/DY.Lib.State.Typed.fst#L67-L68

The main trick used in this pull-request is to add the `unfold` keyword to these higher-level properties, as illustrated in the following minimal example:
```fstar
assume val protocol_invariants: Type0

// p_low is similar to `has_local_bytes_state_predicate`
assume val p_low: protocol_invariants -> prop
// q is any property that would have p_low as precondition
assume val q: protocol_invariants -> prop

// p_high is similar to `has_local_state_predicate`
unfold // note the unfold!
val p_high: protocol_invariants -> prop
let p_high invs = p_low invs

// we have a theorem that has an SMT pattern with `p_high`
assume val p_low_implies_q:
  invs:protocol_invariants ->
  Lemma
  (requires p_high invs)
  (ensures q invs)
  [SMTPat (p_high invs)]
  // the SMT pattern is unfolded to
  // [SMTPat (p_low invs)]

// but the squashed theorem we have in scope is on p_low
assume val global_invs: protocol_invariants
assume val p_low_global_invs: squash (p_low global_invs)

let test () =
  // Thanks to the unfold, the SMT pattern is triggered!
  assert(q global_invs)
```

### Ensuring uniqueness of typeclass resolution for `parseable_serializeable`

On the example of NSL, the message format for `nsl_session` could be obtained in two ways.

First, via the direct `parseable_serializeable` instance: https://github.com/REPROSEC/dolev-yao-star-extrinsic/blob/f8a8c8bdc3317abead8c06697461666d8d7aac02/examples/nsl_pk/DY.Example.NSL.Protocol.Stateful.fst#L26-L27
Second, via the `local_state` instance https://github.com/REPROSEC/dolev-yao-star-extrinsic/blob/f8a8c8bdc3317abead8c06697461666d8d7aac02/examples/nsl_pk/DY.Example.NSL.Protocol.Stateful.fst#L29-L32
which defines `parseable_serializeable` as a sub-typeclass https://github.com/REPROSEC/dolev-yao-star-extrinsic/blob/f8a8c8bdc3317abead8c06697461666d8d7aac02/src/lib/state/DY.Lib.State.Typed.fst#L8-L12

Why this is a problem?

Looking more closely at https://github.com/REPROSEC/dolev-yao-star-extrinsic/blob/f8a8c8bdc3317abead8c06697461666d8d7aac02/src/lib/state/DY.Lib.State.Typed.fst#L40-L43
we see that it is parametrized by a `parseable_serializeable` typeclass instance.
Therefore, resolving the implicits of https://github.com/REPROSEC/dolev-yao-star-extrinsic/blob/f8a8c8bdc3317abead8c06697461666d8d7aac02/src/lib/state/DY.Lib.State.Typed.fst#L67-L68
we obtain
```fstar
let has_local_state_predicate #a #ls invs spred =
  has_local_bytes_state_predicate invs (ls.tag, (local_state_predicate_to_local_bytes_state_predicate #invs.crypto_invs #a #ls.format spred))
```
if we prove the same thing, but replace `#ls.format` with the direct instance of `parseable_serializeable`, then it will not match the correct SMT pattern!
This is why only having one instance is useful, eventhough all typeclass instances we obtain are equal (by reduction).

### Un-inline the tag of map types

For the same reason of trying to match closely the final unfolded value, in map states we must use for the tag `(local_state_map pki_key pki_value).tag` instead of `map_types_pki.tag` (even though they are equal by reduction)

### One last issue

I noticed that the normalization trick we use in the examples do not work well when we only have one predicate… I opened FStarLang/FStar#3353 about that.
In the meantime, adding a dummy event predicate works as a workaround.