### PR TITLE
fix: make `has_..._predicate` SMT-friendly

### DIFF
--- a/src/lib/crypto/DY.Lib.Crypto.AEAD.Split.fst
+++ b/src/lib/crypto/DY.Lib.Crypto.AEAD.Split.fst
@@ -32,8 +32,32 @@ let split_aead_predicate_params (cusages:crypto_usages): split_crypto_predicate_
 }
 
 val has_aead_predicate: cinvs:crypto_invariants -> (string & aead_crypto_predicate cinvs.usages) -> prop
-let has_aead_predicate cinvs (tag, pred) =
-  has_local_crypto_predicate (split_aead_predicate_params cinvs.usages) aead_pred.pred (tag, pred)
+let has_aead_predicate cinvs (tag, local_pred) =
+  forall (tr:trace) (key:bytes) (nonce:bytes) (msg:bytes) (ad:bytes).
+    {:pattern aead_pred.pred tr key nonce msg ad}
+    match get_usage key with
+    | AeadKey aead_tag _ ->
+        aead_tag = tag ==> aead_pred.pred tr key nonce msg ad == local_pred.pred tr key nonce msg ad
+    | _ -> True
+
+val intro_has_aead_predicate:
+  cinvs:crypto_invariants -> tagged_local_pred:(string & aead_crypto_predicate cinvs.usages) ->
+  Lemma
+  (requires has_local_crypto_predicate (split_aead_predicate_params cinvs.usages) aead_pred.pred tagged_local_pred)
+  (ensures has_aead_predicate cinvs tagged_local_pred)
+let intro_has_aead_predicate cinvs (tag, local_pred) =
+  introduce
+    forall tr key nonce msg ad.
+      match get_usage key with
+      | AeadKey aead_tag _ ->
+          aead_tag = tag ==> aead_pred.pred tr key nonce msg ad == local_pred.pred tr key nonce msg ad
+      | _ -> True
+  with (
+    match get_usage key with
+    | AeadKey aead_tag _ ->
+      has_local_crypto_predicate_elim (split_aead_predicate_params cinvs.usages) cinvs.preds.aead_pred.pred tag local_pred tr key (nonce, msg, ad)
+    | _ -> ()
+  )
 
 (*** Global aead predicate builder ***)
 
@@ -56,4 +80,5 @@ val mk_aead_predicate_correct:
   (ensures for_allP (has_aead_predicate cinvs) tagged_local_preds)
 let mk_aead_predicate_correct cinvs tagged_local_preds =
   for_allP_eq (has_aead_predicate cinvs) tagged_local_preds;
-  FStar.Classical.forall_intro_2 (FStar.Classical.move_requires_2 (mk_global_crypto_predicate_correct (split_aead_predicate_params cinvs.usages) tagged_local_preds))
+  FStar.Classical.forall_intro_2 (FStar.Classical.move_requires_2 (mk_global_crypto_predicate_correct (split_aead_predicate_params cinvs.usages) tagged_local_preds));
+  FStar.Classical.forall_intro (FStar.Classical.move_requires (intro_has_aead_predicate cinvs))

--- a/src/lib/crypto/DY.Lib.Crypto.SplitPredicate.fst
+++ b/src/lib/crypto/DY.Lib.Crypto.SplitPredicate.fst
@@ -68,6 +68,18 @@ val has_local_crypto_predicate:
 let has_local_crypto_predicate params global_pred (tag, local_pred) =
   has_local_fun (split_crypto_predicate_parameters_to_split_function_parameters params) global_pred (tag, local_pred)
 
+val has_local_crypto_predicate_elim:
+  params:split_crypto_predicate_parameters ->
+  global_pred:params.global_pred_t -> tag:string -> local_pred:params.local_pred_t ->
+  tr:trace -> key:params.key_t -> data:params.data_t ->
+  Lemma
+  (requires has_local_crypto_predicate params global_pred (tag, local_pred))
+  (ensures
+    params.get_usage key == tag ==> (params.apply_global_pred global_pred (tr, key, data) == params.apply_local_pred local_pred (tr, key, data))
+  )
+let has_local_crypto_predicate_elim params global_pred tag local_pred tr key data =
+  has_local_fun_elim (split_crypto_predicate_parameters_to_split_function_parameters params) global_pred tag local_pred (tr, key, data)
+
 val mk_global_crypto_predicate:
   params:split_crypto_predicate_parameters ->
   list (string & params.local_pred_t) ->

--- a/src/lib/event/DY.Lib.Event.Typed.fst
+++ b/src/lib/event/DY.Lib.Event.Typed.fst
@@ -80,6 +80,7 @@ let compile_event_pred #a #ev epred tr prin content_bytes =
   | None -> False
   | Some(content) -> epred tr prin content
 
+[@@ "opaque_to_smt"]
 val has_compiled_event_pred:
   protocol_invariants -> (string & compiled_event_predicate) -> prop
 let has_compiled_event_pred invs (tag, epred) =
@@ -104,6 +105,7 @@ val mk_event_pred_correct: invs:protocol_invariants -> tagged_local_preds:list (
   )
   (ensures for_allP (has_compiled_event_pred invs) tagged_local_preds)
 let mk_event_pred_correct invs tagged_local_preds =
+  reveal_opaque (`%has_compiled_event_pred) (has_compiled_event_pred);
   no_repeats_p_implies_for_all_pairsP_unequal (List.Tot.map fst tagged_local_preds);
   for_allP_eq (has_compiled_event_pred invs) tagged_local_preds;
   FStar.Classical.forall_intro_2 (FStar.Classical.move_requires_2 (mk_global_fun_correct split_event_pred_params tagged_local_preds))
@@ -153,6 +155,7 @@ val trigger_event_trace_invariant:
    SMTPat (has_event_pred invs epred);
    SMTPat (trace_invariant tr)]
 let trigger_event_trace_invariant #invs #a #ev epred prin e tr =
+  reveal_opaque (`%has_compiled_event_pred) (has_compiled_event_pred);
   reveal_opaque (`%trigger_event) (trigger_event #a);
   reveal_opaque (`%event_triggered_at) (event_triggered_at #a);
   local_eq_global_lemma split_event_pred_params event_pred ev.tag (compile_event_pred epred) (tr, prin, ev.tag, serialize _ e) ev.tag (tr, prin, serialize _ e)
@@ -174,6 +177,7 @@ val event_triggered_at_implies_pred:
    SMTPat (trace_invariant tr);
   ]
 let event_triggered_at_implies_pred #invs #a #ev epred tr i prin e =
+  reveal_opaque (`%has_compiled_event_pred) (has_compiled_event_pred);
   reveal_opaque (`%event_triggered_at) (event_triggered_at #a);
   local_eq_global_lemma split_event_pred_params event_pred ev.tag (compile_event_pred epred) ((prefix tr i), prin, ev.tag, serialize _ e) ev.tag ((prefix tr i), prin, serialize _ e)
 

--- a/src/lib/state/DY.Lib.State.Tagged.fst
+++ b/src/lib/state/DY.Lib.State.Tagged.fst
@@ -70,6 +70,7 @@ let split_local_bytes_state_predicate_params {|crypto_invariants|} : split_funct
   apply_mk_global_fun = (fun bare x -> ());
 }
 
+[@@ "opaque_to_smt"]
 val has_local_bytes_state_predicate: protocol_invariants -> (string & local_bytes_state_predicate) -> prop
 let has_local_bytes_state_predicate invs (tag, spred) =
   has_local_fun split_local_bytes_state_predicate_params (state_pred) (tag, spred)
@@ -129,6 +130,7 @@ val mk_state_pred_correct: invs:protocol_invariants -> tagged_local_preds:list (
   )
   (ensures for_allP (has_local_bytes_state_predicate invs) tagged_local_preds)
 let mk_state_pred_correct invs tagged_local_preds =
+  reveal_opaque (`%has_local_bytes_state_predicate) (has_local_bytes_state_predicate);
   no_repeats_p_implies_for_all_pairsP_unequal (List.Tot.map fst tagged_local_preds);
   for_allP_eq (has_local_bytes_state_predicate invs) tagged_local_preds;
   FStar.Classical.forall_intro_2 (FStar.Classical.move_requires_2 (mk_global_fun_correct split_local_bytes_state_predicate_params tagged_local_preds))
@@ -180,6 +182,7 @@ val set_tagged_state_invariant:
    SMTPat (trace_invariant tr);
    SMTPat (has_local_bytes_state_predicate invs (tag, spred))]
 let set_tagged_state_invariant invs tag spred prin sess_id content tr =
+  reveal_opaque (`%has_local_bytes_state_predicate) (has_local_bytes_state_predicate);
   reveal_opaque (`%set_tagged_state) (set_tagged_state);
   reveal_opaque (`%tagged_state_was_set) (tagged_state_was_set);
   let full_content = {tag; content;} in
@@ -209,6 +212,7 @@ val get_tagged_state_invariant:
    SMTPat (trace_invariant tr);
    SMTPat (has_local_bytes_state_predicate invs (tag, spred))]
 let get_tagged_state_invariant invs tag spred prin sess_id tr =
+  reveal_opaque (`%has_local_bytes_state_predicate) (has_local_bytes_state_predicate);
   reveal_opaque (`%get_tagged_state) (get_tagged_state);
   let (opt_content, tr_out) = get_tagged_state tag prin sess_id tr in
   match opt_content with
@@ -235,6 +239,7 @@ val tagged_state_was_set_implies_pred:
    SMTPat (has_local_bytes_state_predicate invs (tag, spred));
   ]
 let tagged_state_was_set_implies_pred invs tr tag spred prin sess_id content =
+  reveal_opaque (`%has_local_bytes_state_predicate) (has_local_bytes_state_predicate);
   reveal_opaque (`%tagged_state_was_set) (tagged_state_was_set);
   let full_content = {tag; content;} in
   parse_serialize_inv_lemma #bytes tagged_state full_content;

--- a/src/lib/utils/DY.Lib.SplitFunction.fst
+++ b/src/lib/utils/DY.Lib.SplitFunction.fst
@@ -114,12 +114,28 @@ noeq type split_function_parameters = {
 /// This will be a crucial precondition for the correctness theorem `local_eq_global_lemma`.
 
 val has_local_fun: params:split_function_parameters -> params.global_fun_t -> (params.tag_set_t & params.local_fun_t) -> prop
-let has_local_fun params global_fun (tag_set, tagged_local_fun) =
+let has_local_fun params global_fun (tag_set, local_fun) =
   forall tagged_data.
     match params.decode_tagged_data tagged_data with
     | Some (tag, raw_data) ->
-      tag `params.tag_belong_to` tag_set ==> (params.apply_global_fun global_fun tagged_data == params.apply_local_fun tagged_local_fun raw_data)
+      tag `params.tag_belong_to` tag_set ==> (params.apply_global_fun global_fun tagged_data == params.apply_local_fun local_fun raw_data)
     | None -> True
+
+/// A lemma that may be useful when the `forall` quantification doesn't trigger well
+
+val has_local_fun_elim:
+  params:split_function_parameters ->
+  global_fun:params.global_fun_t -> tag_set:params.tag_set_t -> local_fun:params.local_fun_t ->
+  tagged_data:params.tagged_data_t ->
+  Lemma
+  (requires has_local_fun params global_fun (tag_set, local_fun))
+  (ensures (
+    match params.decode_tagged_data tagged_data with
+    | Some (tag, raw_data) ->
+      tag `params.tag_belong_to` tag_set ==> (params.apply_global_fun global_fun tagged_data == params.apply_local_fun local_fun raw_data)
+    | None -> True
+  ))
+let has_local_fun_elim params global_fun tag_set local_fun tagged_data = ()
 
 /// Returns the first local function associated with a tag set containing `tag`, if it exists.
 /// In practice, only one tag set may contain `tag` because tag sets are mutually disjoint


### PR DESCRIPTION
While using the new split cryptographic predicate modules, I realized I could not use the `has_..._predicate` predicates easily. I think this is because when it is unfolded into `has_local_fun`, the `forall` quantifies on a complex type (e.g. `trace & (key:bytes{AeadKey? (get_usage key)}) & (bytes & bytes & bytes)` which is a tuple containing a refined type).
(If you a glimpse of the struggle this `forall` is, have a look at the `intro_has_..._predicate` proofs that aren't as trivial as they should be.)

This pull-request modifies these predicate to have more SMT-friendly quantification, and additionally, use a forall-pattern that acts like the well-known `SMTPat` on `Lemma`s. It's better proof-engineering because otherwise the `forall` is triggered on every instances of the type that is quantified, so it can trigger a lot. I also made state and event `has_..._predicate` opaque to SMT, to hide this `forall`.

I have been using it and this time this version works well.