### PR TITLE
feat: apply split function methodology to cryptographic invariants

### DIFF
--- a/.fst.config.json
+++ b/.fst.config.json
@@ -1,5 +1,15 @@
 { "fstar_exe":"fstar.exe",
   "options":["--cache_dir", "cache", "--hint_dir", "hints", "--use_hints", "--record_hints"],
   "include_dirs":[
-    "../comparse/src", "src/core", "src/lib", "src/lib/comparse", "src/lib/event", "src/lib/state", "src/lib/utils", "examples/nsl_pk", "examples/iso_dh"] 
+    "../comparse/src",
+    "src/core",
+    "src/lib",
+    "src/lib/comparse",
+    "src/lib/crypto",
+    "src/lib/event",
+    "src/lib/state",
+    "src/lib/utils",
+    "examples/nsl_pk",
+    "examples/iso_dh"
+  ]
 }

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ FSTAR_HOME 	?= $(dir $(shell which fstar.exe))/..
 Z3 		?= $(shell which z3)
 COMPARSE_HOME 	?= $(DY_HOME)/../comparse
 
-INNER_SOURCE_DIRS = core lib lib/comparse lib/event lib/state lib/utils
+INNER_SOURCE_DIRS = core lib lib/comparse lib/crypto lib/event lib/state lib/utils
 SOURCE_DIRS = $(addprefix $(DY_HOME)/src/, $(INNER_SOURCE_DIRS))
 INNER_EXAMPLE_DIRS = nsl_pk iso_dh
 EXAMPLE_DIRS = $(addprefix $(DY_HOME)/examples/, $(INNER_EXAMPLE_DIRS))

--- a/examples/iso_dh/DY.Example.DH.Protocol.Stateful.Proof.fst
+++ b/examples/iso_dh/DY.Example.DH.Protocol.Stateful.Proof.fst
@@ -105,7 +105,7 @@ let all_events = [
 /// Create the global trace invariants.
 
 let dh_trace_invs: trace_invariants (dh_crypto_invs) = {
-  state_pred = mk_state_predicate dh_crypto_invs all_sessions;
+  state_pred = mk_state_pred dh_crypto_invs all_sessions;
   event_pred = mk_event_pred all_events;
 }
 
@@ -119,7 +119,7 @@ instance dh_protocol_invs: protocol_invariants = {
 val all_sessions_has_all_sessions: unit -> Lemma (norm [delta_only [`%all_sessions; `%for_allP]; iota; zeta] (for_allP (has_local_bytes_state_predicate dh_protocol_invs) all_sessions))
 let all_sessions_has_all_sessions () =
   assert_norm(List.Tot.no_repeats_p (List.Tot.map fst (all_sessions)));
-  mk_global_local_bytes_state_predicate_correct dh_protocol_invs all_sessions;
+  mk_state_pred_correct dh_protocol_invs all_sessions;
   norm_spec [delta_only [`%all_sessions; `%for_allP]; iota; zeta] (for_allP (has_local_bytes_state_predicate dh_protocol_invs) all_sessions)
 
 val full_dh_session_pred_has_pki_invariant: squash (has_pki_invariant dh_protocol_invs)

--- a/examples/nsl_pk/DY.Example.NSL.Protocol.Stateful.Proof.fst
+++ b/examples/nsl_pk/DY.Example.NSL.Protocol.Stateful.Proof.fst
@@ -96,7 +96,7 @@ let all_events = [
 /// Create the global trace invariants.
 
 let trace_invariants_nsl: trace_invariants (crypto_invariants_nsl) = {
-  state_pred = mk_state_predicate crypto_invariants_nsl all_sessions;
+  state_pred = mk_state_pred crypto_invariants_nsl all_sessions;
   event_pred = mk_event_pred all_events;
 }
 
@@ -110,7 +110,7 @@ instance protocol_invariants_nsl: protocol_invariants = {
 val all_sessions_has_all_sessions: unit -> Lemma (norm [delta_only [`%all_sessions; `%for_allP]; iota; zeta] (for_allP (has_local_bytes_state_predicate protocol_invariants_nsl) all_sessions))
 let all_sessions_has_all_sessions () =
   assert_norm(List.Tot.no_repeats_p (List.Tot.map fst (all_sessions)));
-  mk_global_local_bytes_state_predicate_correct protocol_invariants_nsl all_sessions;
+  mk_state_pred_correct protocol_invariants_nsl all_sessions;
   norm_spec [delta_only [`%all_sessions; `%for_allP]; iota; zeta] (for_allP (has_local_bytes_state_predicate protocol_invariants_nsl) all_sessions)
 
 val protocol_invariants_nsl_has_pki_invariant: squash (has_pki_invariant protocol_invariants_nsl)

--- a/flake.lock
+++ b/flake.lock
@@ -46,11 +46,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1708956704,
-        "narHash": "sha256-xT0V7oQwR0Zns9g/MvV30ILlAX6tcp92SqWPwej1+sI=",
+        "lastModified": 1721552334,
+        "narHash": "sha256-FDfp4JquvP5e4obYdG7hpe5hwMOTxYwe4ArtNXKHvcY=",
         "owner": "FStarLang",
         "repo": "FStar",
-        "rev": "a48722f90e14be69b850f093b41fbbdfee7f6eb9",
+        "rev": "e5cef6f266ece8a8b55ef4cd9b61cdf103520d38",
         "type": "github"
       },
       "original": {

--- a/src/lib/DY.Lib.fst
+++ b/src/lib/DY.Lib.fst
@@ -10,6 +10,12 @@ include DY.Lib.Comparse.Parsers
 /// The split function methodology
 include DY.Lib.SplitFunction
 
+/// Split function methodology for cryptographic invariants
+include DY.Lib.Crypto.AEAD.Split
+include DY.Lib.Crypto.KdfExpand.Split
+include DY.Lib.Crypto.PkEncryption.Split
+include DY.Lib.Crypto.Signature.Split
+
 /// User-friendly event API
 include DY.Lib.Event.Typed
 

--- a/src/lib/crypto/DY.Lib.Crypto.AEAD.Split.fst
+++ b/src/lib/crypto/DY.Lib.Crypto.AEAD.Split.fst
@@ -47,33 +47,33 @@ let mk_global_aead_predicate #cusgs l =
   mk_global_fun (split_aead_predicate_params cusgs) l
 
 val mk_global_aead_predicate_correct:
-  cinvs:crypto_invariants -> lpreds:list (string & aead_crypto_predicate cinvs.usages) ->
+  cinvs:crypto_invariants -> tagged_local_preds:list (string & aead_crypto_predicate cinvs.usages) ->
   Lemma
   (requires
-    aead_pred.pred == mk_global_aead_predicate lpreds /\
-    List.Tot.no_repeats_p (List.Tot.map fst lpreds)
+    aead_pred.pred == mk_global_aead_predicate tagged_local_preds /\
+    List.Tot.no_repeats_p (List.Tot.map fst tagged_local_preds)
   )
-  (ensures for_allP (has_aead_predicate cinvs) lpreds)
-let mk_global_aead_predicate_correct cinvs lpreds =
-  no_repeats_p_implies_for_all_pairsP_unequal (List.Tot.map fst lpreds);
-  for_allP_eq (has_aead_predicate cinvs) lpreds;
-  FStar.Classical.forall_intro_2 (FStar.Classical.move_requires_2 (mk_global_fun_correct (split_aead_predicate_params cinvs.usages) lpreds))
+  (ensures for_allP (has_aead_predicate cinvs) tagged_local_preds)
+let mk_global_aead_predicate_correct cinvs tagged_local_preds =
+  no_repeats_p_implies_for_all_pairsP_unequal (List.Tot.map fst tagged_local_preds);
+  for_allP_eq (has_aead_predicate cinvs) tagged_local_preds;
+  FStar.Classical.forall_intro_2 (FStar.Classical.move_requires_2 (mk_global_fun_correct (split_aead_predicate_params cinvs.usages) tagged_local_preds))
 
 val mk_global_aead_predicate_later:
-  {|cusgs:crypto_usages|} -> lpreds:list (string & aead_crypto_predicate cusgs) ->
+  {|cusgs:crypto_usages|} -> tagged_local_preds:list (string & aead_crypto_predicate cusgs) ->
   tr1:trace -> tr2:trace -> key:bytes{AeadKey? (get_usage key)} -> msg:bytes -> ad:bytes ->
   Lemma
-  (requires mk_global_aead_predicate lpreds tr1 key msg ad /\ tr1 <$ tr2)
-  (ensures mk_global_aead_predicate lpreds tr2 key msg ad)
-let mk_global_aead_predicate_later #cusgs lpreds tr1 tr2 key msg ad =
-  mk_global_fun_eq (split_aead_predicate_params cusgs) lpreds (tr1, key, msg, ad);
-  mk_global_fun_eq (split_aead_predicate_params cusgs) lpreds (tr2, key, msg, ad);
+  (requires mk_global_aead_predicate tagged_local_preds tr1 key msg ad /\ tr1 <$ tr2)
+  (ensures mk_global_aead_predicate tagged_local_preds tr2 key msg ad)
+let mk_global_aead_predicate_later #cusgs tagged_local_preds tr1 tr2 key msg ad =
+  mk_global_fun_eq (split_aead_predicate_params cusgs) tagged_local_preds (tr1, key, msg, ad);
+  mk_global_fun_eq (split_aead_predicate_params cusgs) tagged_local_preds (tr2, key, msg, ad);
   introduce forall lpred. (split_aead_predicate_params cusgs).apply_local_fun lpred (tr1, key, msg, ad) ==> (split_aead_predicate_params cusgs).apply_local_fun lpred (tr2, key, msg, ad) with (
     introduce _ ==> _ with _. lpred.pred_later tr1 tr2 key msg ad
   )
 
 val mk_aead_predicate: {|cusgs:crypto_usages|} -> list (string & aead_crypto_predicate cusgs) -> aead_crypto_predicate cusgs
-let mk_aead_predicate #cusgs lpreds = {
-  pred = mk_global_aead_predicate lpreds;
-  pred_later = mk_global_aead_predicate_later lpreds;
+let mk_aead_predicate #cusgs tagged_local_preds = {
+  pred = mk_global_aead_predicate tagged_local_preds;
+  pred_later = mk_global_aead_predicate_later tagged_local_preds;
 }

--- a/src/lib/crypto/DY.Lib.Crypto.AEAD.Split.fst
+++ b/src/lib/crypto/DY.Lib.Crypto.AEAD.Split.fst
@@ -4,7 +4,7 @@ open Comparse // for_allP, for_allP_eq
 open DY.Core
 open DY.Lib.SplitFunction
 
-let split_aead_predicate_params (cusages:crypto_usages) = {
+let split_aead_predicate_params (cusages:crypto_usages): split_function_parameters = {
   singleton_split_function_parameters string with
 
   tagged_data_t = (trace & (key:bytes{AeadKey? (get_usage key)}) & bytes & bytes);

--- a/src/lib/crypto/DY.Lib.Crypto.AEAD.Split.fst
+++ b/src/lib/crypto/DY.Lib.Crypto.AEAD.Split.fst
@@ -2,78 +2,58 @@ module DY.Lib.Crypto.AEAD.Split
 
 open Comparse // for_allP, for_allP_eq
 open DY.Core
-open DY.Lib.SplitFunction
+open DY.Lib.Crypto.SplitPredicate
 
-let split_aead_predicate_params (cusages:crypto_usages): split_function_parameters = {
-  singleton_split_function_parameters string with
-
-  tagged_data_t = (trace & (key:bytes{AeadKey? (get_usage key)}) & bytes & bytes);
-  raw_data_t = (trace & (key:bytes{AeadKey? (get_usage key)}) & bytes & bytes);
-  output_t = prop;
-
-  decode_tagged_data = (fun (tr, key, msg, ad) ->
+let split_aead_predicate_params (cusages:crypto_usages): split_crypto_predicate_parameters = {
+  key_t = key:bytes{AeadKey? (get_usage key)};
+  data_t = (bytes & bytes);
+  get_usage = (fun key ->
     let AeadKey tag _ = get_usage key in
-    Some (tag, (tr, key, msg, ad))
+    tag
   );
 
-  local_fun_t = aead_crypto_predicate cusages;
-  global_fun_t = trace -> key:bytes{AeadKey? (get_usage key)} -> msg:bytes -> ad:bytes -> prop;
+  local_pred_t = aead_crypto_predicate cusages;
+  global_pred_t = trace -> key:bytes{AeadKey? (get_usage key)} -> msg:bytes -> ad:bytes -> prop;
 
-  default_global_fun = (fun tr key msg ad -> False);
-
-  apply_local_fun = (fun pred (tr, key, msg, ad) ->
+  apply_local_pred = (fun pred (tr, key, (msg, ad)) ->
     pred.pred tr key msg ad
   );
-  apply_global_fun = (fun pred (tr, key, msg, ad) ->
+  apply_global_pred = (fun pred (tr, key, (msg, ad)) ->
     pred tr key msg ad
   );
-  mk_global_fun = (fun pred tr key msg ad ->
-    pred (tr, key, msg, ad)
+  mk_global_pred = (fun pred tr key msg ad ->
+    pred (tr, key, (msg, ad))
   );
-  apply_mk_global_fun = (fun bare x -> ());
+
+  apply_mk_global_pred = (fun bare x -> ());
+  apply_local_pred_later = (fun lpred tr1 tr2 key (msg, ad) ->
+    lpred.pred_later tr1 tr2 key msg ad
+  );
 }
 
 val has_aead_predicate: cinvs:crypto_invariants -> (string & aead_crypto_predicate cinvs.usages) -> prop
 let has_aead_predicate cinvs (tag, pred) =
-  has_local_fun (split_aead_predicate_params cinvs.usages) aead_pred.pred (tag, pred)
+  has_local_crypto_predicate (split_aead_predicate_params cinvs.usages) aead_pred.pred (tag, pred)
 
 (*** Global aead predicate builder ***)
 
-val mk_global_aead_predicate:
+val mk_aead_predicate:
   {|cusgs:crypto_usages|} ->
   list (string & aead_crypto_predicate cusgs) ->
-  trace -> key:bytes{AeadKey? (get_usage key)} -> msg:bytes -> ad:bytes -> prop
-let mk_global_aead_predicate #cusgs l =
-  mk_global_fun (split_aead_predicate_params cusgs) l
+  aead_crypto_predicate cusgs
+let mk_aead_predicate #cusgs l = {
+  pred = mk_global_crypto_predicate (split_aead_predicate_params cusgs) l;
+  pred_later = (fun tr1 tr2 key msg ad -> mk_global_crypto_predicate_later (split_aead_predicate_params cusgs) l tr1 tr2 key (msg, ad));
+}
 
-val mk_global_aead_predicate_correct:
+val mk_aead_predicate_correct:
   cinvs:crypto_invariants -> tagged_local_preds:list (string & aead_crypto_predicate cinvs.usages) ->
   Lemma
   (requires
-    aead_pred.pred == mk_global_aead_predicate tagged_local_preds /\
+    aead_pred == mk_aead_predicate tagged_local_preds /\
     List.Tot.no_repeats_p (List.Tot.map fst tagged_local_preds)
   )
   (ensures for_allP (has_aead_predicate cinvs) tagged_local_preds)
-let mk_global_aead_predicate_correct cinvs tagged_local_preds =
-  no_repeats_p_implies_for_all_pairsP_unequal (List.Tot.map fst tagged_local_preds);
+let mk_aead_predicate_correct cinvs tagged_local_preds =
   for_allP_eq (has_aead_predicate cinvs) tagged_local_preds;
-  FStar.Classical.forall_intro_2 (FStar.Classical.move_requires_2 (mk_global_fun_correct (split_aead_predicate_params cinvs.usages) tagged_local_preds))
-
-val mk_global_aead_predicate_later:
-  {|cusgs:crypto_usages|} -> tagged_local_preds:list (string & aead_crypto_predicate cusgs) ->
-  tr1:trace -> tr2:trace -> key:bytes{AeadKey? (get_usage key)} -> msg:bytes -> ad:bytes ->
-  Lemma
-  (requires mk_global_aead_predicate tagged_local_preds tr1 key msg ad /\ tr1 <$ tr2)
-  (ensures mk_global_aead_predicate tagged_local_preds tr2 key msg ad)
-let mk_global_aead_predicate_later #cusgs tagged_local_preds tr1 tr2 key msg ad =
-  mk_global_fun_eq (split_aead_predicate_params cusgs) tagged_local_preds (tr1, key, msg, ad);
-  mk_global_fun_eq (split_aead_predicate_params cusgs) tagged_local_preds (tr2, key, msg, ad);
-  introduce forall lpred. (split_aead_predicate_params cusgs).apply_local_fun lpred (tr1, key, msg, ad) ==> (split_aead_predicate_params cusgs).apply_local_fun lpred (tr2, key, msg, ad) with (
-    introduce _ ==> _ with _. lpred.pred_later tr1 tr2 key msg ad
-  )
-
-val mk_aead_predicate: {|cusgs:crypto_usages|} -> list (string & aead_crypto_predicate cusgs) -> aead_crypto_predicate cusgs
-let mk_aead_predicate #cusgs tagged_local_preds = {
-  pred = mk_global_aead_predicate tagged_local_preds;
-  pred_later = mk_global_aead_predicate_later tagged_local_preds;
-}
+  FStar.Classical.forall_intro_2 (FStar.Classical.move_requires_2 (mk_global_crypto_predicate_correct (split_aead_predicate_params cinvs.usages) tagged_local_preds))

--- a/src/lib/crypto/DY.Lib.Crypto.AEAD.Split.fst
+++ b/src/lib/crypto/DY.Lib.Crypto.AEAD.Split.fst
@@ -1,0 +1,79 @@
+module DY.Lib.Crypto.AEAD.Split
+
+open Comparse // for_allP, for_allP_eq
+open DY.Core
+open DY.Lib.SplitFunction
+
+let split_aead_predicate_params (cusages:crypto_usages) = {
+  singleton_split_function_parameters string with
+
+  tagged_data_t = (trace & (key:bytes{AeadKey? (get_usage key)}) & bytes & bytes);
+  raw_data_t = (trace & (key:bytes{AeadKey? (get_usage key)}) & bytes & bytes);
+  output_t = prop;
+
+  decode_tagged_data = (fun (tr, key, msg, ad) ->
+    let AeadKey tag _ = get_usage key in
+    Some (tag, (tr, key, msg, ad))
+  );
+
+  local_fun_t = aead_crypto_predicate cusages;
+  global_fun_t = trace -> key:bytes{AeadKey? (get_usage key)} -> msg:bytes -> ad:bytes -> prop;
+
+  default_global_fun = (fun tr key msg ad -> False);
+
+  apply_local_fun = (fun pred (tr, key, msg, ad) ->
+    pred.pred tr key msg ad
+  );
+  apply_global_fun = (fun pred (tr, key, msg, ad) ->
+    pred tr key msg ad
+  );
+  mk_global_fun = (fun pred tr key msg ad ->
+    pred (tr, key, msg, ad)
+  );
+  apply_mk_global_fun = (fun bare x -> ());
+}
+
+val has_aead_predicate: cinvs:crypto_invariants -> (string & aead_crypto_predicate cinvs.usages) -> prop
+let has_aead_predicate cinvs (tag, pred) =
+  has_local_fun (split_aead_predicate_params cinvs.usages) aead_pred.pred (tag, pred)
+
+(*** Global aead predicate builder ***)
+
+val mk_global_aead_predicate:
+  {|cusgs:crypto_usages|} ->
+  list (string & aead_crypto_predicate cusgs) ->
+  trace -> key:bytes{AeadKey? (get_usage key)} -> msg:bytes -> ad:bytes -> prop
+let mk_global_aead_predicate #cusgs l =
+  mk_global_fun (split_aead_predicate_params cusgs) l
+
+val mk_global_aead_predicate_correct:
+  cinvs:crypto_invariants -> lpreds:list (string & aead_crypto_predicate cinvs.usages) ->
+  Lemma
+  (requires
+    aead_pred.pred == mk_global_aead_predicate lpreds /\
+    List.Tot.no_repeats_p (List.Tot.map fst lpreds)
+  )
+  (ensures for_allP (has_aead_predicate cinvs) lpreds)
+let mk_global_aead_predicate_correct cinvs lpreds =
+  no_repeats_p_implies_for_all_pairsP_unequal (List.Tot.map fst lpreds);
+  for_allP_eq (has_aead_predicate cinvs) lpreds;
+  FStar.Classical.forall_intro_2 (FStar.Classical.move_requires_2 (mk_global_fun_correct (split_aead_predicate_params cinvs.usages) lpreds))
+
+val mk_global_aead_predicate_later:
+  {|cusgs:crypto_usages|} -> lpreds:list (string & aead_crypto_predicate cusgs) ->
+  tr1:trace -> tr2:trace -> key:bytes{AeadKey? (get_usage key)} -> msg:bytes -> ad:bytes ->
+  Lemma
+  (requires mk_global_aead_predicate lpreds tr1 key msg ad /\ tr1 <$ tr2)
+  (ensures mk_global_aead_predicate lpreds tr2 key msg ad)
+let mk_global_aead_predicate_later #cusgs lpreds tr1 tr2 key msg ad =
+  mk_global_fun_eq (split_aead_predicate_params cusgs) lpreds (tr1, key, msg, ad);
+  mk_global_fun_eq (split_aead_predicate_params cusgs) lpreds (tr2, key, msg, ad);
+  introduce forall lpred. (split_aead_predicate_params cusgs).apply_local_fun lpred (tr1, key, msg, ad) ==> (split_aead_predicate_params cusgs).apply_local_fun lpred (tr2, key, msg, ad) with (
+    introduce _ ==> _ with _. lpred.pred_later tr1 tr2 key msg ad
+  )
+
+val mk_aead_predicate: {|cusgs:crypto_usages|} -> list (string & aead_crypto_predicate cusgs) -> aead_crypto_predicate cusgs
+let mk_aead_predicate #cusgs lpreds = {
+  pred = mk_global_aead_predicate lpreds;
+  pred_later = mk_global_aead_predicate_later lpreds;
+}

--- a/src/lib/crypto/DY.Lib.Crypto.KdfExpand.Split.fst
+++ b/src/lib/crypto/DY.Lib.Crypto.KdfExpand.Split.fst
@@ -4,7 +4,7 @@ open Comparse // for_allP, for_allP_eq
 open DY.Core
 open DY.Lib.SplitFunction
 
-let split_kdf_expand_usage_get_usage_params = {
+let split_kdf_expand_usage_get_usage_params: split_function_parameters = {
   singleton_split_function_parameters string with
 
   tagged_data_t = (prk_usage:usage{KdfExpandKey? prk_usage}) & bytes;

--- a/src/lib/crypto/DY.Lib.Crypto.KdfExpand.Split.fst
+++ b/src/lib/crypto/DY.Lib.Crypto.KdfExpand.Split.fst
@@ -83,21 +83,6 @@ val mk_global_kdf_expand_usage_get_label:
 let mk_global_kdf_expand_usage_get_label tagged_local_invariants =
   mk_global_fun (split_kdf_expand_usage_get_label_params) tagged_local_invariants
 
-val mk_global_kdf_expand_usage_correct:
-  cusgs:crypto_usages -> tagged_local_invariants:list (string & kdf_expand_crypto_usage) ->
-  Lemma
-  (requires
-    kdf_expand_usage.get_usage == mk_global_kdf_expand_usage_get_usage tagged_local_invariants /\
-    kdf_expand_usage.get_label == mk_global_kdf_expand_usage_get_label tagged_local_invariants /\
-    List.Tot.no_repeats_p (List.Tot.map fst tagged_local_invariants)
-  )
-  (ensures for_allP (has_kdf_expand_usage cusgs) tagged_local_invariants)
-let mk_global_kdf_expand_usage_correct cusgs tagged_local_invariants =
-  no_repeats_p_implies_for_all_pairsP_unequal (List.Tot.map fst tagged_local_invariants);
-  for_allP_eq (has_kdf_expand_usage cusgs) tagged_local_invariants;
-  FStar.Classical.forall_intro_2 (FStar.Classical.move_requires_2 (mk_global_fun_correct split_kdf_expand_usage_get_usage_params tagged_local_invariants));
-  FStar.Classical.forall_intro_2 (FStar.Classical.move_requires_2 (mk_global_fun_correct split_kdf_expand_usage_get_label_params tagged_local_invariants))
-
 val mk_global_kdf_expand_usage_get_label_lemma:
   tagged_local_invariants:list (string & kdf_expand_crypto_usage) ->
   tr:trace ->
@@ -115,3 +100,17 @@ let mk_kdf_expand_usage tagged_local_invariants = {
   get_label = mk_global_kdf_expand_usage_get_label tagged_local_invariants;
   get_label_lemma = mk_global_kdf_expand_usage_get_label_lemma tagged_local_invariants;
 }
+
+val mk_kdf_expand_usage_correct:
+  cusgs:crypto_usages -> tagged_local_invariants:list (string & kdf_expand_crypto_usage) ->
+  Lemma
+  (requires
+    kdf_expand_usage == mk_kdf_expand_usage tagged_local_invariants /\
+    List.Tot.no_repeats_p (List.Tot.map fst tagged_local_invariants)
+  )
+  (ensures for_allP (has_kdf_expand_usage cusgs) tagged_local_invariants)
+let mk_kdf_expand_usage_correct cusgs tagged_local_invariants =
+  no_repeats_p_implies_for_all_pairsP_unequal (List.Tot.map fst tagged_local_invariants);
+  for_allP_eq (has_kdf_expand_usage cusgs) tagged_local_invariants;
+  FStar.Classical.forall_intro_2 (FStar.Classical.move_requires_2 (mk_global_fun_correct split_kdf_expand_usage_get_usage_params tagged_local_invariants));
+  FStar.Classical.forall_intro_2 (FStar.Classical.move_requires_2 (mk_global_fun_correct split_kdf_expand_usage_get_label_params tagged_local_invariants))

--- a/src/lib/crypto/DY.Lib.Crypto.KdfExpand.Split.fst
+++ b/src/lib/crypto/DY.Lib.Crypto.KdfExpand.Split.fst
@@ -1,0 +1,117 @@
+module DY.Lib.Crypto.KdfExpand.Split
+
+open Comparse // for_allP, for_allP_eq
+open DY.Core
+open DY.Lib.SplitFunction
+
+let split_kdf_expand_usage_get_usage_params = {
+  singleton_split_function_parameters string with
+
+  tagged_data_t = (prk_usage:usage{KdfExpandKey? prk_usage}) & bytes;
+  raw_data_t = (prk_usage:usage{KdfExpandKey? prk_usage}) & bytes;
+  output_t = usage;
+
+  decode_tagged_data = (fun (prk_usage, info) ->
+    let KdfExpandKey tag _ = prk_usage in
+    Some (tag, (prk_usage, info))
+  );
+
+  local_fun_t = kdf_expand_crypto_usage;
+  global_fun_t = prk_usage:usage{KdfExpandKey? prk_usage} -> info:bytes -> usage;
+
+  default_global_fun = (fun prk_usage info -> NoUsage);
+
+  apply_local_fun = (fun lfun (prk_usage, info) ->
+    lfun.get_usage prk_usage info
+  );
+  apply_global_fun = (fun gfun (prk_usage, info) ->
+    gfun prk_usage info
+  );
+  mk_global_fun = (fun gfun prk_usage info ->
+    gfun (prk_usage, info)
+  );
+  apply_mk_global_fun = (fun bare x -> ());
+}
+
+let split_kdf_expand_usage_get_label_params = {
+  singleton_split_function_parameters string with
+
+  tagged_data_t = (prk_usage:usage{KdfExpandKey? prk_usage}) & label & bytes;
+  raw_data_t = (prk_usage:usage{KdfExpandKey? prk_usage}) & label & bytes;
+  output_t = label;
+
+  decode_tagged_data = (fun (prk_usage, prk_label, info) ->
+    let KdfExpandKey tag _ = prk_usage in
+    Some (tag, (prk_usage, prk_label, info))
+  );
+
+  local_fun_t = kdf_expand_crypto_usage;
+  global_fun_t = prk_usage:usage{KdfExpandKey? prk_usage} -> prk_label:label -> info:bytes -> label;
+
+  default_global_fun = (fun prk_usage prk_label info -> prk_label);
+
+  apply_local_fun = (fun lfun (prk_usage, prk_label, info) ->
+    lfun.get_label prk_usage prk_label info
+  );
+  apply_global_fun = (fun gfun (prk_usage, prk_label, info) ->
+    gfun prk_usage prk_label info
+  );
+  mk_global_fun = (fun gfun prk_usage prk_label info ->
+    gfun (prk_usage, prk_label, info)
+  );
+  apply_mk_global_fun = (fun bare x -> ());
+}
+
+val has_kdf_expand_usage: cusgs:crypto_usages -> (string & kdf_expand_crypto_usage) -> prop
+let has_kdf_expand_usage cinvs (tag, crypto_usage) =
+  has_local_fun split_kdf_expand_usage_get_usage_params kdf_expand_usage.get_usage (tag, crypto_usage) /\
+  has_local_fun split_kdf_expand_usage_get_label_params kdf_expand_usage.get_label (tag, crypto_usage)
+
+(*** Global kdf_expand usage builder ***)
+
+val mk_global_kdf_expand_usage_get_usage:
+  list (string & kdf_expand_crypto_usage) ->
+  prk_usage:usage{KdfExpandKey? prk_usage} -> info:bytes ->
+  usage
+let mk_global_kdf_expand_usage_get_usage l =
+  mk_global_fun (split_kdf_expand_usage_get_usage_params) l
+
+val mk_global_kdf_expand_usage_get_label:
+  list (string & kdf_expand_crypto_usage) ->
+  prk_usage:usage{KdfExpandKey? prk_usage} -> prk_label:label -> info:bytes ->
+  label
+let mk_global_kdf_expand_usage_get_label l =
+  mk_global_fun (split_kdf_expand_usage_get_label_params) l
+
+val mk_global_kdf_expand_usage_correct:
+  cusgs:crypto_usages -> lusages:list (string & kdf_expand_crypto_usage) ->
+  Lemma
+  (requires
+    kdf_expand_usage.get_usage == mk_global_kdf_expand_usage_get_usage lusages /\
+    kdf_expand_usage.get_label == mk_global_kdf_expand_usage_get_label lusages /\
+    List.Tot.no_repeats_p (List.Tot.map fst lusages)
+  )
+  (ensures for_allP (has_kdf_expand_usage cusgs) lusages)
+let mk_global_kdf_expand_usage_correct cusgs lusages =
+  no_repeats_p_implies_for_all_pairsP_unequal (List.Tot.map fst lusages);
+  for_allP_eq (has_kdf_expand_usage cusgs) lusages;
+  FStar.Classical.forall_intro_2 (FStar.Classical.move_requires_2 (mk_global_fun_correct split_kdf_expand_usage_get_usage_params lusages));
+  FStar.Classical.forall_intro_2 (FStar.Classical.move_requires_2 (mk_global_fun_correct split_kdf_expand_usage_get_label_params lusages))
+
+val mk_global_kdf_expand_usage_get_label_lemma:
+  lusages:list (string & kdf_expand_crypto_usage) ->
+  tr:trace ->
+  prk_usage:usage{KdfExpandKey? prk_usage} -> prk_label:label -> info:bytes ->
+  Lemma ((mk_global_kdf_expand_usage_get_label lusages prk_usage prk_label info) `can_flow tr` prk_label)
+let mk_global_kdf_expand_usage_get_label_lemma lusages tr prk_usage prk_label info =
+  mk_global_fun_eq split_kdf_expand_usage_get_label_params lusages (prk_usage, prk_label, info);
+  introduce forall lusages. split_kdf_expand_usage_get_label_params.apply_local_fun lusages (prk_usage, prk_label, info) `can_flow tr` prk_label with (
+    lusages.get_label_lemma tr prk_usage prk_label info
+  )
+
+val mk_kdf_expand_usage: list (string & kdf_expand_crypto_usage) -> kdf_expand_crypto_usage
+let mk_kdf_expand_usage lusages = {
+  get_usage = mk_global_kdf_expand_usage_get_usage lusages;
+  get_label = mk_global_kdf_expand_usage_get_label lusages;
+  get_label_lemma = mk_global_kdf_expand_usage_get_label_lemma lusages;
+}

--- a/src/lib/crypto/DY.Lib.Crypto.KdfExpand.Split.fst
+++ b/src/lib/crypto/DY.Lib.Crypto.KdfExpand.Split.fst
@@ -73,45 +73,45 @@ val mk_global_kdf_expand_usage_get_usage:
   list (string & kdf_expand_crypto_usage) ->
   prk_usage:usage{KdfExpandKey? prk_usage} -> info:bytes ->
   usage
-let mk_global_kdf_expand_usage_get_usage l =
-  mk_global_fun (split_kdf_expand_usage_get_usage_params) l
+let mk_global_kdf_expand_usage_get_usage tagged_local_invariants =
+  mk_global_fun (split_kdf_expand_usage_get_usage_params) tagged_local_invariants
 
 val mk_global_kdf_expand_usage_get_label:
   list (string & kdf_expand_crypto_usage) ->
   prk_usage:usage{KdfExpandKey? prk_usage} -> prk_label:label -> info:bytes ->
   label
-let mk_global_kdf_expand_usage_get_label l =
-  mk_global_fun (split_kdf_expand_usage_get_label_params) l
+let mk_global_kdf_expand_usage_get_label tagged_local_invariants =
+  mk_global_fun (split_kdf_expand_usage_get_label_params) tagged_local_invariants
 
 val mk_global_kdf_expand_usage_correct:
-  cusgs:crypto_usages -> lusages:list (string & kdf_expand_crypto_usage) ->
+  cusgs:crypto_usages -> tagged_local_invariants:list (string & kdf_expand_crypto_usage) ->
   Lemma
   (requires
-    kdf_expand_usage.get_usage == mk_global_kdf_expand_usage_get_usage lusages /\
-    kdf_expand_usage.get_label == mk_global_kdf_expand_usage_get_label lusages /\
-    List.Tot.no_repeats_p (List.Tot.map fst lusages)
+    kdf_expand_usage.get_usage == mk_global_kdf_expand_usage_get_usage tagged_local_invariants /\
+    kdf_expand_usage.get_label == mk_global_kdf_expand_usage_get_label tagged_local_invariants /\
+    List.Tot.no_repeats_p (List.Tot.map fst tagged_local_invariants)
   )
-  (ensures for_allP (has_kdf_expand_usage cusgs) lusages)
-let mk_global_kdf_expand_usage_correct cusgs lusages =
-  no_repeats_p_implies_for_all_pairsP_unequal (List.Tot.map fst lusages);
-  for_allP_eq (has_kdf_expand_usage cusgs) lusages;
-  FStar.Classical.forall_intro_2 (FStar.Classical.move_requires_2 (mk_global_fun_correct split_kdf_expand_usage_get_usage_params lusages));
-  FStar.Classical.forall_intro_2 (FStar.Classical.move_requires_2 (mk_global_fun_correct split_kdf_expand_usage_get_label_params lusages))
+  (ensures for_allP (has_kdf_expand_usage cusgs) tagged_local_invariants)
+let mk_global_kdf_expand_usage_correct cusgs tagged_local_invariants =
+  no_repeats_p_implies_for_all_pairsP_unequal (List.Tot.map fst tagged_local_invariants);
+  for_allP_eq (has_kdf_expand_usage cusgs) tagged_local_invariants;
+  FStar.Classical.forall_intro_2 (FStar.Classical.move_requires_2 (mk_global_fun_correct split_kdf_expand_usage_get_usage_params tagged_local_invariants));
+  FStar.Classical.forall_intro_2 (FStar.Classical.move_requires_2 (mk_global_fun_correct split_kdf_expand_usage_get_label_params tagged_local_invariants))
 
 val mk_global_kdf_expand_usage_get_label_lemma:
-  lusages:list (string & kdf_expand_crypto_usage) ->
+  tagged_local_invariants:list (string & kdf_expand_crypto_usage) ->
   tr:trace ->
   prk_usage:usage{KdfExpandKey? prk_usage} -> prk_label:label -> info:bytes ->
-  Lemma ((mk_global_kdf_expand_usage_get_label lusages prk_usage prk_label info) `can_flow tr` prk_label)
-let mk_global_kdf_expand_usage_get_label_lemma lusages tr prk_usage prk_label info =
-  mk_global_fun_eq split_kdf_expand_usage_get_label_params lusages (prk_usage, prk_label, info);
-  introduce forall lusages. split_kdf_expand_usage_get_label_params.apply_local_fun lusages (prk_usage, prk_label, info) `can_flow tr` prk_label with (
-    lusages.get_label_lemma tr prk_usage prk_label info
+  Lemma ((mk_global_kdf_expand_usage_get_label tagged_local_invariants prk_usage prk_label info) `can_flow tr` prk_label)
+let mk_global_kdf_expand_usage_get_label_lemma tagged_local_invariants tr prk_usage prk_label info =
+  mk_global_fun_eq split_kdf_expand_usage_get_label_params tagged_local_invariants (prk_usage, prk_label, info);
+  introduce forall tagged_local_invariants. split_kdf_expand_usage_get_label_params.apply_local_fun tagged_local_invariants (prk_usage, prk_label, info) `can_flow tr` prk_label with (
+    tagged_local_invariants.get_label_lemma tr prk_usage prk_label info
   )
 
 val mk_kdf_expand_usage: list (string & kdf_expand_crypto_usage) -> kdf_expand_crypto_usage
-let mk_kdf_expand_usage lusages = {
-  get_usage = mk_global_kdf_expand_usage_get_usage lusages;
-  get_label = mk_global_kdf_expand_usage_get_label lusages;
-  get_label_lemma = mk_global_kdf_expand_usage_get_label_lemma lusages;
+let mk_kdf_expand_usage tagged_local_invariants = {
+  get_usage = mk_global_kdf_expand_usage_get_usage tagged_local_invariants;
+  get_label = mk_global_kdf_expand_usage_get_label tagged_local_invariants;
+  get_label_lemma = mk_global_kdf_expand_usage_get_label_lemma tagged_local_invariants;
 }

--- a/src/lib/crypto/DY.Lib.Crypto.PkEncryption.Split.fst
+++ b/src/lib/crypto/DY.Lib.Crypto.PkEncryption.Split.fst
@@ -47,33 +47,33 @@ let mk_global_pkenc_predicate #cusgs l =
   mk_global_fun (split_pkenc_predicate_params cusgs) l
 
 val mk_global_pkenc_predicate_correct:
-  cinvs:crypto_invariants -> lpreds:list (string & pkenc_crypto_predicate cinvs.usages) ->
+  cinvs:crypto_invariants -> tagged_local_preds:list (string & pkenc_crypto_predicate cinvs.usages) ->
   Lemma
   (requires
-    pkenc_pred.pred == mk_global_pkenc_predicate lpreds /\
-    List.Tot.no_repeats_p (List.Tot.map fst lpreds)
+    pkenc_pred.pred == mk_global_pkenc_predicate tagged_local_preds /\
+    List.Tot.no_repeats_p (List.Tot.map fst tagged_local_preds)
   )
-  (ensures for_allP (has_pkenc_predicate cinvs) lpreds)
-let mk_global_pkenc_predicate_correct cinvs lpreds =
-  no_repeats_p_implies_for_all_pairsP_unequal (List.Tot.map fst lpreds);
-  for_allP_eq (has_pkenc_predicate cinvs) lpreds;
-  FStar.Classical.forall_intro_2 (FStar.Classical.move_requires_2 (mk_global_fun_correct (split_pkenc_predicate_params cinvs.usages) lpreds))
+  (ensures for_allP (has_pkenc_predicate cinvs) tagged_local_preds)
+let mk_global_pkenc_predicate_correct cinvs tagged_local_preds =
+  no_repeats_p_implies_for_all_pairsP_unequal (List.Tot.map fst tagged_local_preds);
+  for_allP_eq (has_pkenc_predicate cinvs) tagged_local_preds;
+  FStar.Classical.forall_intro_2 (FStar.Classical.move_requires_2 (mk_global_fun_correct (split_pkenc_predicate_params cinvs.usages) tagged_local_preds))
 
 val mk_global_pkenc_predicate_later:
-  {|cusgs:crypto_usages|} -> lpreds:list (string & pkenc_crypto_predicate cusgs) ->
+  {|cusgs:crypto_usages|} -> tagged_local_preds:list (string & pkenc_crypto_predicate cusgs) ->
   tr1:trace -> tr2:trace -> pk:bytes{PkdecKey? (get_sk_usage pk)} -> msg:bytes ->
   Lemma
-  (requires mk_global_pkenc_predicate lpreds tr1 pk msg  /\ tr1 <$ tr2)
-  (ensures mk_global_pkenc_predicate lpreds tr2 pk msg)
-let mk_global_pkenc_predicate_later #cusgs lpreds tr1 tr2 pk msg  =
-  mk_global_fun_eq (split_pkenc_predicate_params cusgs) lpreds (tr1, pk, msg);
-  mk_global_fun_eq (split_pkenc_predicate_params cusgs) lpreds (tr2, pk, msg);
+  (requires mk_global_pkenc_predicate tagged_local_preds tr1 pk msg  /\ tr1 <$ tr2)
+  (ensures mk_global_pkenc_predicate tagged_local_preds tr2 pk msg)
+let mk_global_pkenc_predicate_later #cusgs tagged_local_preds tr1 tr2 pk msg  =
+  mk_global_fun_eq (split_pkenc_predicate_params cusgs) tagged_local_preds (tr1, pk, msg);
+  mk_global_fun_eq (split_pkenc_predicate_params cusgs) tagged_local_preds (tr2, pk, msg);
   introduce forall lpred. (split_pkenc_predicate_params cusgs).apply_local_fun lpred (tr1, pk, msg) ==> (split_pkenc_predicate_params cusgs).apply_local_fun lpred (tr2, pk, msg) with (
     introduce _ ==> _ with _. lpred.pred_later tr1 tr2 pk msg
   )
 
 val mk_pkenc_predicate: {|cusgs:crypto_usages|} -> list (string & pkenc_crypto_predicate cusgs) -> pkenc_crypto_predicate cusgs
-let mk_pkenc_predicate #cusgs lpreds = {
-  pred = mk_global_pkenc_predicate lpreds;
-  pred_later = mk_global_pkenc_predicate_later lpreds;
+let mk_pkenc_predicate #cusgs tagged_local_preds = {
+  pred = mk_global_pkenc_predicate tagged_local_preds;
+  pred_later = mk_global_pkenc_predicate_later tagged_local_preds;
 }

--- a/src/lib/crypto/DY.Lib.Crypto.PkEncryption.Split.fst
+++ b/src/lib/crypto/DY.Lib.Crypto.PkEncryption.Split.fst
@@ -5,15 +5,15 @@ open DY.Core
 open DY.Lib.Crypto.SplitPredicate
 
 let split_pkenc_predicate_params (cusages:crypto_usages): split_crypto_predicate_parameters = {
-  key_t = pk:bytes{PkdecKey? (get_sk_usage pk)};
+  key_t = pk:bytes{PkKey? (get_sk_usage pk)};
   data_t = bytes;
   get_usage = (fun pk ->
-    let PkdecKey tag _ = get_sk_usage pk in
+    let PkKey tag _ = get_sk_usage pk in
     tag
   );
 
   local_pred_t = pkenc_crypto_predicate cusages;
-  global_pred_t = tr:trace -> pk:bytes{PkdecKey? (get_sk_usage pk)} -> msg:bytes -> prop;
+  global_pred_t = tr:trace -> pk:bytes{PkKey? (get_sk_usage pk)} -> msg:bytes -> prop;
 
   apply_local_pred = (fun pred (tr, pk, msg) ->
     pred.pred tr pk msg

--- a/src/lib/crypto/DY.Lib.Crypto.PkEncryption.Split.fst
+++ b/src/lib/crypto/DY.Lib.Crypto.PkEncryption.Split.fst
@@ -1,0 +1,79 @@
+module DY.Lib.Crypto.PkEncryption.Split
+
+open Comparse // for_allP, for_allP_eq
+open DY.Core
+open DY.Lib.SplitFunction
+
+let split_pkenc_predicate_params (cusages:crypto_usages) = {
+  singleton_split_function_parameters string with
+
+  tagged_data_t = (trace & (pk:bytes{PkdecKey? (get_sk_usage pk)}) & bytes);
+  raw_data_t = (trace & (pk:bytes{PkdecKey? (get_sk_usage pk)}) & bytes);
+  output_t = prop;
+
+  decode_tagged_data = (fun (tr, pk, msg) ->
+    let PkdecKey tag _ = get_sk_usage pk in
+    Some (tag, (tr, pk, msg))
+  );
+
+  local_fun_t = pkenc_crypto_predicate cusages;
+  global_fun_t = trace -> pk:bytes{PkdecKey? (get_sk_usage pk)} -> msg:bytes -> prop;
+
+  default_global_fun = (fun tr pk msg -> False);
+
+  apply_local_fun = (fun pred (tr, pk, msg) ->
+    pred.pred tr pk msg
+  );
+  apply_global_fun = (fun pred (tr, pk, msg) ->
+    pred tr pk msg
+  );
+  mk_global_fun = (fun pred tr pk msg ->
+    pred (tr, pk, msg)
+  );
+  apply_mk_global_fun = (fun bare x -> ());
+}
+
+val has_pkenc_predicate: cinvs:crypto_invariants -> (string & pkenc_crypto_predicate cinvs.usages) -> prop
+let has_pkenc_predicate cinvs (tag, pred) =
+  has_local_fun (split_pkenc_predicate_params cinvs.usages) pkenc_pred.pred (tag, pred)
+
+(*** Global pkenc predicate builder ***)
+
+val mk_global_pkenc_predicate:
+  {|cusgs:crypto_usages|} ->
+  list (string & pkenc_crypto_predicate cusgs) ->
+  trace -> pk:bytes{PkdecKey? (get_sk_usage pk)} -> msg:bytes -> prop
+let mk_global_pkenc_predicate #cusgs l =
+  mk_global_fun (split_pkenc_predicate_params cusgs) l
+
+val mk_global_pkenc_predicate_correct:
+  cinvs:crypto_invariants -> lpreds:list (string & pkenc_crypto_predicate cinvs.usages) ->
+  Lemma
+  (requires
+    pkenc_pred.pred == mk_global_pkenc_predicate lpreds /\
+    List.Tot.no_repeats_p (List.Tot.map fst lpreds)
+  )
+  (ensures for_allP (has_pkenc_predicate cinvs) lpreds)
+let mk_global_pkenc_predicate_correct cinvs lpreds =
+  no_repeats_p_implies_for_all_pairsP_unequal (List.Tot.map fst lpreds);
+  for_allP_eq (has_pkenc_predicate cinvs) lpreds;
+  FStar.Classical.forall_intro_2 (FStar.Classical.move_requires_2 (mk_global_fun_correct (split_pkenc_predicate_params cinvs.usages) lpreds))
+
+val mk_global_pkenc_predicate_later:
+  {|cusgs:crypto_usages|} -> lpreds:list (string & pkenc_crypto_predicate cusgs) ->
+  tr1:trace -> tr2:trace -> pk:bytes{PkdecKey? (get_sk_usage pk)} -> msg:bytes ->
+  Lemma
+  (requires mk_global_pkenc_predicate lpreds tr1 pk msg  /\ tr1 <$ tr2)
+  (ensures mk_global_pkenc_predicate lpreds tr2 pk msg)
+let mk_global_pkenc_predicate_later #cusgs lpreds tr1 tr2 pk msg  =
+  mk_global_fun_eq (split_pkenc_predicate_params cusgs) lpreds (tr1, pk, msg);
+  mk_global_fun_eq (split_pkenc_predicate_params cusgs) lpreds (tr2, pk, msg);
+  introduce forall lpred. (split_pkenc_predicate_params cusgs).apply_local_fun lpred (tr1, pk, msg) ==> (split_pkenc_predicate_params cusgs).apply_local_fun lpred (tr2, pk, msg) with (
+    introduce _ ==> _ with _. lpred.pred_later tr1 tr2 pk msg
+  )
+
+val mk_pkenc_predicate: {|cusgs:crypto_usages|} -> list (string & pkenc_crypto_predicate cusgs) -> pkenc_crypto_predicate cusgs
+let mk_pkenc_predicate #cusgs lpreds = {
+  pred = mk_global_pkenc_predicate lpreds;
+  pred_later = mk_global_pkenc_predicate_later lpreds;
+}

--- a/src/lib/crypto/DY.Lib.Crypto.PkEncryption.Split.fst
+++ b/src/lib/crypto/DY.Lib.Crypto.PkEncryption.Split.fst
@@ -4,7 +4,7 @@ open Comparse // for_allP, for_allP_eq
 open DY.Core
 open DY.Lib.SplitFunction
 
-let split_pkenc_predicate_params (cusages:crypto_usages) = {
+let split_pkenc_predicate_params (cusages:crypto_usages): split_function_parameters = {
   singleton_split_function_parameters string with
 
   tagged_data_t = (trace & (pk:bytes{PkdecKey? (get_sk_usage pk)}) & bytes);

--- a/src/lib/crypto/DY.Lib.Crypto.Signature.Split.fst
+++ b/src/lib/crypto/DY.Lib.Crypto.Signature.Split.fst
@@ -2,78 +2,58 @@ module DY.Lib.Crypto.Signature.Split
 
 open Comparse // for_allP, for_allP_eq
 open DY.Core
-open DY.Lib.SplitFunction
+open DY.Lib.Crypto.SplitPredicate
 
-let split_sign_predicate_params (cusages:crypto_usages): split_function_parameters = {
-  singleton_split_function_parameters string with
-
-  tagged_data_t = (trace & (vk:bytes{SigKey? (get_signkey_usage vk)}) & bytes);
-  raw_data_t = (trace & (vk:bytes{SigKey? (get_signkey_usage vk)}) & bytes);
-  output_t = prop;
-
-  decode_tagged_data = (fun (tr, vk, msg) ->
-    let SigKey tag _ = get_signkey_usage vk in
-    Some (tag, (tr, vk, msg))
+let split_sign_predicate_params (cusages:crypto_usages): split_crypto_predicate_parameters = {
+  key_t = vk:bytes{SigKey? (get_signkey_usage vk)};
+  data_t = bytes;
+  get_usage = (fun pk ->
+    let SigKey tag _ = get_signkey_usage pk in
+    tag
   );
 
-  local_fun_t = sign_crypto_predicate cusages;
-  global_fun_t = trace -> vk:bytes{SigKey? (get_signkey_usage vk)} -> msg:bytes -> prop;
+  local_pred_t = sign_crypto_predicate cusages;
+  global_pred_t = tr:trace -> vk:bytes{SigKey? (get_signkey_usage vk)} -> msg:bytes -> prop;
 
-  default_global_fun = (fun tr vk msg -> False);
-
-  apply_local_fun = (fun pred (tr, vk, msg) ->
+  apply_local_pred = (fun pred (tr, vk, msg) ->
     pred.pred tr vk msg
   );
-  apply_global_fun = (fun pred (tr, vk, msg) ->
+  apply_global_pred = (fun pred (tr, vk, msg) ->
     pred tr vk msg
   );
-  mk_global_fun = (fun pred tr vk msg ->
+  mk_global_pred = (fun pred tr vk msg ->
     pred (tr, vk, msg)
   );
-  apply_mk_global_fun = (fun bare x -> ());
+
+  apply_mk_global_pred = (fun bare x -> ());
+  apply_local_pred_later = (fun lpred tr1 tr2 vk msg ->
+    lpred.pred_later tr1 tr2 vk msg
+  );
 }
 
 val has_sign_predicate: cinvs:crypto_invariants -> (string & sign_crypto_predicate cinvs.usages) -> prop
 let has_sign_predicate cinvs (tag, pred) =
-  has_local_fun (split_sign_predicate_params cinvs.usages) sign_pred.pred (tag, pred)
+  has_local_crypto_predicate (split_sign_predicate_params cinvs.usages) sign_pred.pred (tag, pred)
 
 (*** Global sign predicate builder ***)
 
-val mk_global_sign_predicate:
+val mk_sign_predicate:
   {|cusgs:crypto_usages|} ->
   list (string & sign_crypto_predicate cusgs) ->
-  trace -> vk:bytes{SigKey? (get_signkey_usage vk)} -> msg:bytes -> prop
-let mk_global_sign_predicate #cusgs l =
-  mk_global_fun (split_sign_predicate_params cusgs) l
+  sign_crypto_predicate cusgs
+let mk_sign_predicate #cusgs l = {
+  pred = mk_global_crypto_predicate (split_sign_predicate_params cusgs) l;
+  pred_later = mk_global_crypto_predicate_later (split_sign_predicate_params cusgs) l;
+}
 
-val mk_global_sign_predicate_correct:
+val mk_sign_predicate_correct:
   cinvs:crypto_invariants -> tagged_local_preds:list (string & sign_crypto_predicate cinvs.usages) ->
   Lemma
   (requires
-    sign_pred.pred == mk_global_sign_predicate tagged_local_preds /\
+    sign_pred == mk_sign_predicate tagged_local_preds /\
     List.Tot.no_repeats_p (List.Tot.map fst tagged_local_preds)
   )
   (ensures for_allP (has_sign_predicate cinvs) tagged_local_preds)
-let mk_global_sign_predicate_correct cinvs tagged_local_preds =
-  no_repeats_p_implies_for_all_pairsP_unequal (List.Tot.map fst tagged_local_preds);
+let mk_sign_predicate_correct cinvs tagged_local_preds =
   for_allP_eq (has_sign_predicate cinvs) tagged_local_preds;
-  FStar.Classical.forall_intro_2 (FStar.Classical.move_requires_2 (mk_global_fun_correct (split_sign_predicate_params cinvs.usages) tagged_local_preds))
-
-val mk_global_sign_predicate_later:
-  {|cusgs:crypto_usages|} -> tagged_local_preds:list (string & sign_crypto_predicate cusgs) ->
-  tr1:trace -> tr2:trace -> vk:bytes{SigKey? (get_signkey_usage vk)} -> msg:bytes ->
-  Lemma
-  (requires mk_global_sign_predicate tagged_local_preds tr1 vk msg  /\ tr1 <$ tr2)
-  (ensures mk_global_sign_predicate tagged_local_preds tr2 vk msg)
-let mk_global_sign_predicate_later #cusgs tagged_local_preds tr1 tr2 vk msg  =
-  mk_global_fun_eq (split_sign_predicate_params cusgs) tagged_local_preds (tr1, vk, msg);
-  mk_global_fun_eq (split_sign_predicate_params cusgs) tagged_local_preds (tr2, vk, msg);
-  introduce forall lpred. (split_sign_predicate_params cusgs).apply_local_fun lpred (tr1, vk, msg) ==> (split_sign_predicate_params cusgs).apply_local_fun lpred (tr2, vk, msg) with (
-    introduce _ ==> _ with _. lpred.pred_later tr1 tr2 vk msg
-  )
-
-val mk_sign_predicate: {|cusgs:crypto_usages|} -> list (string & sign_crypto_predicate cusgs) -> sign_crypto_predicate cusgs
-let mk_sign_predicate #cusgs tagged_local_preds = {
-  pred = mk_global_sign_predicate tagged_local_preds;
-  pred_later = mk_global_sign_predicate_later tagged_local_preds;
-}
+  FStar.Classical.forall_intro_2 (FStar.Classical.move_requires_2 (mk_global_crypto_predicate_correct (split_sign_predicate_params cinvs.usages) tagged_local_preds))

--- a/src/lib/crypto/DY.Lib.Crypto.Signature.Split.fst
+++ b/src/lib/crypto/DY.Lib.Crypto.Signature.Split.fst
@@ -4,7 +4,7 @@ open Comparse // for_allP, for_allP_eq
 open DY.Core
 open DY.Lib.SplitFunction
 
-let split_sign_predicate_params (cusages:crypto_usages) = {
+let split_sign_predicate_params (cusages:crypto_usages): split_function_parameters = {
   singleton_split_function_parameters string with
 
   tagged_data_t = (trace & (vk:bytes{SigKey? (get_signkey_usage vk)}) & bytes);

--- a/src/lib/crypto/DY.Lib.Crypto.Signature.Split.fst
+++ b/src/lib/crypto/DY.Lib.Crypto.Signature.Split.fst
@@ -1,0 +1,79 @@
+module DY.Lib.Crypto.Signature.Split
+
+open Comparse // for_allP, for_allP_eq
+open DY.Core
+open DY.Lib.SplitFunction
+
+let split_sign_predicate_params (cusages:crypto_usages) = {
+  singleton_split_function_parameters string with
+
+  tagged_data_t = (trace & (vk:bytes{SigKey? (get_signkey_usage vk)}) & bytes);
+  raw_data_t = (trace & (vk:bytes{SigKey? (get_signkey_usage vk)}) & bytes);
+  output_t = prop;
+
+  decode_tagged_data = (fun (tr, vk, msg) ->
+    let SigKey tag _ = get_signkey_usage vk in
+    Some (tag, (tr, vk, msg))
+  );
+
+  local_fun_t = sign_crypto_predicate cusages;
+  global_fun_t = trace -> vk:bytes{SigKey? (get_signkey_usage vk)} -> msg:bytes -> prop;
+
+  default_global_fun = (fun tr vk msg -> False);
+
+  apply_local_fun = (fun pred (tr, vk, msg) ->
+    pred.pred tr vk msg
+  );
+  apply_global_fun = (fun pred (tr, vk, msg) ->
+    pred tr vk msg
+  );
+  mk_global_fun = (fun pred tr vk msg ->
+    pred (tr, vk, msg)
+  );
+  apply_mk_global_fun = (fun bare x -> ());
+}
+
+val has_sign_predicate: cinvs:crypto_invariants -> (string & sign_crypto_predicate cinvs.usages) -> prop
+let has_sign_predicate cinvs (tag, pred) =
+  has_local_fun (split_sign_predicate_params cinvs.usages) sign_pred.pred (tag, pred)
+
+(*** Global sign predicate builder ***)
+
+val mk_global_sign_predicate:
+  {|cusgs:crypto_usages|} ->
+  list (string & sign_crypto_predicate cusgs) ->
+  trace -> vk:bytes{SigKey? (get_signkey_usage vk)} -> msg:bytes -> prop
+let mk_global_sign_predicate #cusgs l =
+  mk_global_fun (split_sign_predicate_params cusgs) l
+
+val mk_global_sign_predicate_correct:
+  cinvs:crypto_invariants -> lpreds:list (string & sign_crypto_predicate cinvs.usages) ->
+  Lemma
+  (requires
+    sign_pred.pred == mk_global_sign_predicate lpreds /\
+    List.Tot.no_repeats_p (List.Tot.map fst lpreds)
+  )
+  (ensures for_allP (has_sign_predicate cinvs) lpreds)
+let mk_global_sign_predicate_correct cinvs lpreds =
+  no_repeats_p_implies_for_all_pairsP_unequal (List.Tot.map fst lpreds);
+  for_allP_eq (has_sign_predicate cinvs) lpreds;
+  FStar.Classical.forall_intro_2 (FStar.Classical.move_requires_2 (mk_global_fun_correct (split_sign_predicate_params cinvs.usages) lpreds))
+
+val mk_global_sign_predicate_later:
+  {|cusgs:crypto_usages|} -> lpreds:list (string & sign_crypto_predicate cusgs) ->
+  tr1:trace -> tr2:trace -> vk:bytes{SigKey? (get_signkey_usage vk)} -> msg:bytes ->
+  Lemma
+  (requires mk_global_sign_predicate lpreds tr1 vk msg  /\ tr1 <$ tr2)
+  (ensures mk_global_sign_predicate lpreds tr2 vk msg)
+let mk_global_sign_predicate_later #cusgs lpreds tr1 tr2 vk msg  =
+  mk_global_fun_eq (split_sign_predicate_params cusgs) lpreds (tr1, vk, msg);
+  mk_global_fun_eq (split_sign_predicate_params cusgs) lpreds (tr2, vk, msg);
+  introduce forall lpred. (split_sign_predicate_params cusgs).apply_local_fun lpred (tr1, vk, msg) ==> (split_sign_predicate_params cusgs).apply_local_fun lpred (tr2, vk, msg) with (
+    introduce _ ==> _ with _. lpred.pred_later tr1 tr2 vk msg
+  )
+
+val mk_sign_predicate: {|cusgs:crypto_usages|} -> list (string & sign_crypto_predicate cusgs) -> sign_crypto_predicate cusgs
+let mk_sign_predicate #cusgs lpreds = {
+  pred = mk_global_sign_predicate lpreds;
+  pred_later = mk_global_sign_predicate_later lpreds;
+}

--- a/src/lib/crypto/DY.Lib.Crypto.SplitPredicate.fst
+++ b/src/lib/crypto/DY.Lib.Crypto.SplitPredicate.fst
@@ -1,0 +1,101 @@
+module DY.Lib.Crypto.SplitPredicate
+
+open DY.Core
+open DY.Lib.SplitFunction
+
+noeq
+type split_crypto_predicate_parameters = {
+  key_t: Type;
+  data_t: Type;
+  get_usage: key_t -> string;
+
+  local_pred_t: Type;
+  global_pred_t: Type;
+
+  apply_local_pred: local_pred_t -> (trace & key_t & data_t) -> prop;
+  apply_global_pred: global_pred_t -> (trace & key_t & data_t) -> prop;
+  mk_global_pred: ((trace & key_t & data_t) -> prop) -> global_pred_t;
+
+  apply_mk_global_pred: bare:((trace & key_t & data_t) -> prop) -> x:(trace & key_t & data_t) -> Lemma
+    (apply_global_pred (mk_global_pred bare) x == bare x);
+  apply_local_pred_later:
+    lpred: local_pred_t ->
+    tr1:trace -> tr2:trace ->
+    key:key_t -> data:data_t ->
+    Lemma
+    (requires apply_local_pred lpred (tr1, key, data) /\ tr1 <$ tr2)
+    (ensures apply_local_pred lpred (tr2, key, data))
+  ;
+}
+
+val always_false: #a:Type -> a -> prop
+let always_false #a x = False
+
+let split_crypto_predicate_parameters_to_split_function_parameters (params:split_crypto_predicate_parameters): split_function_parameters = {
+  singleton_split_function_parameters string with
+
+  tagged_data_t = (trace & params.key_t & params.data_t);
+  raw_data_t = (trace & params.key_t & params.data_t);
+  output_t = prop;
+
+  decode_tagged_data = (fun (tr, key, data) ->
+    let tag = params.get_usage key in
+    Some (tag, (tr, key, data))
+  );
+
+  local_fun_t = params.local_pred_t;
+  global_fun_t = params.global_pred_t;
+
+  default_global_fun = params.mk_global_pred always_false;
+
+  apply_local_fun = params.apply_local_pred;
+  apply_global_fun = params.apply_global_pred;
+  mk_global_fun = params.mk_global_pred;
+  apply_mk_global_fun = params.apply_mk_global_pred;
+}
+
+val has_local_crypto_predicate:
+  params:split_crypto_predicate_parameters ->
+  params.global_pred_t -> (string & params.local_pred_t) ->
+  prop
+let has_local_crypto_predicate params global_pred (tag, local_pred) =
+  has_local_fun (split_crypto_predicate_parameters_to_split_function_parameters params) global_pred (tag, local_pred)
+
+val mk_global_crypto_predicate:
+  params:split_crypto_predicate_parameters ->
+  list (string & params.local_pred_t) ->
+  params.global_pred_t
+let mk_global_crypto_predicate params tagged_local_preds =
+  mk_global_fun (split_crypto_predicate_parameters_to_split_function_parameters params) tagged_local_preds
+
+val mk_global_crypto_predicate_later:
+  params:split_crypto_predicate_parameters ->
+  tagged_local_preds:list (string & params.local_pred_t) ->
+  tr1:trace -> tr2:trace ->
+  key:params.key_t -> data:params.data_t ->
+  Lemma
+  (requires params.apply_global_pred (mk_global_crypto_predicate params tagged_local_preds) (tr1, key, data) /\ tr1 <$ tr2)
+  (ensures params.apply_global_pred (mk_global_crypto_predicate params tagged_local_preds) (tr2, key, data))
+let mk_global_crypto_predicate_later params tagged_local_preds tr1 tr2 key data =
+  let fparams = split_crypto_predicate_parameters_to_split_function_parameters params in
+  params.apply_mk_global_pred always_false (tr1, key, data);
+  mk_global_fun_eq fparams tagged_local_preds (tr1, key, data);
+  mk_global_fun_eq fparams tagged_local_preds (tr2, key, data);
+  introduce forall lpred. fparams.apply_local_fun lpred (tr1, key, data) ==> fparams.apply_local_fun lpred (tr2, key, data) with (
+    introduce _ ==> _ with _. params.apply_local_pred_later lpred tr1 tr2 key data
+  )
+
+val mk_global_crypto_predicate_correct:
+  params:split_crypto_predicate_parameters ->
+  tagged_local_preds:list (string & params.local_pred_t) ->
+  tag:string -> local_pred:params.local_pred_t ->
+  Lemma
+  (requires
+    FStar.List.Tot.no_repeats_p (List.Tot.map fst tagged_local_preds) /\
+    List.Tot.memP (tag, local_pred) tagged_local_preds
+  )
+  (ensures has_local_crypto_predicate params (mk_global_crypto_predicate params tagged_local_preds) (tag, local_pred))
+let mk_global_crypto_predicate_correct params tagged_local_preds tag local_pred =
+  no_repeats_p_implies_for_all_pairsP_unequal (List.Tot.map fst tagged_local_preds);
+  mk_global_fun_correct (split_crypto_predicate_parameters_to_split_function_parameters params) tagged_local_preds tag local_pred
+

--- a/src/lib/crypto/DY.Lib.Crypto.SplitPredicate.fst
+++ b/src/lib/crypto/DY.Lib.Crypto.SplitPredicate.fst
@@ -3,6 +3,13 @@ module DY.Lib.Crypto.SplitPredicate
 open DY.Core
 open DY.Lib.SplitFunction
 
+/// This module defines a library to create a global cryptographic predicate from several independent local predicates.
+/// This is based on the DY.Lib.SplitFunction module,
+/// and is specific to cryptographic predicates that follow a specific shape,
+/// where the tag is a string derived from the usage of the key,
+/// and the predicate stays true when the trace grows.
+/// For these specific cryptographic predicates, this module allows to define predicate splitting with little boilerplate.
+
 noeq
 type split_crypto_predicate_parameters = {
   key_t: Type;


### PR DESCRIPTION
Everything is in the title, this will allow to define cryptographic invariants modularly.
I tackled every cryptographic invariant that fits nicely in this framework, in particular, I left DH and KDF.Extract for future work.

The diff is big because this PR is based on the merge of #35 and #41, only the last commit is relevant (until we merge the two aforementioned PRs)