### PR TITLE
cleanup: generalize and handle usages more consistently

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,10 +21,9 @@ FSTAR_EXTRACT = --extract '-* +DY +Comparse'
 
 # Allowed warnings:
 # - (Warning 242) Definitions of inner let-rec ... and its enclosing top-level letbinding are not encoded to the solver, you will only be able to reason with their types
-# - (Warning 290) SMT may not be able to prove the types of ... and ...  to be equal, if the proof fails, try annotating these with the same type
 # - (Warning 335) Interface ... is admitted without an implementation 
 
-FSTAR_FLAGS = $(FSTAR_INCLUDE_DIRS) --cache_checked_modules --already_cached '+Prims +FStar' --warn_error '@0..1000' --warn_error '+242+290-335' --record_hints --hint_dir $(DY_HOME)/hints --cache_dir $(DY_HOME)/cache --odir $(DY_HOME)/obj --cmi
+FSTAR_FLAGS = $(FSTAR_INCLUDE_DIRS) --cache_checked_modules --already_cached '+Prims +FStar' --warn_error '@0..1000' --warn_error '+242-335' --record_hints --hint_dir $(DY_HOME)/hints --cache_dir $(DY_HOME)/cache --odir $(DY_HOME)/obj --cmi
 
 .PHONY: all clean
 

--- a/examples/iso_dh/DY.Example.DH.Protocol.Stateful.Proof.fst
+++ b/examples/iso_dh/DY.Example.DH.Protocol.Stateful.Proof.fst
@@ -20,7 +20,7 @@ let is_dh_shared_key tr alice bob k = exists si sj.
   // ``join (principal_state_label bob sj) (principal_state_label alice si)``.
   // This is because k is either build from ``dh x (dh_pk y)`` or ``dh y (dh_pk x)``.
   get_label k `equivalent tr` join (principal_state_label alice si) (principal_state_label bob sj) /\ 
-  get_usage k == AeadKey "DH.aead_key"
+  get_usage k == AeadKey "DH.aead_key" empty
 
 let dh_session_pred: local_state_predicate dh_session = {
   pred = (fun tr prin sess_id st ->
@@ -28,13 +28,13 @@ let dh_session_pred: local_state_predicate dh_session = {
     | InitiatorSentMsg1 bob x -> (
       let alice = prin in
       is_secret (principal_state_label alice sess_id) tr x /\
-      get_usage x == DhKey "DH.dh_key" /\
+      get_usage x == DhKey "DH.dh_key" empty /\
       event_triggered tr alice (Initiate1 alice bob x)
     )
     | ResponderSentMsg2 alice gx gy y -> (
       let bob = prin in
       is_publishable tr gx /\ is_publishable tr gy /\
-      is_secret (principal_state_label bob sess_id) tr y /\ get_usage y  == DhKey "DH.dh_key" /\
+      is_secret (principal_state_label bob sess_id) tr y /\ get_usage y  == DhKey "DH.dh_key" empty /\
       gy == dh_pk y /\
       event_triggered tr bob (Respond1 alice bob gx gy y)
     )
@@ -72,7 +72,7 @@ let dh_event_pred: event_predicate dh_event =
     | Respond1 alice bob gx gy y -> (
       is_publishable tr gx /\ is_publishable tr gy /\
       (exists sess_id. is_secret (principal_state_label bob sess_id) tr y) /\
-      get_usage y == DhKey "DH.dh_key" /\
+      get_usage y == DhKey "DH.dh_key" empty /\
       gy = dh_pk y
     )
     | Initiate2 alice bob gx gy k -> (
@@ -252,7 +252,7 @@ let prepare_msg3_proof tr global_sess_id alice alice_si bob msg_id =
 
           assert((exists x sess_id. is_secret (principal_state_label alice sess_id) tr x /\
             res.gx = dh_pk x));
-          assert(get_usage k = AeadKey "DH.aead_key");
+          assert(get_usage k = AeadKey "DH.aead_key" empty);
           assert(exists si. is_knowable_by (principal_state_label alice si) tr k);
 
           let alice_and_bob_not_corrupt = (~(is_corrupt tr (principal_state_label alice alice_si) \/ is_corrupt tr (principal_label bob))) in
@@ -371,7 +371,7 @@ let verify_msg3_proof tr global_sess_id alice bob msg_id bob_si =
 
             assert(is_corrupt tr (principal_label alice) \/ is_corrupt tr (principal_state_label bob bob_si) \/ 
               (exists si. get_label res.k `equivalent tr` join (principal_state_label alice si) (principal_state_label bob bob_si)));
-            assert(get_usage res.k == AeadKey "DH.aead_key");
+            assert(get_usage res.k == AeadKey "DH.aead_key" empty);
             assert(is_corrupt tr (principal_label alice) \/ is_corrupt tr (principal_state_label bob bob_si) \/
               (is_dh_shared_key tr alice bob res.k /\ event_triggered tr alice (Initiate2 alice bob gx gy res.k)));
             ()

--- a/examples/iso_dh/DY.Example.DH.Protocol.Stateful.fst
+++ b/examples/iso_dh/DY.Example.DH.Protocol.Stateful.fst
@@ -59,7 +59,7 @@ type dh_global_sess_ids = {
 val prepare_msg1: principal -> principal -> traceful state_id
 let prepare_msg1 alice bob =
   let* alice_si = new_session_id alice in
-  let* x = mk_rand (DhKey "DH.dh_key") (principal_state_label alice alice_si) 32 in
+  let* x = mk_rand (DhKey "DH.dh_key" empty) (principal_state_label alice alice_si) 32 in
   trigger_event alice (Initiate1 alice bob x);*
   set_state alice alice_si (InitiatorSentMsg1 bob x <: dh_session);*
   return alice_si
@@ -82,7 +82,7 @@ let prepare_msg2 alice bob msg_id =
   let*? msg = recv_msg msg_id in
   let*? msg1: message1 = return (decode_message1 msg) in
   let* bob_si = new_session_id bob in
-  let* y = mk_rand (DhKey "DH.dh_key") (principal_state_label bob bob_si) 32 in
+  let* y = mk_rand (DhKey "DH.dh_key" empty) (principal_state_label bob bob_si) 32 in
   trigger_event bob (Respond1 alice bob msg1.gx (dh_pk y) y);*
   set_state bob bob_si (ResponderSentMsg2 alice msg1.gx (dh_pk y) y <: dh_session);*
   return (Some bob_si)
@@ -146,4 +146,3 @@ let verify_msg3 global_sess_id alice bob msg_id bob_si =
     return (Some ())
   )
   | _ -> return None
-    

--- a/src/core/DY.Core.Bytes.Type.fst
+++ b/src/core/DY.Core.Bytes.Type.fst
@@ -18,27 +18,27 @@ open DY.Core.Label.Type
 /// To this bytestring will correspond a usage (e.g. "SigKey"),
 /// which will ensure it can only be used as the key of one specific cryptographic primitive (e.g. signature function).
 ///
-/// Second, the various usages additionally contain a usage string,
+/// Second, the various usages additionally contain a usage string "tag",
 /// which is used to further distinguish keys used with a given cryptographic primitive:
 /// for example to distinguish the long-term key from the ephemeral ones,
 /// or to distinguish keys from two sub-protocols running in parallel.
 /// At the end, this usage string may play a role in the security proof
 /// via the protocol invariants.
 ///
-/// Although most usages only contain a usage string to disambiguate different keys,
-/// KDF keys additionally contains a full `bytes` in their usage.
+/// Because a string may not be enough to express the complex reasons two keys are distinct,
+/// usages also contain a `bytes` called "data".
 /// This is useful to do security proofs of protocols with complex key schedules,
 /// allowing the usage's `data` field and the label of the keys to evolve
 /// when calling kdf_extract and kdf_expand.
 
 type usage =
   | NoUsage: usage // baked-in None
-  | SigKey: tag:string -> usage
+  | SigKey: tag:string -> data:bytes -> usage
   | SigNonce: usage
-  | PkdecKey: tag:string -> usage
+  | PkdecKey: tag:string -> data:bytes -> usage
   | PkNonce: usage
-  | AeadKey: tag:string -> usage
-  | DhKey: tag:string -> usage
+  | AeadKey: tag:string -> data:bytes -> usage
+  | DhKey: tag:string -> data:bytes -> usage
   | KdfExtractSaltKey: tag:string -> data:bytes -> usage
   | KdfExtractIkmKey: tag:string -> data:bytes -> usage
   | KdfExpandKey: tag:string -> data:bytes -> usage
@@ -96,12 +96,12 @@ val encode_bytes: bytes -> list int
 let rec encode_usage usg =
   match usg with
   | NoUsage -> 0::[]
-  | SigKey tag -> 1::(encode_list [encode tag])
+  | SigKey tag data -> 1::(encode_list [encode tag; encode_bytes data])
   | SigNonce -> 2::[]
-  | PkdecKey tag -> 3::(encode_list [encode tag])
+  | PkdecKey tag data -> 3::(encode_list [encode tag; encode_bytes data])
   | PkNonce -> 4::[]
-  | AeadKey tag -> 5::(encode_list [encode tag])
-  | DhKey tag -> 6::(encode_list [encode tag])
+  | AeadKey tag data -> 5::(encode_list [encode tag; encode_bytes data])
+  | DhKey tag data -> 6::(encode_list [encode tag; encode_bytes data])
   | KdfExtractSaltKey tag data -> 7::(encode_list [encode tag; encode_bytes data])
   | KdfExtractIkmKey tag data -> 8::(encode_list [encode tag; encode_bytes data])
   | KdfExpandKey tag data -> 9::(encode_list [encode tag; encode_bytes data])
@@ -121,7 +121,8 @@ and encode_bytes b =
   | KdfExtract salt ikm -> 11::(encode_list [encode_bytes salt; encode_bytes ikm])
   | KdfExpand prk info len -> 12::(encode_list [encode_bytes prk; encode_bytes info; encode (len <: nat)])
 
-#push-options "--z3rlimit 25 --fuel 4 --ifuel 4"
+// --warn_error is a workaround for FStar/FStarLang#3220
+#push-options "--z3rlimit 25 --fuel 4 --ifuel 4 --warn_error +290"
 val encode_usage_inj: usg1:usage -> usg2:usage -> Lemma (requires encode_usage usg1 == encode_usage usg2) (ensures usg1 == usg2)
 val encode_bytes_inj: b1:bytes -> b2:bytes -> Lemma (requires encode_bytes b1 == encode_bytes b2) (ensures b1 == b2)
 let rec encode_usage_inj usg1 usg2 =
@@ -130,11 +131,10 @@ let rec encode_usage_inj usg1 usg2 =
   | SigNonce, SigNonce
   | PkNonce, PkNonce
   | NoUsage, NoUsage -> ()
-  | SigKey tag1, SigKey tag2
-  | PkdecKey tag1, PkdecKey tag2
-  | AeadKey tag1, AeadKey tag2
-  | DhKey tag1, DhKey tag2 ->
-    encode_inj tag1 tag2
+  | SigKey tag1 data1, SigKey tag2 data2
+  | PkdecKey tag1 data1, PkdecKey tag2 data2
+  | AeadKey tag1 data1, AeadKey tag2 data2
+  | DhKey tag1 data1, DhKey tag2 data2
   | KdfExtractSaltKey tag1 data1, KdfExtractSaltKey tag2 data2
   | KdfExtractIkmKey tag1 data1, KdfExtractIkmKey tag2 data2
   | KdfExpandKey tag1 data1, KdfExpandKey tag2 data2 -> (

--- a/src/lib/state/DY.Lib.State.PKI.fst
+++ b/src/lib/state/DY.Lib.State.PKI.fst
@@ -60,10 +60,10 @@ val is_public_key_for:
 let is_public_key_for #cinvs tr pk pk_type who =
   match pk_type with
   | PkEnc usg -> (
-    is_encryption_key usg (principal_label who) tr pk
+    is_encryption_key (PkdecKey usg empty) (principal_label who) tr pk
   )
   | Verify usg -> (
-    is_verification_key usg (principal_label who) tr pk
+    is_verification_key (SigKey usg empty) (principal_label who) tr pk
   )
 
 // The `#_` at the end is a workaround for FStarLang/FStar#3286

--- a/src/lib/state/DY.Lib.State.PrivateKeys.fst
+++ b/src/lib/state/DY.Lib.State.PrivateKeys.fst
@@ -52,10 +52,10 @@ val is_private_key_for:
 let is_private_key_for #cinvs tr sk sk_type who =
   match sk_type with
   | PkDec usg -> (
-    is_decryption_key usg (principal_label who) tr sk
+    is_decryption_key (PkdecKey usg empty) (principal_label who) tr sk
   )
   | Sign usg -> (
-    is_signature_key usg (principal_label who) tr sk
+    is_signature_key (SigKey usg empty) (principal_label who) tr sk
   )
 
 // The `#_` at the end is a workaround for FStarLang/FStar#3286
@@ -80,8 +80,8 @@ val private_key_type_to_usage:
   usage
 let private_key_type_to_usage sk_type =
   match sk_type with
-  | PkDec usg -> PkdecKey usg
-  | Sign usg -> SigKey usg
+  | PkDec usg -> PkdecKey usg empty
+  | Sign usg -> SigKey usg empty
 
 (*** Private Keys API ***)
 

--- a/src/lib/utils/DY.Lib.Printing.fst
+++ b/src/lib/utils/DY.Lib.Printing.fst
@@ -87,12 +87,12 @@ val usage_to_string: (u:usage) -> string
 let usage_to_string u =
   match u with
   | NoUsage -> "NoUsage"
-  | SigKey tag -> "SigKey " ^ tag
+  | SigKey tag _ -> "SigKey " ^ tag
   | SigNonce -> "SigNonce"
-  | PkdecKey tag -> "PkdecKey " ^ tag
+  | PkdecKey tag _ -> "PkdecKey " ^ tag
   | PkNonce -> "PkNonce"
-  | AeadKey tag -> "AeadKey " ^ tag
-  | DhKey tag -> "DhKey " ^ tag
+  | AeadKey tag data -> Printf.sprintf "AeadKey %s (data=(%s))" tag (bytes_to_string data)
+  | DhKey tag _ -> "DhKey " ^ tag
   | KdfExtractSaltKey tag data -> Printf.sprintf "KdfExtractSaltKey %s (data=(%s))" tag (bytes_to_string data)
   | KdfExtractIkmKey tag data -> Printf.sprintf "KdfExtractIkmKey %s (data=(%s))" tag (bytes_to_string data)
   | KdfExpandKey tag data -> Printf.sprintf "KdfExpandKey %s (data=(%s))" tag (bytes_to_string data)


### PR DESCRIPTION
This pull request do mostly two things.

First, usages are generalized to always contain a usage string and additional `data` bytes, that may contain useful information on how the key was derived via a key schedule. I need this for AEAD in an example for HPKE I'm working on (that will appear here in a few days), but because this can be useful for any cryptographic primitive, and for consistency, I implemented that for all keys.

Second, the cryptographic invariants are better organized, for example by separating the record containing `aead_pred` and `aead_pred_later` from the one containing `sign_pred` and `sign_pred_later`. This will be useful for applying cleanly the split functions methodology to cryptographic invariants (that will appear later today).