### PR TITLE
cleanup: use typeclass mechanism systematically for invariants

### DIFF
--- a/examples/iso_dh/DY.Example.DH.Protocol.Stateful.Proof.fst
+++ b/examples/iso_dh/DY.Example.DH.Protocol.Stateful.Proof.fst
@@ -116,31 +116,37 @@ instance dh_protocol_invs: protocol_invariants = {
 
 /// Lemmas that the global state predicate contains all the local ones
 
-val all_sessions_has_all_sessions: unit -> Lemma (norm [delta_only [`%all_sessions; `%for_allP]; iota; zeta] (for_allP has_local_bytes_state_predicate all_sessions))
+// Below, the `has_..._predicate` are called with the implicit argument `#dh_protocol_invs`.
+// This argument could be omitted as it can be instantiated automatically by F*'s typeclass resolution algorithm.
+// However we instantiate it explicitly here so that the meaning of `has_..._predicate` is easier to understand.
+
+val all_sessions_has_all_sessions: unit -> Lemma (norm [delta_only [`%all_sessions; `%for_allP]; iota; zeta] (for_allP (has_local_bytes_state_predicate #dh_protocol_invs) all_sessions))
 let all_sessions_has_all_sessions () =
   assert_norm(List.Tot.no_repeats_p (List.Tot.map fst (all_sessions)));
-  mk_state_pred_correct all_sessions;
-  norm_spec [delta_only [`%all_sessions; `%for_allP]; iota; zeta] (for_allP has_local_bytes_state_predicate all_sessions)
+  mk_state_pred_correct #dh_protocol_invs all_sessions;
+  norm_spec [delta_only [`%all_sessions; `%for_allP]; iota; zeta] (for_allP (has_local_bytes_state_predicate #dh_protocol_invs) all_sessions)
 
-val full_dh_session_pred_has_pki_invariant: squash has_pki_invariant
+val full_dh_session_pred_has_pki_invariant: squash (has_pki_invariant #dh_protocol_invs)
 let full_dh_session_pred_has_pki_invariant = all_sessions_has_all_sessions ()
 
-val full_dh_session_pred_has_private_keys_invariant: squash has_private_keys_invariant
+val full_dh_session_pred_has_private_keys_invariant: squash (has_private_keys_invariant #dh_protocol_invs)
 let full_dh_session_pred_has_private_keys_invariant = all_sessions_has_all_sessions ()
 
+// As an example, below `#dh_protocol_invs` is omitted and instantiated using F*'s typeclass resolution algorithm
 val full_dh_session_pred_has_dh_invariant: squash (has_local_state_predicate dh_session_pred)
 let full_dh_session_pred_has_dh_invariant = all_sessions_has_all_sessions ()
 
 /// Lemmas that the global event predicate contains all the local ones
 
-val all_events_has_all_events: unit -> Lemma (norm [delta_only [`%all_events; `%for_allP]; iota; zeta] (for_allP has_compiled_event_pred all_events))
+val all_events_has_all_events: unit -> Lemma (norm [delta_only [`%all_events; `%for_allP]; iota; zeta] (for_allP (has_compiled_event_pred #dh_protocol_invs) all_events))
 let all_events_has_all_events () =
   assert_norm(List.Tot.no_repeats_p (List.Tot.map fst (all_events)));
-  mk_event_pred_correct all_events;
-  norm_spec [delta_only [`%all_events; `%for_allP]; iota; zeta] (for_allP has_compiled_event_pred all_events);
+  mk_event_pred_correct #dh_protocol_invs all_events;
+  norm_spec [delta_only [`%all_events; `%for_allP]; iota; zeta] (for_allP (has_compiled_event_pred #dh_protocol_invs) all_events);
   let dumb_lemma (x:prop) (y:prop): Lemma (requires x /\ x == y) (ensures y) = () in
-  dumb_lemma (for_allP has_compiled_event_pred all_events) (norm [delta_only [`%all_events; `%for_allP]; iota; zeta] (for_allP has_compiled_event_pred all_events))
+  dumb_lemma (for_allP (has_compiled_event_pred #dh_protocol_invs) all_events) (norm [delta_only [`%all_events; `%for_allP]; iota; zeta] (for_allP (has_compiled_event_pred #dh_protocol_invs) all_events))
 
+// As an example, below `#dh_protocol_invs` is omitted and instantiated using F*'s typeclass resolution algorithm
 val full_dh_event_pred_has_dh_invariant: squash (has_event_pred dh_event_pred)
 let full_dh_event_pred_has_dh_invariant = all_events_has_all_events ()
 

--- a/examples/iso_dh/DY.Example.DH.Protocol.Stateful.Proof.fst
+++ b/examples/iso_dh/DY.Example.DH.Protocol.Stateful.Proof.fst
@@ -104,8 +104,8 @@ let all_events = [
 
 /// Create the global trace invariants.
 
-let dh_trace_invs: trace_invariants (dh_crypto_invs) = {
-  state_pred = mk_state_pred dh_crypto_invs all_sessions;
+let dh_trace_invs: trace_invariants = {
+  state_pred = mk_state_pred all_sessions;
   event_pred = mk_event_pred all_events;
 }
 
@@ -116,32 +116,32 @@ instance dh_protocol_invs: protocol_invariants = {
 
 /// Lemmas that the global state predicate contains all the local ones
 
-val all_sessions_has_all_sessions: unit -> Lemma (norm [delta_only [`%all_sessions; `%for_allP]; iota; zeta] (for_allP (has_local_bytes_state_predicate dh_protocol_invs) all_sessions))
+val all_sessions_has_all_sessions: unit -> Lemma (norm [delta_only [`%all_sessions; `%for_allP]; iota; zeta] (for_allP has_local_bytes_state_predicate all_sessions))
 let all_sessions_has_all_sessions () =
   assert_norm(List.Tot.no_repeats_p (List.Tot.map fst (all_sessions)));
-  mk_state_pred_correct dh_protocol_invs all_sessions;
-  norm_spec [delta_only [`%all_sessions; `%for_allP]; iota; zeta] (for_allP (has_local_bytes_state_predicate dh_protocol_invs) all_sessions)
+  mk_state_pred_correct all_sessions;
+  norm_spec [delta_only [`%all_sessions; `%for_allP]; iota; zeta] (for_allP has_local_bytes_state_predicate all_sessions)
 
-val full_dh_session_pred_has_pki_invariant: squash (has_pki_invariant dh_protocol_invs)
+val full_dh_session_pred_has_pki_invariant: squash has_pki_invariant
 let full_dh_session_pred_has_pki_invariant = all_sessions_has_all_sessions ()
 
-val full_dh_session_pred_has_private_keys_invariant: squash (has_private_keys_invariant dh_protocol_invs)
+val full_dh_session_pred_has_private_keys_invariant: squash has_private_keys_invariant
 let full_dh_session_pred_has_private_keys_invariant = all_sessions_has_all_sessions ()
 
-val full_dh_session_pred_has_dh_invariant: squash (has_local_state_predicate dh_protocol_invs dh_session_pred)
+val full_dh_session_pred_has_dh_invariant: squash (has_local_state_predicate dh_session_pred)
 let full_dh_session_pred_has_dh_invariant = all_sessions_has_all_sessions ()
 
 /// Lemmas that the global event predicate contains all the local ones
 
-val all_events_has_all_events: unit -> Lemma (norm [delta_only [`%all_events; `%for_allP]; iota; zeta] (for_allP (has_compiled_event_pred dh_protocol_invs) all_events))
+val all_events_has_all_events: unit -> Lemma (norm [delta_only [`%all_events; `%for_allP]; iota; zeta] (for_allP has_compiled_event_pred all_events))
 let all_events_has_all_events () =
   assert_norm(List.Tot.no_repeats_p (List.Tot.map fst (all_events)));
-  mk_event_pred_correct dh_protocol_invs all_events;
-  norm_spec [delta_only [`%all_events; `%for_allP]; iota; zeta] (for_allP (has_compiled_event_pred dh_protocol_invs) all_events);
+  mk_event_pred_correct all_events;
+  norm_spec [delta_only [`%all_events; `%for_allP]; iota; zeta] (for_allP has_compiled_event_pred all_events);
   let dumb_lemma (x:prop) (y:prop): Lemma (requires x /\ x == y) (ensures y) = () in
-  dumb_lemma (for_allP (has_compiled_event_pred dh_protocol_invs) all_events) (norm [delta_only [`%all_events; `%for_allP]; iota; zeta] (for_allP (has_compiled_event_pred dh_protocol_invs) all_events))
+  dumb_lemma (for_allP has_compiled_event_pred all_events) (norm [delta_only [`%all_events; `%for_allP]; iota; zeta] (for_allP has_compiled_event_pred all_events))
 
-val full_dh_event_pred_has_dh_invariant: squash (has_event_pred dh_protocol_invs dh_event_pred)
+val full_dh_event_pred_has_dh_invariant: squash (has_event_pred dh_event_pred)
 let full_dh_event_pred_has_dh_invariant = all_events_has_all_events ()
 
 (*** Proofs ****)

--- a/examples/iso_dh/DY.Example.DH.Protocol.Total.Proof.fst
+++ b/examples/iso_dh/DY.Example.DH.Protocol.Total.Proof.fst
@@ -31,9 +31,9 @@ instance dh_crypto_usages = {
 }
 
 #push-options "--ifuel 2 --fuel 0"
-val dh_crypto_preds: crypto_predicates dh_crypto_usages
+val dh_crypto_preds: crypto_predicates
 let dh_crypto_preds = {
-  default_crypto_predicates dh_crypto_usages with
+  default_crypto_predicates with
 
   sign_pred = {
     pred = (fun tr vk sig_msg ->

--- a/examples/nsl_pk/DY.Example.NSL.Protocol.Stateful.Proof.fst
+++ b/examples/nsl_pk/DY.Example.NSL.Protocol.Stateful.Proof.fst
@@ -107,31 +107,37 @@ instance protocol_invariants_nsl: protocol_invariants = {
 
 /// Lemmas that the global state predicate contains all the local ones
 
-val all_sessions_has_all_sessions: unit -> Lemma (norm [delta_only [`%all_sessions; `%for_allP]; iota; zeta] (for_allP has_local_bytes_state_predicate all_sessions))
+// Below, the `has_..._predicate` are called with the implicit argument `#protocol_invariants_nsl`.
+// This argument could be omitted as it can be instantiated automatically by F*'s typeclass resolution algorithm.
+// However we instantiate it explicitly here so that the meaning of `has_..._predicate` is easier to understand.
+
+val all_sessions_has_all_sessions: unit -> Lemma (norm [delta_only [`%all_sessions; `%for_allP]; iota; zeta] (for_allP (has_local_bytes_state_predicate #protocol_invariants_nsl) all_sessions))
 let all_sessions_has_all_sessions () =
   assert_norm(List.Tot.no_repeats_p (List.Tot.map fst (all_sessions)));
-  mk_state_pred_correct all_sessions;
-  norm_spec [delta_only [`%all_sessions; `%for_allP]; iota; zeta] (for_allP has_local_bytes_state_predicate all_sessions)
+  mk_state_pred_correct #protocol_invariants_nsl all_sessions;
+  norm_spec [delta_only [`%all_sessions; `%for_allP]; iota; zeta] (for_allP (has_local_bytes_state_predicate #protocol_invariants_nsl) all_sessions)
 
-val protocol_invariants_nsl_has_pki_invariant: squash has_pki_invariant
+val protocol_invariants_nsl_has_pki_invariant: squash (has_pki_invariant #protocol_invariants_nsl)
 let protocol_invariants_nsl_has_pki_invariant = all_sessions_has_all_sessions ()
 
-val protocol_invariants_nsl_has_private_keys_invariant: squash has_private_keys_invariant
+val protocol_invariants_nsl_has_private_keys_invariant: squash (has_private_keys_invariant #protocol_invariants_nsl)
 let protocol_invariants_nsl_has_private_keys_invariant = all_sessions_has_all_sessions ()
 
+// As an example, below `#protocol_invariants_nsl` is omitted and instantiated using F*'s typeclass resolution algorithm
 val protocol_invariants_nsl_has_nsl_session_invariant: squash (has_local_state_predicate state_predicate_nsl)
 let protocol_invariants_nsl_has_nsl_session_invariant = all_sessions_has_all_sessions ()
 
 /// Lemmas that the global event predicate contains all the local ones
 
-val all_events_has_all_events: unit -> Lemma (norm [delta_only [`%all_events; `%for_allP]; iota; zeta] (for_allP has_compiled_event_pred all_events))
+val all_events_has_all_events: unit -> Lemma (norm [delta_only [`%all_events; `%for_allP]; iota; zeta] (for_allP (has_compiled_event_pred #protocol_invariants_nsl) all_events))
 let all_events_has_all_events () =
   assert_norm(List.Tot.no_repeats_p (List.Tot.map fst (all_events)));
-  mk_event_pred_correct all_events;
-  norm_spec [delta_only [`%all_events; `%for_allP]; iota; zeta] (for_allP has_compiled_event_pred all_events);
+  mk_event_pred_correct #protocol_invariants_nsl all_events;
+  norm_spec [delta_only [`%all_events; `%for_allP]; iota; zeta] (for_allP (has_compiled_event_pred #protocol_invariants_nsl) all_events);
   let dumb_lemma (x:prop) (y:prop): Lemma (requires x /\ x == y) (ensures y) = () in
-  dumb_lemma (for_allP has_compiled_event_pred all_events) (norm [delta_only [`%all_events; `%for_allP]; iota; zeta] (for_allP has_compiled_event_pred all_events))
+  dumb_lemma (for_allP (has_compiled_event_pred #protocol_invariants_nsl) all_events) (norm [delta_only [`%all_events; `%for_allP]; iota; zeta] (for_allP (has_compiled_event_pred #protocol_invariants_nsl) all_events))
 
+// As an example, below `#protocol_invariants_nsl` is omitted and instantiated using F*'s typeclass resolution algorithm
 val protocol_invariants_nsl_has_nsl_event_invariant: squash (has_event_pred event_predicate_nsl)
 let protocol_invariants_nsl_has_nsl_event_invariant = all_events_has_all_events ()
 

--- a/examples/nsl_pk/DY.Example.NSL.Protocol.Stateful.Proof.fst
+++ b/examples/nsl_pk/DY.Example.NSL.Protocol.Stateful.Proof.fst
@@ -95,8 +95,8 @@ let all_events = [
 
 /// Create the global trace invariants.
 
-let trace_invariants_nsl: trace_invariants (crypto_invariants_nsl) = {
-  state_pred = mk_state_pred crypto_invariants_nsl all_sessions;
+let trace_invariants_nsl: trace_invariants = {
+  state_pred = mk_state_pred all_sessions;
   event_pred = mk_event_pred all_events;
 }
 
@@ -107,32 +107,32 @@ instance protocol_invariants_nsl: protocol_invariants = {
 
 /// Lemmas that the global state predicate contains all the local ones
 
-val all_sessions_has_all_sessions: unit -> Lemma (norm [delta_only [`%all_sessions; `%for_allP]; iota; zeta] (for_allP (has_local_bytes_state_predicate protocol_invariants_nsl) all_sessions))
+val all_sessions_has_all_sessions: unit -> Lemma (norm [delta_only [`%all_sessions; `%for_allP]; iota; zeta] (for_allP has_local_bytes_state_predicate all_sessions))
 let all_sessions_has_all_sessions () =
   assert_norm(List.Tot.no_repeats_p (List.Tot.map fst (all_sessions)));
-  mk_state_pred_correct protocol_invariants_nsl all_sessions;
-  norm_spec [delta_only [`%all_sessions; `%for_allP]; iota; zeta] (for_allP (has_local_bytes_state_predicate protocol_invariants_nsl) all_sessions)
+  mk_state_pred_correct all_sessions;
+  norm_spec [delta_only [`%all_sessions; `%for_allP]; iota; zeta] (for_allP has_local_bytes_state_predicate all_sessions)
 
-val protocol_invariants_nsl_has_pki_invariant: squash (has_pki_invariant protocol_invariants_nsl)
+val protocol_invariants_nsl_has_pki_invariant: squash has_pki_invariant
 let protocol_invariants_nsl_has_pki_invariant = all_sessions_has_all_sessions ()
 
-val protocol_invariants_nsl_has_private_keys_invariant: squash (has_private_keys_invariant protocol_invariants_nsl)
+val protocol_invariants_nsl_has_private_keys_invariant: squash has_private_keys_invariant
 let protocol_invariants_nsl_has_private_keys_invariant = all_sessions_has_all_sessions ()
 
-val protocol_invariants_nsl_has_nsl_session_invariant: squash (has_local_state_predicate protocol_invariants_nsl state_predicate_nsl)
+val protocol_invariants_nsl_has_nsl_session_invariant: squash (has_local_state_predicate state_predicate_nsl)
 let protocol_invariants_nsl_has_nsl_session_invariant = all_sessions_has_all_sessions ()
 
 /// Lemmas that the global event predicate contains all the local ones
 
-val all_events_has_all_events: unit -> Lemma (norm [delta_only [`%all_events; `%for_allP]; iota; zeta] (for_allP (has_compiled_event_pred protocol_invariants_nsl) all_events))
+val all_events_has_all_events: unit -> Lemma (norm [delta_only [`%all_events; `%for_allP]; iota; zeta] (for_allP has_compiled_event_pred all_events))
 let all_events_has_all_events () =
   assert_norm(List.Tot.no_repeats_p (List.Tot.map fst (all_events)));
-  mk_event_pred_correct protocol_invariants_nsl all_events;
-  norm_spec [delta_only [`%all_events; `%for_allP]; iota; zeta] (for_allP (has_compiled_event_pred protocol_invariants_nsl) all_events);
+  mk_event_pred_correct all_events;
+  norm_spec [delta_only [`%all_events; `%for_allP]; iota; zeta] (for_allP has_compiled_event_pred all_events);
   let dumb_lemma (x:prop) (y:prop): Lemma (requires x /\ x == y) (ensures y) = () in
-  dumb_lemma (for_allP (has_compiled_event_pred protocol_invariants_nsl) all_events) (norm [delta_only [`%all_events; `%for_allP]; iota; zeta] (for_allP (has_compiled_event_pred protocol_invariants_nsl) all_events))
+  dumb_lemma (for_allP has_compiled_event_pred all_events) (norm [delta_only [`%all_events; `%for_allP]; iota; zeta] (for_allP has_compiled_event_pred all_events))
 
-val protocol_invariants_nsl_has_nsl_event_invariant: squash (has_event_pred protocol_invariants_nsl event_predicate_nsl)
+val protocol_invariants_nsl_has_nsl_event_invariant: squash (has_event_pred event_predicate_nsl)
 let protocol_invariants_nsl_has_nsl_event_invariant = all_events_has_all_events ()
 
 (*** Proofs ***)

--- a/examples/nsl_pk/DY.Example.NSL.Protocol.Total.Proof.fst
+++ b/examples/nsl_pk/DY.Example.NSL.Protocol.Total.Proof.fst
@@ -17,9 +17,9 @@ open DY.Example.NSL.Protocol.Stateful
 instance crypto_usages_nsl : crypto_usages = default_crypto_usages
 
 #push-options "--ifuel 2 --fuel 0"
-val crypto_predicates_nsl: crypto_predicates crypto_usages_nsl
+val crypto_predicates_nsl: crypto_predicates
 let crypto_predicates_nsl = {
-  default_crypto_predicates crypto_usages_nsl with
+  default_crypto_predicates with
 
   pkenc_pred = {
     pred = (fun tr pk msg ->

--- a/src/core/DY.Core.Bytes.fst
+++ b/src/core/DY.Core.Bytes.fst
@@ -399,7 +399,7 @@ let get_kem_sk_usage #cusages pk =
 /// by honest principals.
 
 noeq
-type aead_crypto_predicate (cusages:crypto_usages) = {
+type aead_crypto_predicate {|crypto_usages|} = {
   pred: tr:trace -> key:bytes{AeadKey? (get_usage key)} -> nonce:bytes -> msg:bytes -> ad:bytes -> prop;
   pred_later:
     tr1:trace -> tr2:trace ->
@@ -411,7 +411,7 @@ type aead_crypto_predicate (cusages:crypto_usages) = {
 }
 
 noeq
-type pkenc_crypto_predicate (cusages:crypto_usages) = {
+type pkenc_crypto_predicate {|crypto_usages|} = {
   pred: tr:trace -> pk:bytes{PkKey? (get_sk_usage pk)} -> msg:bytes -> prop;
   pred_later:
     tr1:trace -> tr2:trace ->
@@ -423,7 +423,7 @@ type pkenc_crypto_predicate (cusages:crypto_usages) = {
 }
 
 noeq
-type sign_crypto_predicate (cusages:crypto_usages) = {
+type sign_crypto_predicate {|crypto_usages|} = {
   pred: tr:trace -> vk:bytes{SigKey? (get_signkey_usage vk)} -> msg:bytes -> prop;
   pred_later:
     tr1:trace -> tr2:trace ->
@@ -435,10 +435,10 @@ type sign_crypto_predicate (cusages:crypto_usages) = {
 }
 
 noeq
-type crypto_predicates (cusages:crypto_usages) = {
-  aead_pred: aead_crypto_predicate cusages;
-  pkenc_pred: pkenc_crypto_predicate cusages;
-  sign_pred: sign_crypto_predicate cusages;
+type crypto_predicates {|crypto_usages|} = {
+  aead_pred: aead_crypto_predicate;
+  pkenc_pred: pkenc_crypto_predicate;
+  sign_pred: sign_crypto_predicate;
 }
 
 /// Default (empty) cryptographic predicates, that can be used like this:
@@ -446,31 +446,31 @@ type crypto_predicates (cusages:crypto_usages) = {
 ///   sign_pred = ...;
 /// }
 
-val default_aead_predicate: cusages:crypto_usages -> aead_crypto_predicate cusages
-let default_aead_predicate cusages = {
+val default_aead_predicate: {|crypto_usages|} -> aead_crypto_predicate
+let default_aead_predicate #cusages = {
   pred = (fun tr key nonce msg ad -> False);
   pred_later = (fun tr1 tr2 key nonce msg ad -> ());
 }
 
-val default_pkenc_predicate: cusages:crypto_usages -> pkenc_crypto_predicate cusages
-let default_pkenc_predicate cusages = {
+val default_pkenc_predicate: {|crypto_usages|} -> pkenc_crypto_predicate
+let default_pkenc_predicate #cusages = {
   pred = (fun tr pk msg -> False);
   pred_later = (fun tr1 tr2 pk msg -> ());
 }
 
-val default_sign_predicate: cusages:crypto_usages -> sign_crypto_predicate cusages
-let default_sign_predicate cusages = {
+val default_sign_predicate: {|crypto_usages|} -> sign_crypto_predicate
+let default_sign_predicate #cusages = {
   pred = (fun tr vk msg -> False);
   pred_later = (fun tr1 tr2 vk msg -> ());
 }
 
 val default_crypto_predicates:
-  cusages:crypto_usages ->
-  crypto_predicates cusages
-let default_crypto_predicates cusages = {
-  aead_pred = default_aead_predicate cusages;
-  pkenc_pred = default_pkenc_predicate cusages;
-  sign_pred = default_sign_predicate cusages;
+  {|crypto_usages|} ->
+  crypto_predicates
+let default_crypto_predicates #cusages = {
+  aead_pred = default_aead_predicate;
+  pkenc_pred = default_pkenc_predicate;
+  sign_pred = default_sign_predicate;
 }
 
 /// Gather the usage functions and the cryptographic predicates
@@ -481,7 +481,7 @@ class crypto_invariants = {
   [@@@FStar.Tactics.Typeclasses.tcinstance]
   usages: crypto_usages;
   [@@@FStar.Tactics.Typeclasses.no_method]
-  preds: crypto_predicates usages;
+  preds: crypto_predicates;
 }
 
 // `crypto_predicates` cannot be a typeclass that is inherited by `crypto_invariants`,

--- a/src/core/DY.Core.Trace.Manipulation.fst
+++ b/src/core/DY.Core.Trace.Manipulation.fst
@@ -411,7 +411,7 @@ val set_state_invariant:
   prin:principal -> sess_id:state_id -> content:bytes -> tr:trace ->
   Lemma
   (requires
-    state_pred tr prin sess_id content /\
+    state_pred.pred tr prin sess_id content /\
     trace_invariant tr
   )
   (ensures (
@@ -435,7 +435,7 @@ val get_state_aux_state_invariant:
   (ensures (
     match get_state_aux prin sess_id tr with
     | None -> True
-    | Some content -> state_pred tr prin sess_id content
+    | Some content -> state_pred.pred tr prin sess_id content
   ))
 let rec get_state_aux_state_invariant #invs prin sess_id tr =
   reveal_opaque (`%grows) (grows);
@@ -445,19 +445,19 @@ let rec get_state_aux_state_invariant #invs prin sess_id tr =
   | Nil -> ()
   | Snoc tr_init (SetState prin' sess_id' content) -> (
     if prin = prin' && sess_id = sess_id' then (
-      state_pred_later tr_init tr prin sess_id content
+      state_pred.pred_later tr_init tr prin sess_id content
     ) else (
       get_state_aux_state_invariant prin sess_id tr_init;
       match get_state_aux prin sess_id tr_init with
       | None -> ()
-      | Some content -> state_pred_later tr_init tr prin sess_id content
+      | Some content -> state_pred.pred_later tr_init tr prin sess_id content
     )
   )
   | Snoc tr_init _ ->
     get_state_aux_state_invariant prin sess_id tr_init;
     match get_state_aux prin sess_id tr_init with
     | None -> ()
-    | Some content -> state_pred_later tr_init tr prin sess_id content
+    | Some content -> state_pred.pred_later tr_init tr prin sess_id content
 
 /// When the trace invariant holds,
 /// retrieved states satisfy the state predicate.
@@ -474,7 +474,7 @@ val get_state_state_invariant:
     tr == tr_out /\ (
       match opt_content with
       | None -> True
-      | Some content -> state_pred tr prin sess_id content
+      | Some content -> state_pred.pred tr prin sess_id content
     )
   ))
   [SMTPat (get_state prin sess_id tr); SMTPat (trace_invariant tr)]

--- a/src/lib/crypto/DY.Lib.Crypto.AEAD.Split.fst
+++ b/src/lib/crypto/DY.Lib.Crypto.AEAD.Split.fst
@@ -4,7 +4,7 @@ open Comparse // for_allP, for_allP_eq
 open DY.Core
 open DY.Lib.Crypto.SplitPredicate
 
-let split_aead_predicate_params (cusages:crypto_usages): split_crypto_predicate_parameters = {
+let split_aead_predicate_params {|crypto_usages|}: split_crypto_predicate_parameters = {
   key_t = key:bytes{AeadKey? (get_usage key)};
   data_t = (bytes & bytes & bytes);
   get_usage = (fun key ->
@@ -12,7 +12,7 @@ let split_aead_predicate_params (cusages:crypto_usages): split_crypto_predicate_
     tag
   );
 
-  local_pred_t = aead_crypto_predicate cusages;
+  local_pred_t = aead_crypto_predicate;
   global_pred_t = trace -> key:bytes{AeadKey? (get_usage key)} -> nonce:bytes -> msg:bytes -> ad:bytes -> prop;
 
   apply_local_pred = (fun pred (tr, key, (nonce, msg, ad)) ->
@@ -31,8 +31,8 @@ let split_aead_predicate_params (cusages:crypto_usages): split_crypto_predicate_
   );
 }
 
-val has_aead_predicate: cinvs:crypto_invariants -> (string & aead_crypto_predicate cinvs.usages) -> prop
-let has_aead_predicate cinvs (tag, local_pred) =
+val has_aead_predicate: {|crypto_invariants|} -> (string & aead_crypto_predicate) -> prop
+let has_aead_predicate #cinvs (tag, local_pred) =
   forall (tr:trace) (key:bytes) (nonce:bytes) (msg:bytes) (ad:bytes).
     {:pattern aead_pred.pred tr key nonce msg ad}
     match get_usage key with
@@ -41,11 +41,11 @@ let has_aead_predicate cinvs (tag, local_pred) =
     | _ -> True
 
 val intro_has_aead_predicate:
-  cinvs:crypto_invariants -> tagged_local_pred:(string & aead_crypto_predicate cinvs.usages) ->
+  {|crypto_invariants|} -> tagged_local_pred:(string & aead_crypto_predicate) ->
   Lemma
-  (requires has_local_crypto_predicate (split_aead_predicate_params cinvs.usages) aead_pred.pred tagged_local_pred)
-  (ensures has_aead_predicate cinvs tagged_local_pred)
-let intro_has_aead_predicate cinvs (tag, local_pred) =
+  (requires has_local_crypto_predicate split_aead_predicate_params aead_pred.pred tagged_local_pred)
+  (ensures has_aead_predicate tagged_local_pred)
+let intro_has_aead_predicate #cinvs (tag, local_pred) =
   introduce
     forall tr key nonce msg ad.
       match get_usage key with
@@ -55,30 +55,30 @@ let intro_has_aead_predicate cinvs (tag, local_pred) =
   with (
     match get_usage key with
     | AeadKey aead_tag _ ->
-      has_local_crypto_predicate_elim (split_aead_predicate_params cinvs.usages) cinvs.preds.aead_pred.pred tag local_pred tr key (nonce, msg, ad)
+      has_local_crypto_predicate_elim split_aead_predicate_params aead_pred.pred tag local_pred tr key (nonce, msg, ad)
     | _ -> ()
   )
 
 (*** Global aead predicate builder ***)
 
 val mk_aead_predicate:
-  {|cusgs:crypto_usages|} ->
-  list (string & aead_crypto_predicate cusgs) ->
-  aead_crypto_predicate cusgs
+  {|crypto_usages|} ->
+  list (string & aead_crypto_predicate) ->
+  aead_crypto_predicate
 let mk_aead_predicate #cusgs l = {
-  pred = mk_global_crypto_predicate (split_aead_predicate_params cusgs) l;
-  pred_later = (fun tr1 tr2 key nonce msg ad -> mk_global_crypto_predicate_later (split_aead_predicate_params cusgs) l tr1 tr2 key (nonce, msg, ad));
+  pred = mk_global_crypto_predicate split_aead_predicate_params l;
+  pred_later = (fun tr1 tr2 key nonce msg ad -> mk_global_crypto_predicate_later split_aead_predicate_params l tr1 tr2 key (nonce, msg, ad));
 }
 
 val mk_aead_predicate_correct:
-  cinvs:crypto_invariants -> tagged_local_preds:list (string & aead_crypto_predicate cinvs.usages) ->
+  {|crypto_invariants|} -> tagged_local_preds:list (string & aead_crypto_predicate) ->
   Lemma
   (requires
     aead_pred == mk_aead_predicate tagged_local_preds /\
     List.Tot.no_repeats_p (List.Tot.map fst tagged_local_preds)
   )
-  (ensures for_allP (has_aead_predicate cinvs) tagged_local_preds)
-let mk_aead_predicate_correct cinvs tagged_local_preds =
-  for_allP_eq (has_aead_predicate cinvs) tagged_local_preds;
-  FStar.Classical.forall_intro_2 (FStar.Classical.move_requires_2 (mk_global_crypto_predicate_correct (split_aead_predicate_params cinvs.usages) tagged_local_preds));
-  FStar.Classical.forall_intro (FStar.Classical.move_requires (intro_has_aead_predicate cinvs))
+  (ensures for_allP has_aead_predicate tagged_local_preds)
+let mk_aead_predicate_correct #cinvs tagged_local_preds =
+  for_allP_eq has_aead_predicate tagged_local_preds;
+  FStar.Classical.forall_intro_2 (FStar.Classical.move_requires_2 (mk_global_crypto_predicate_correct split_aead_predicate_params tagged_local_preds));
+  FStar.Classical.forall_intro (FStar.Classical.move_requires intro_has_aead_predicate)

--- a/src/lib/crypto/DY.Lib.Crypto.KdfExpand.Split.fst
+++ b/src/lib/crypto/DY.Lib.Crypto.KdfExpand.Split.fst
@@ -62,8 +62,8 @@ let split_kdf_expand_usage_get_label_params = {
   apply_mk_global_fun = (fun bare x -> ());
 }
 
-val has_kdf_expand_usage_get_usage: cusgs:crypto_usages -> (string & kdf_expand_crypto_usage) -> prop
-let has_kdf_expand_usage_get_usage cinvs (tag, local_invariant) =
+val has_kdf_expand_usage_get_usage: {|crypto_usages|} -> (string & kdf_expand_crypto_usage) -> prop
+let has_kdf_expand_usage_get_usage #cusgs (tag, local_invariant) =
   forall (prk_usage:usage) (info:bytes).
     {:pattern kdf_expand_usage.get_usage prk_usage info}
     match prk_usage with
@@ -71,8 +71,8 @@ let has_kdf_expand_usage_get_usage cinvs (tag, local_invariant) =
         prk_tag = tag ==> kdf_expand_usage.get_usage prk_usage info == local_invariant.get_usage prk_usage info
     | _ -> True
 
-val has_kdf_expand_usage_get_label: cusgs:crypto_usages -> (string & kdf_expand_crypto_usage) -> prop
-let has_kdf_expand_usage_get_label cinvs (tag, local_invariant) =
+val has_kdf_expand_usage_get_label: {|crypto_usages|} -> (string & kdf_expand_crypto_usage) -> prop
+let has_kdf_expand_usage_get_label #cusgs (tag, local_invariant) =
   forall (prk_usage:usage) (prk_label:label) (info:bytes).
     {:pattern kdf_expand_usage.get_label prk_usage prk_label info}
     match prk_usage with
@@ -80,17 +80,17 @@ let has_kdf_expand_usage_get_label cinvs (tag, local_invariant) =
         prk_tag = tag ==> kdf_expand_usage.get_label prk_usage prk_label info == local_invariant.get_label prk_usage prk_label info
     | _ -> True
 
-val has_kdf_expand_usage: cusgs:crypto_usages -> (string & kdf_expand_crypto_usage) -> prop
-let has_kdf_expand_usage cinvs (tag, local_invariant) =
-  has_kdf_expand_usage_get_usage cinvs (tag, local_invariant) /\
-  has_kdf_expand_usage_get_label cinvs (tag, local_invariant)
+val has_kdf_expand_usage: {|crypto_usages|} -> (string & kdf_expand_crypto_usage) -> prop
+let has_kdf_expand_usage #cusgs (tag, local_invariant) =
+  has_kdf_expand_usage_get_usage (tag, local_invariant) /\
+  has_kdf_expand_usage_get_label (tag, local_invariant)
 
 val intro_has_kdf_expand_usage_get_usage:
-  cusgs:crypto_usages -> tagged_local_invariant:(string & kdf_expand_crypto_usage) ->
+  {|crypto_usages|} -> tagged_local_invariant:(string & kdf_expand_crypto_usage) ->
   Lemma
   (requires has_local_fun split_kdf_expand_usage_get_usage_params kdf_expand_usage.get_usage tagged_local_invariant)
-  (ensures has_kdf_expand_usage_get_usage cusgs tagged_local_invariant)
-let intro_has_kdf_expand_usage_get_usage cusgs (tag, local_invariant) =
+  (ensures has_kdf_expand_usage_get_usage tagged_local_invariant)
+let intro_has_kdf_expand_usage_get_usage #cusgs (tag, local_invariant) =
   introduce
     forall prk_usage info.
       match prk_usage with
@@ -105,11 +105,11 @@ let intro_has_kdf_expand_usage_get_usage cusgs (tag, local_invariant) =
   )
 
 val intro_has_kdf_expand_usage_get_label:
-  cusgs:crypto_usages -> tagged_local_invariant:(string & kdf_expand_crypto_usage) ->
+  {|crypto_usages|} -> tagged_local_invariant:(string & kdf_expand_crypto_usage) ->
   Lemma
   (requires has_local_fun split_kdf_expand_usage_get_label_params kdf_expand_usage.get_label tagged_local_invariant)
-  (ensures has_kdf_expand_usage_get_label cusgs tagged_local_invariant)
-let intro_has_kdf_expand_usage_get_label cusgs (tag, local_invariant) =
+  (ensures has_kdf_expand_usage_get_label tagged_local_invariant)
+let intro_has_kdf_expand_usage_get_label #cusgs (tag, local_invariant) =
   introduce
     forall prk_usage prk_label info.
       match prk_usage with
@@ -158,17 +158,17 @@ let mk_kdf_expand_usage tagged_local_invariants = {
 }
 
 val mk_kdf_expand_usage_correct:
-  cusgs:crypto_usages -> tagged_local_invariants:list (string & kdf_expand_crypto_usage) ->
+  {|crypto_usages|} -> tagged_local_invariants:list (string & kdf_expand_crypto_usage) ->
   Lemma
   (requires
     kdf_expand_usage == mk_kdf_expand_usage tagged_local_invariants /\
     List.Tot.no_repeats_p (List.Tot.map fst tagged_local_invariants)
   )
-  (ensures for_allP (has_kdf_expand_usage cusgs) tagged_local_invariants)
-let mk_kdf_expand_usage_correct cusgs tagged_local_invariants =
+  (ensures for_allP has_kdf_expand_usage tagged_local_invariants)
+let mk_kdf_expand_usage_correct #cusgs tagged_local_invariants =
   no_repeats_p_implies_for_all_pairsP_unequal (List.Tot.map fst tagged_local_invariants);
-  for_allP_eq (has_kdf_expand_usage cusgs) tagged_local_invariants;
+  for_allP_eq has_kdf_expand_usage tagged_local_invariants;
   FStar.Classical.forall_intro_2 (FStar.Classical.move_requires_2 (mk_global_fun_correct split_kdf_expand_usage_get_usage_params tagged_local_invariants));
   FStar.Classical.forall_intro_2 (FStar.Classical.move_requires_2 (mk_global_fun_correct split_kdf_expand_usage_get_label_params tagged_local_invariants));
-  FStar.Classical.forall_intro (FStar.Classical.move_requires (intro_has_kdf_expand_usage_get_usage cusgs));
-  FStar.Classical.forall_intro (FStar.Classical.move_requires (intro_has_kdf_expand_usage_get_label cusgs))
+  FStar.Classical.forall_intro (FStar.Classical.move_requires intro_has_kdf_expand_usage_get_usage);
+  FStar.Classical.forall_intro (FStar.Classical.move_requires intro_has_kdf_expand_usage_get_label)

--- a/src/lib/crypto/DY.Lib.Crypto.PkEncryption.Split.fst
+++ b/src/lib/crypto/DY.Lib.Crypto.PkEncryption.Split.fst
@@ -4,7 +4,7 @@ open Comparse // for_allP, for_allP_eq
 open DY.Core
 open DY.Lib.Crypto.SplitPredicate
 
-let split_pkenc_predicate_params (cusages:crypto_usages): split_crypto_predicate_parameters = {
+let split_pkenc_predicate_params {|crypto_usages|}: split_crypto_predicate_parameters = {
   key_t = pk:bytes{PkKey? (get_sk_usage pk)};
   data_t = bytes;
   get_usage = (fun pk ->
@@ -12,7 +12,7 @@ let split_pkenc_predicate_params (cusages:crypto_usages): split_crypto_predicate
     tag
   );
 
-  local_pred_t = pkenc_crypto_predicate cusages;
+  local_pred_t = pkenc_crypto_predicate;
   global_pred_t = tr:trace -> pk:bytes{PkKey? (get_sk_usage pk)} -> msg:bytes -> prop;
 
   apply_local_pred = (fun pred (tr, pk, msg) ->
@@ -31,8 +31,8 @@ let split_pkenc_predicate_params (cusages:crypto_usages): split_crypto_predicate
   );
 }
 
-val has_pkenc_predicate: cinvs:crypto_invariants -> (string & pkenc_crypto_predicate cinvs.usages) -> prop
-let has_pkenc_predicate cinvs (tag, local_pred) =
+val has_pkenc_predicate: {|crypto_invariants|} -> (string & pkenc_crypto_predicate) -> prop
+let has_pkenc_predicate #cinvs (tag, local_pred) =
   forall (tr:trace) (pk:bytes) (msg:bytes).
     {:pattern pkenc_pred.pred tr pk msg}
     match get_sk_usage pk with
@@ -41,11 +41,11 @@ let has_pkenc_predicate cinvs (tag, local_pred) =
     | _ -> True
 
 val intro_has_pkenc_predicate:
-  cinvs:crypto_invariants -> tagged_local_pred:(string & pkenc_crypto_predicate cinvs.usages) ->
+  {|crypto_invariants|} -> tagged_local_pred:(string & pkenc_crypto_predicate) ->
   Lemma
-  (requires has_local_crypto_predicate (split_pkenc_predicate_params cinvs.usages) pkenc_pred.pred tagged_local_pred)
-  (ensures has_pkenc_predicate cinvs tagged_local_pred)
-let intro_has_pkenc_predicate cinvs (tag, local_pred) =
+  (requires has_local_crypto_predicate split_pkenc_predicate_params pkenc_pred.pred tagged_local_pred)
+  (ensures has_pkenc_predicate tagged_local_pred)
+let intro_has_pkenc_predicate #cinvs (tag, local_pred) =
   introduce
     forall tr pk msg.
       match get_sk_usage pk with
@@ -55,30 +55,30 @@ let intro_has_pkenc_predicate cinvs (tag, local_pred) =
   with (
     match get_sk_usage pk with
     | PkKey pkenc_tag _ ->
-      has_local_crypto_predicate_elim (split_pkenc_predicate_params cinvs.usages) cinvs.preds.pkenc_pred.pred tag local_pred tr pk msg
+      has_local_crypto_predicate_elim split_pkenc_predicate_params pkenc_pred.pred tag local_pred tr pk msg
     | _ -> ()
   )
 
 (*** Global pkenc predicate builder ***)
 
 val mk_pkenc_predicate:
-  {|cusgs:crypto_usages|} ->
-  list (string & pkenc_crypto_predicate cusgs) ->
-  pkenc_crypto_predicate cusgs
+  {|crypto_usages|} ->
+  list (string & pkenc_crypto_predicate) ->
+  pkenc_crypto_predicate
 let mk_pkenc_predicate #cusgs l = {
-  pred = mk_global_crypto_predicate (split_pkenc_predicate_params cusgs) l;
-  pred_later = mk_global_crypto_predicate_later (split_pkenc_predicate_params cusgs) l;
+  pred = mk_global_crypto_predicate split_pkenc_predicate_params l;
+  pred_later = mk_global_crypto_predicate_later split_pkenc_predicate_params l;
 }
 
 val mk_pkenc_predicate_correct:
-  cinvs:crypto_invariants -> tagged_local_preds:list (string & pkenc_crypto_predicate cinvs.usages) ->
+  {|crypto_invariants|} -> tagged_local_preds:list (string & pkenc_crypto_predicate) ->
   Lemma
   (requires
     pkenc_pred == mk_pkenc_predicate tagged_local_preds /\
     List.Tot.no_repeats_p (List.Tot.map fst tagged_local_preds)
   )
-  (ensures for_allP (has_pkenc_predicate cinvs) tagged_local_preds)
-let mk_pkenc_predicate_correct cinvs tagged_local_preds =
-  for_allP_eq (has_pkenc_predicate cinvs) tagged_local_preds;
-  FStar.Classical.forall_intro_2 (FStar.Classical.move_requires_2 (mk_global_crypto_predicate_correct (split_pkenc_predicate_params cinvs.usages) tagged_local_preds));
-  FStar.Classical.forall_intro (FStar.Classical.move_requires (intro_has_pkenc_predicate cinvs))
+  (ensures for_allP has_pkenc_predicate tagged_local_preds)
+let mk_pkenc_predicate_correct #cinvs tagged_local_preds =
+  for_allP_eq has_pkenc_predicate tagged_local_preds;
+  FStar.Classical.forall_intro_2 (FStar.Classical.move_requires_2 (mk_global_crypto_predicate_correct split_pkenc_predicate_params tagged_local_preds));
+  FStar.Classical.forall_intro (FStar.Classical.move_requires intro_has_pkenc_predicate)

--- a/src/lib/state/DY.Lib.State.Map.fst
+++ b/src/lib/state/DY.Lib.State.Map.fst
@@ -118,9 +118,9 @@ let map_session_invariant #cinvs #key_t #value_t #mt mpred = {
 
 val has_map_session_invariant:
   #key_t:eqtype -> #value_t:Type0 -> {|map_types key_t value_t|} ->
-  protocol_invariants -> map_predicate key_t value_t -> prop
-let has_map_session_invariant #key_t #value_t #mt invs mpred =
-  has_local_state_predicate invs (map_session_invariant mpred)
+  {|protocol_invariants|} -> map_predicate key_t value_t -> prop
+let has_map_session_invariant #key_t #value_t #mt #invs mpred =
+  has_local_state_predicate (map_session_invariant mpred)
 
 (*** Map API ***)
 
@@ -183,7 +183,7 @@ let find_value #key_t #value_t #mt prin sess_id key =
 
 #push-options "--fuel 1"
 val initialize_map_invariant:
-  {|invs:protocol_invariants|} ->
+  {|protocol_invariants|} ->
   #key_t:eqtype -> #value_t:Type0 -> {|map_types key_t value_t|} ->
   mpred:map_predicate key_t value_t ->
   prin:principal ->
@@ -191,14 +191,14 @@ val initialize_map_invariant:
   Lemma
   (requires
     trace_invariant tr /\
-    has_map_session_invariant invs mpred
+    has_map_session_invariant mpred
   )
   (ensures (
     let (_, tr_out) = initialize_map key_t value_t prin tr in
     trace_invariant tr_out
   ))
   [SMTPat (initialize_map key_t value_t prin tr);
-   SMTPat (has_map_session_invariant invs mpred);
+   SMTPat (has_map_session_invariant mpred);
    SMTPat (trace_invariant tr)
   ]
 let initialize_map_invariant #invs #key_t #value_t #mt mpred prin tr =
@@ -207,7 +207,7 @@ let initialize_map_invariant #invs #key_t #value_t #mt mpred prin tr =
 
 #push-options "--fuel 1"
 val add_key_value_invariant:
-  {|invs:protocol_invariants|} ->
+  {|protocol_invariants|} ->
   #key_t:eqtype -> #value_t:Type0 -> {|map_types key_t value_t|} ->
   mpred:map_predicate key_t value_t ->
   prin:principal -> sess_id:state_id ->
@@ -217,14 +217,14 @@ val add_key_value_invariant:
   (requires
     mpred.pred tr prin sess_id key value /\
     trace_invariant tr /\
-    has_map_session_invariant invs mpred
+    has_map_session_invariant mpred
   )
   (ensures (
     let (_, tr_out) = add_key_value prin sess_id key value tr in
     trace_invariant tr_out
   ))
   [SMTPat (add_key_value prin sess_id key value tr);
-   SMTPat (has_map_session_invariant invs mpred);
+   SMTPat (has_map_session_invariant mpred);
    SMTPat (trace_invariant tr)
   ]
 let add_key_value_invariant #invs #key_t #value_t #mt mpred prin sess_id key value tr =
@@ -232,7 +232,7 @@ let add_key_value_invariant #invs #key_t #value_t #mt mpred prin sess_id key val
 #pop-options
 
 val find_value_invariant:
-  {|invs:protocol_invariants|} ->
+  {|protocol_invariants|} ->
   #key_t:eqtype -> #value_t:Type0 -> {|map_types key_t value_t|} ->
   mpred:map_predicate key_t value_t ->
   prin:principal -> sess_id:state_id ->
@@ -241,7 +241,7 @@ val find_value_invariant:
   Lemma
   (requires
     trace_invariant tr /\
-    has_map_session_invariant invs mpred
+    has_map_session_invariant mpred
   )
   (ensures (
     let (opt_value, tr_out) = find_value prin sess_id key tr in
@@ -254,7 +254,7 @@ val find_value_invariant:
     )
   ))
   [SMTPat (find_value #key_t #value_t prin sess_id key tr);
-   SMTPat (has_map_session_invariant invs mpred);
+   SMTPat (has_map_session_invariant mpred);
    SMTPat (trace_invariant tr);
   ]
 let find_value_invariant #invs #key_t #value_t #mt mpred prin sess_id key tr =

--- a/src/lib/state/DY.Lib.State.PKI.fst
+++ b/src/lib/state/DY.Lib.State.PKI.fst
@@ -76,9 +76,9 @@ let pki_pred #cinvs = {
   pred_knowable = (fun tr prin sess_id key value -> ());
 }
 
-val has_pki_invariant: protocol_invariants -> prop
-let has_pki_invariant invs =
-  has_map_session_invariant invs pki_pred
+val has_pki_invariant: {|protocol_invariants|} -> prop
+let has_pki_invariant #invs =
+  has_map_session_invariant pki_pred
 
 val pki_tag_and_invariant: {|crypto_invariants|} -> string & local_bytes_state_predicate
 let pki_tag_and_invariant #ci = (map_types_pki.tag, local_state_predicate_to_local_bytes_state_predicate (map_session_invariant pki_pred))
@@ -101,49 +101,49 @@ let get_public_key prin sess_id pk_type who =
   return (Some res.public_key)
 
 val initialize_pki_invariant:
-  {|invs:protocol_invariants|} ->
+  {|protocol_invariants|} ->
   prin:principal -> tr:trace ->
   Lemma
   (requires
     trace_invariant tr /\
-    has_pki_invariant invs
+    has_pki_invariant
   )
   (ensures (
     let (_, tr_out) = initialize_pki prin tr in
     trace_invariant tr_out
   ))
   [SMTPat (initialize_pki prin tr);
-   SMTPat (has_pki_invariant invs);
+   SMTPat (has_pki_invariant);
    SMTPat (trace_invariant tr)]
 let initialize_pki_invariant #invs prin tr =
   reveal_opaque (`%initialize_pki) (initialize_pki)
 
 val install_public_key_invariant:
-  {|invs:protocol_invariants|} ->
+  {|protocol_invariants|} ->
   prin:principal -> sess_id:state_id -> pk_type:public_key_type -> who:principal -> pk:bytes -> tr:trace ->
   Lemma
   (requires
     is_public_key_for tr pk pk_type who /\
     trace_invariant tr /\
-    has_pki_invariant invs
+    has_pki_invariant
   )
   (ensures (
     let (_, tr_out) = install_public_key prin sess_id pk_type who pk tr in
     trace_invariant tr_out
   ))
   [SMTPat (install_public_key prin sess_id pk_type who pk tr);
-   SMTPat (has_pki_invariant invs);
+   SMTPat (has_pki_invariant);
    SMTPat (trace_invariant tr)]
 let install_public_key_invariant #invs prin sess_id pk_type who pk tr =
   reveal_opaque (`%install_public_key) (install_public_key)
 
 val get_public_key_invariant:
-  {|invs:protocol_invariants|} ->
+  {|protocol_invariants|} ->
   prin:principal -> sess_id:state_id -> pk_type:public_key_type -> who:principal -> tr:trace ->
   Lemma
   (requires
     trace_invariant tr /\
-    has_pki_invariant invs
+    has_pki_invariant
   )
   (ensures (
     let (opt_public_key, tr_out) = get_public_key prin sess_id pk_type who tr in
@@ -155,7 +155,7 @@ val get_public_key_invariant:
     )
   ))
   [SMTPat (get_public_key prin sess_id pk_type who tr);
-   SMTPat (has_pki_invariant invs);
+   SMTPat (has_pki_invariant);
    SMTPat (trace_invariant tr)]
 let get_public_key_invariant #invs prin sess_id pk_type who tr =
   reveal_opaque (`%get_public_key) (get_public_key)

--- a/src/lib/state/DY.Lib.State.PrivateKeys.fst
+++ b/src/lib/state/DY.Lib.State.PrivateKeys.fst
@@ -68,9 +68,9 @@ let private_keys_pred #cinvs = {
   pred_knowable = (fun tr prin sess_id key value -> ());
 }
 
-val has_private_keys_invariant: protocol_invariants -> prop
-let has_private_keys_invariant invs =
-  has_map_session_invariant invs private_keys_pred
+val has_private_keys_invariant: {|protocol_invariants|} -> prop
+let has_private_keys_invariant #invs =
+  has_map_session_invariant private_keys_pred
 
 val private_keys_tag_and_invariant: {|crypto_invariants|} -> string & local_bytes_state_predicate
 let private_keys_tag_and_invariant #ci = (map_types_private_keys.tag, local_state_predicate_to_local_bytes_state_predicate (map_session_invariant private_keys_pred))
@@ -102,48 +102,48 @@ let get_private_key prin sess_id sk_type =
   return (Some res.private_key)
 
 val initialize_private_keys_invariant:
-  {|invs:protocol_invariants|} ->
+  {|protocol_invariants|} ->
   prin:principal -> tr:trace ->
   Lemma
   (requires
     trace_invariant tr /\
-    has_private_keys_invariant invs
+    has_private_keys_invariant
   )
   (ensures (
     let (_, tr_out) = initialize_private_keys prin tr in
     trace_invariant tr_out
   ))
   [SMTPat (initialize_private_keys prin tr);
-   SMTPat (has_private_keys_invariant invs);
+   SMTPat (has_private_keys_invariant);
    SMTPat (trace_invariant tr)]
 let initialize_private_keys_invariant #invs prin tr =
   reveal_opaque (`%initialize_private_keys) (initialize_private_keys)
 
 val generate_private_key_invariant:
-  {|invs:protocol_invariants|} ->
+  {|protocol_invariants|} ->
   prin:principal -> sess_id:state_id -> sk_type:private_key_type -> tr:trace ->
   Lemma
   (requires
     trace_invariant tr /\
-    has_private_keys_invariant invs
+    has_private_keys_invariant
   )
   (ensures (
     let (_, tr_out) = generate_private_key prin sess_id sk_type tr in
     trace_invariant tr_out
   ))
   [SMTPat (generate_private_key prin sess_id sk_type tr);
-   SMTPat (has_private_keys_invariant invs);
+   SMTPat (has_private_keys_invariant);
    SMTPat (trace_invariant tr)]
 let generate_private_key_invariant #invs prin sess_id sk_type tr =
   reveal_opaque (`%generate_private_key) (generate_private_key)
 
 val get_private_key_invariant:
-  {|invs:protocol_invariants|} ->
+  {|protocol_invariants|} ->
   prin:principal -> sess_id:state_id -> pk_type:private_key_type -> tr:trace ->
   Lemma
   (requires
     trace_invariant tr /\
-    has_private_keys_invariant invs
+    has_private_keys_invariant
   )
   (ensures (
     let (opt_private_key, tr_out) = get_private_key prin sess_id pk_type tr in
@@ -155,7 +155,7 @@ val get_private_key_invariant:
     )
   ))
   [SMTPat (get_private_key prin sess_id pk_type tr);
-   SMTPat (has_private_keys_invariant invs);
+   SMTPat (has_private_keys_invariant);
    SMTPat (trace_invariant tr)]
 let get_private_key_invariant #invs prin sess_id pk_type tr =
   reveal_opaque (`%get_private_key) (get_private_key)

--- a/src/lib/state/DY.Lib.State.Tagged.fst
+++ b/src/lib/state/DY.Lib.State.Tagged.fst
@@ -71,9 +71,9 @@ let split_local_bytes_state_predicate_params {|crypto_invariants|} : split_funct
 }
 
 [@@ "opaque_to_smt"]
-val has_local_bytes_state_predicate: protocol_invariants -> (string & local_bytes_state_predicate) -> prop
-let has_local_bytes_state_predicate invs (tag, spred) =
-  has_local_fun split_local_bytes_state_predicate_params (state_pred) (tag, spred)
+val has_local_bytes_state_predicate: {|protocol_invariants|} -> (string & local_bytes_state_predicate) -> prop
+let has_local_bytes_state_predicate #invs (tag, spred) =
+  has_local_fun split_local_bytes_state_predicate_params state_pred.pred (tag, spred)
 
 (*** Global tagged state predicate builder ***)
 
@@ -83,11 +83,11 @@ let mk_global_local_bytes_state_predicate #cinvs tagged_local_preds =
 
 #push-options "--ifuel 2" // to deconstruct nested tuples
 val mk_global_local_bytes_state_predicate_later:
-  cinvs:crypto_invariants -> tagged_local_preds:list (string & local_bytes_state_predicate) ->
+  {|crypto_invariants|} -> tagged_local_preds:list (string & local_bytes_state_predicate) ->
   tr1:trace -> tr2:trace -> prin:principal -> sess_id:state_id -> full_content:bytes -> Lemma
   (requires mk_global_local_bytes_state_predicate tagged_local_preds tr1 prin sess_id full_content /\ tr1 <$ tr2)
   (ensures mk_global_local_bytes_state_predicate tagged_local_preds tr2 prin sess_id full_content)
-let mk_global_local_bytes_state_predicate_later cinvs tagged_local_preds tr1 tr2 prin sess_id full_content =
+let mk_global_local_bytes_state_predicate_later #cinvs tagged_local_preds tr1 tr2 prin sess_id full_content =
   mk_global_fun_eq split_local_bytes_state_predicate_params tagged_local_preds (tr1, prin, sess_id, full_content);
   mk_global_fun_eq split_local_bytes_state_predicate_params tagged_local_preds (tr2, prin, sess_id, full_content);
   introduce forall lpred content. split_local_bytes_state_predicate_params.apply_local_fun lpred (tr1, prin, sess_id, content) ==> split_local_bytes_state_predicate_params.apply_local_fun lpred (tr2, prin, sess_id, content) with (
@@ -96,12 +96,12 @@ let mk_global_local_bytes_state_predicate_later cinvs tagged_local_preds tr1 tr2
 #pop-options
 
 val mk_global_local_bytes_state_predicate_knowable:
-  cinvs:crypto_invariants -> tagged_local_preds:list (string & local_bytes_state_predicate) ->
+  {|crypto_invariants|} -> tagged_local_preds:list (string & local_bytes_state_predicate) ->
   tr:trace -> prin:principal -> sess_id:state_id -> full_content:bytes ->
   Lemma
   (requires mk_global_local_bytes_state_predicate tagged_local_preds tr prin sess_id full_content)
   (ensures is_knowable_by (principal_state_label prin sess_id) tr full_content)
-let mk_global_local_bytes_state_predicate_knowable cinvs tagged_local_preds tr prin sess_id full_content =
+let mk_global_local_bytes_state_predicate_knowable #cinvs tagged_local_preds tr prin sess_id full_content =
   mk_global_fun_eq split_local_bytes_state_predicate_params tagged_local_preds (tr, prin, sess_id, full_content);
   match split_local_bytes_state_predicate_params.decode_tagged_data (tr, prin, sess_id, full_content) with
   | Some (tag, (_, _, _, content)) -> (
@@ -115,24 +115,24 @@ let mk_global_local_bytes_state_predicate_knowable cinvs tagged_local_preds tr p
   )
   | None -> ()
 
-val mk_state_pred: cinvs:crypto_invariants -> list (string & local_bytes_state_predicate) -> state_predicate cinvs
-let mk_state_pred cinvs tagged_local_preds =
+val mk_state_pred: {|crypto_invariants|} -> list (string & local_bytes_state_predicate) -> state_predicate
+let mk_state_pred #cinvs tagged_local_preds =
   {
     pred = mk_global_local_bytes_state_predicate tagged_local_preds;
-    pred_later = mk_global_local_bytes_state_predicate_later cinvs tagged_local_preds;
-    pred_knowable = mk_global_local_bytes_state_predicate_knowable cinvs tagged_local_preds;
+    pred_later = mk_global_local_bytes_state_predicate_later tagged_local_preds;
+    pred_knowable = mk_global_local_bytes_state_predicate_knowable tagged_local_preds;
   }
 
-val mk_state_pred_correct: invs:protocol_invariants -> tagged_local_preds:list (string & local_bytes_state_predicate) -> Lemma
+val mk_state_pred_correct: {|protocol_invariants|} -> tagged_local_preds:list (string & local_bytes_state_predicate) -> Lemma
   (requires
-    invs.trace_invs.state_pred == mk_state_pred invs.crypto_invs tagged_local_preds /\
+    state_pred == mk_state_pred tagged_local_preds /\
     List.Tot.no_repeats_p (List.Tot.map fst tagged_local_preds)
   )
-  (ensures for_allP (has_local_bytes_state_predicate invs) tagged_local_preds)
-let mk_state_pred_correct invs tagged_local_preds =
+  (ensures for_allP has_local_bytes_state_predicate tagged_local_preds)
+let mk_state_pred_correct #invs tagged_local_preds =
   reveal_opaque (`%has_local_bytes_state_predicate) (has_local_bytes_state_predicate);
   no_repeats_p_implies_for_all_pairsP_unequal (List.Tot.map fst tagged_local_preds);
-  for_allP_eq (has_local_bytes_state_predicate invs) tagged_local_preds;
+  for_allP_eq has_local_bytes_state_predicate tagged_local_preds;
   FStar.Classical.forall_intro_2 (FStar.Classical.move_requires_2 (mk_global_fun_correct split_local_bytes_state_predicate_params tagged_local_preds))
 
 (*** Predicates on trace ***)
@@ -164,14 +164,14 @@ let get_tagged_state the_tag prin sess_id =
       else return None
 
 val set_tagged_state_invariant:
-  invs:protocol_invariants ->
+  {|protocol_invariants|} ->
   tag:string -> spred:local_bytes_state_predicate ->
   prin:principal -> sess_id:state_id -> content:bytes -> tr:trace ->
   Lemma
   (requires
     spred.pred tr prin sess_id content /\
     trace_invariant tr /\
-    has_local_bytes_state_predicate invs (tag, spred)
+    has_local_bytes_state_predicate (tag, spred)
   )
   (ensures (
     let ((), tr_out) = set_tagged_state tag prin sess_id content tr in
@@ -180,23 +180,23 @@ val set_tagged_state_invariant:
   ))
   [SMTPat (set_tagged_state tag prin sess_id content tr);
    SMTPat (trace_invariant tr);
-   SMTPat (has_local_bytes_state_predicate invs (tag, spred))]
-let set_tagged_state_invariant invs tag spred prin sess_id content tr =
+   SMTPat (has_local_bytes_state_predicate (tag, spred))]
+let set_tagged_state_invariant #invs tag spred prin sess_id content tr =
   reveal_opaque (`%has_local_bytes_state_predicate) (has_local_bytes_state_predicate);
   reveal_opaque (`%set_tagged_state) (set_tagged_state);
   reveal_opaque (`%tagged_state_was_set) (tagged_state_was_set);
   let full_content = {tag; content;} in
   parse_serialize_inv_lemma #bytes tagged_state full_content;
-  local_eq_global_lemma split_local_bytes_state_predicate_params state_pred tag spred (tr, prin, sess_id, serialize _ full_content) tag (tr, prin, sess_id, content)
+  local_eq_global_lemma split_local_bytes_state_predicate_params state_pred.pred tag spred (tr, prin, sess_id, serialize _ full_content) tag (tr, prin, sess_id, content)
 
 val get_tagged_state_invariant:
-  invs:protocol_invariants ->
+  {|protocol_invariants|} ->
   tag:string -> spred:local_bytes_state_predicate ->
   prin:principal -> sess_id:state_id -> tr:trace ->
   Lemma
   (requires
     trace_invariant tr /\
-    has_local_bytes_state_predicate invs (tag, spred)
+    has_local_bytes_state_predicate (tag, spred)
   )
   (ensures (
     let (opt_content, tr_out) = get_tagged_state tag prin sess_id tr in
@@ -210,8 +210,8 @@ val get_tagged_state_invariant:
   ))
   [SMTPat (get_tagged_state tag prin sess_id tr);
    SMTPat (trace_invariant tr);
-   SMTPat (has_local_bytes_state_predicate invs (tag, spred))]
-let get_tagged_state_invariant invs tag spred prin sess_id tr =
+   SMTPat (has_local_bytes_state_predicate (tag, spred))]
+let get_tagged_state_invariant #invs tag spred prin sess_id tr =
   reveal_opaque (`%has_local_bytes_state_predicate) (has_local_bytes_state_predicate);
   reveal_opaque (`%get_tagged_state) (get_tagged_state);
   let (opt_content, tr_out) = get_tagged_state tag prin sess_id tr in
@@ -219,29 +219,29 @@ let get_tagged_state_invariant invs tag spred prin sess_id tr =
   | None -> ()
   | Some content ->
     let (Some full_content_bytes, tr) = get_state prin sess_id tr in
-    local_eq_global_lemma split_local_bytes_state_predicate_params state_pred tag spred (tr, prin, sess_id, full_content_bytes) tag (tr, prin, sess_id, content)
+    local_eq_global_lemma split_local_bytes_state_predicate_params state_pred.pred tag spred (tr, prin, sess_id, full_content_bytes) tag (tr, prin, sess_id, content)
 
 (*** Theorem ***)
 
 val tagged_state_was_set_implies_pred:
-  invs:protocol_invariants -> tr:trace ->
+  {|protocol_invariants|} -> tr:trace ->
   tag:string -> spred:local_bytes_state_predicate ->
   prin:principal -> sess_id:state_id -> content:bytes ->
   Lemma
   (requires
     tagged_state_was_set tr tag prin sess_id content /\
     trace_invariant tr /\
-    has_local_bytes_state_predicate invs (tag, spred)
+    has_local_bytes_state_predicate (tag, spred)
   )
   (ensures spred.pred tr prin sess_id content)
   [SMTPat (tagged_state_was_set tr tag prin sess_id content);
    SMTPat (trace_invariant tr);
-   SMTPat (has_local_bytes_state_predicate invs (tag, spred));
+   SMTPat (has_local_bytes_state_predicate (tag, spred));
   ]
-let tagged_state_was_set_implies_pred invs tr tag spred prin sess_id content =
+let tagged_state_was_set_implies_pred #invs tr tag spred prin sess_id content =
   reveal_opaque (`%has_local_bytes_state_predicate) (has_local_bytes_state_predicate);
   reveal_opaque (`%tagged_state_was_set) (tagged_state_was_set);
   let full_content = {tag; content;} in
   parse_serialize_inv_lemma #bytes tagged_state full_content;
   let full_content_bytes: bytes = serialize tagged_state full_content in
-  local_eq_global_lemma split_local_bytes_state_predicate_params state_pred tag spred (tr, prin, sess_id, full_content_bytes) tag (tr, prin, sess_id, content)
+  local_eq_global_lemma split_local_bytes_state_predicate_params state_pred.pred tag spred (tr, prin, sess_id, full_content_bytes) tag (tr, prin, sess_id, content)


### PR DESCRIPTION
As proposed in #46, this PR use the typeclass mechanism more systematically for invariants.
The idea is that everywhere in the code there should only be one global invariant in the scope:
- either it is defined somewhere in the global scope, as it is done e.g. in the NSL or ISO-DH examples
- or it is a parameter of security proofs, as it is done in most of `DY.Lib`

It means that instead of typing these arguments by hand, we can let the typeclass resolution algorithm do that for us because there is only one possibility.