### PR TITLE
cleanup: use more modular proofs in examples

### DIFF
--- a/examples/nsl_pk/DY.Example.NSL.Invariants.fst
+++ b/examples/nsl_pk/DY.Example.NSL.Invariants.fst
@@ -1,0 +1,88 @@
+module DY.Example.NSL.Invariants
+
+open Comparse
+open DY.Core
+open DY.Lib
+open DY.Example.NSL.Protocol.Total.Proof
+open DY.Example.NSL.Protocol.Stateful
+open DY.Example.NSL.Protocol.Stateful.Proof
+
+#set-options "--fuel 0 --ifuel 0"
+
+/// Crypto Usages
+
+instance nsl_crypto_usages: crypto_usages = default_crypto_usages
+
+/// List of all local pkenc predicates
+
+let all_pkenc_tag_and_preds = [
+  nsl_tag_and_pkenc_pred;
+]
+
+let nsl_crypto_predicates: crypto_predicates nsl_crypto_usages = {
+  default_crypto_predicates nsl_crypto_usages with
+  pkenc_pred = mk_pkenc_predicate all_pkenc_tag_and_preds
+}
+
+/// Crypto Invariants
+
+instance nsl_crypto_invariants: crypto_invariants = {
+  usages = nsl_crypto_usages;
+  preds = nsl_crypto_predicates;
+}
+
+// fuel 1 is a workaround for FStarLang/FStar#3360
+#push-options "--fuel 1"
+val nsl_crypto_invariants_has_nsl_crypto_invariants:
+  unit ->
+  Lemma (has_nsl_crypto_invariants #nsl_crypto_invariants)
+let nsl_crypto_invariants_has_nsl_crypto_invariants () =
+  assert_norm(List.Tot.no_repeats_p (List.Tot.map fst all_pkenc_tag_and_preds));
+  mk_pkenc_predicate_correct nsl_crypto_invariants all_pkenc_tag_and_preds;
+  norm_spec [delta_only [`%all_pkenc_tag_and_preds; `%for_allP]; iota; zeta] (for_allP (has_pkenc_predicate nsl_crypto_invariants) all_pkenc_tag_and_preds)
+#pop-options
+
+/// List of all local state predicates.
+
+let all_state_tag_and_preds = [
+  pki_tag_and_invariant;
+  private_keys_tag_and_invariant;
+  (local_state_nsl_session.tag, local_state_predicate_to_local_bytes_state_predicate state_predicate_nsl);
+]
+
+/// List of all local event predicates.
+
+let all_event_tag_and_preds = [
+  (event_nsl_event.tag, compile_event_pred event_predicate_nsl)
+]
+
+/// Trace Invariant
+
+let nsl_trace_invariants: trace_invariants nsl_crypto_invariants = {
+  state_pred = mk_state_pred nsl_crypto_invariants all_state_tag_and_preds;
+  event_pred = mk_event_pred all_event_tag_and_preds;
+}
+
+/// Protocol Invariants
+
+instance nsl_protocol_invariants: protocol_invariants = {
+  crypto_invs = nsl_crypto_invariants;
+  trace_invs = nsl_trace_invariants;
+}
+
+// fuel 1 is a workaround for FStarLang/FStar#3360
+#push-options "--fuel 1"
+val nsl_protocol_invariants_has_nsl_invariants:
+  unit ->
+  Lemma (has_nsl_invariants #nsl_protocol_invariants)
+let nsl_protocol_invariants_has_nsl_invariants () =
+  nsl_crypto_invariants_has_nsl_crypto_invariants ();
+
+  assert_norm(List.Tot.no_repeats_p (List.Tot.map fst (all_state_tag_and_preds)));
+  mk_state_pred_correct nsl_protocol_invariants all_state_tag_and_preds;
+  norm_spec [delta_only [`%all_state_tag_and_preds; `%for_allP]; iota; zeta] (for_allP (has_local_bytes_state_predicate nsl_protocol_invariants) all_state_tag_and_preds);
+
+  assert_norm(List.Tot.no_repeats_p (List.Tot.map fst (all_event_tag_and_preds)));
+  mk_event_pred_correct nsl_protocol_invariants all_event_tag_and_preds;
+  norm_spec [delta_only [`%all_event_tag_and_preds; `%for_allP]; iota; zeta] (for_allP (has_compiled_event_pred nsl_protocol_invariants) all_event_tag_and_preds)
+#pop-options

--- a/examples/nsl_pk/DY.Example.NSL.SecurityProperties.fst
+++ b/examples/nsl_pk/DY.Example.NSL.SecurityProperties.fst
@@ -22,41 +22,46 @@ open DY.Example.NSL.Protocol.Stateful.Proof
 /// unless the attacker corrupted Alice or Bob.
 
 val initiator_authentication:
+  {|protocol_invariants|} ->
   tr:trace -> i:timestamp ->
   alice:principal -> bob:principal -> n_a:bytes -> n_b:bytes ->
   Lemma
   (requires
     event_triggered_at tr i bob (Respond2 alice bob n_a n_b) /\
-    trace_invariant tr
+    trace_invariant tr /\
+    has_nsl_invariants
   )
   (ensures
     is_corrupt tr (principal_label alice) \/ is_corrupt tr (principal_label bob) \/
     event_triggered (prefix tr i) alice (Initiate2 alice bob n_a n_b)
   )
-let initiator_authentication tr i alice bob n_a n_b = ()
+let initiator_authentication #invs tr i alice bob n_a n_b = ()
 
 /// If Alice thinks she talks with Bob,
 /// then Bob thinks he talk to Alice (with the same nonces),
 /// unless the attacker corrupted Alice or Bob.
 
 val responder_authentication:
+  {|protocol_invariants|} ->
   tr:trace -> i:timestamp ->
   alice:principal -> bob:principal -> n_a:bytes -> n_b:bytes ->
   Lemma
   (requires
     event_triggered_at tr i alice (Initiate2 alice bob n_a n_b) /\
-    trace_invariant tr
+    trace_invariant tr /\
+    has_nsl_invariants
   )
   (ensures
     is_corrupt tr (principal_label alice) \/ is_corrupt tr (principal_label bob) \/
     event_triggered (prefix tr i) bob (Respond1 alice bob n_a n_b)
   )
-let responder_authentication tr i alice bob n_a n_b = ()
+let responder_authentication #invs tr i alice bob n_a n_b = ()
 
 /// The nonce n_a is unknown to the attacker,
 /// unless the attacker corrupted Alice or Bob.
 
 val n_a_secrecy:
+  {|protocol_invariants|} ->
   tr:trace -> alice:principal -> bob:principal -> n_a:bytes ->
   Lemma
   (requires
@@ -65,16 +70,18 @@ val n_a_secrecy:
       (exists sess_id. state_was_set tr alice sess_id (InitiatorSentMsg1 bob n_a)) \/
       (exists sess_id n_b. state_was_set tr alice sess_id (InitiatorSentMsg3 bob n_a n_b)) \/
       (exists sess_id n_b. state_was_set tr bob sess_id (ResponderReceivedMsg3 alice n_a n_b))
-    )
+    ) /\
+    has_nsl_invariants
   )
   (ensures is_corrupt tr (principal_label alice) \/ is_corrupt tr (principal_label bob))
-let n_a_secrecy tr alice bob n_a =
+let n_a_secrecy #invs tr alice bob n_a =
   attacker_only_knows_publishable_values tr n_a
 
 /// The nonce n_b is unknown to the attacker,
 /// unless the attacker corrupted Alice or Bob.
 
 val n_b_secrecy:
+  {|protocol_invariants|} ->
   tr:trace -> alice:principal -> bob:principal -> n_b:bytes ->
   Lemma
   (requires
@@ -83,8 +90,9 @@ val n_b_secrecy:
       (exists sess_id n_a. state_was_set tr bob sess_id (ResponderSentMsg2 alice n_a n_b)) \/
       (exists sess_id n_a. state_was_set tr bob sess_id (ResponderReceivedMsg3 alice n_a n_b)) \/
       (exists sess_id n_a. state_was_set tr alice sess_id (InitiatorSentMsg3 bob n_a n_b))
-    )
+    ) /\
+    has_nsl_invariants
   )
   (ensures is_corrupt tr (principal_label alice) \/ is_corrupt tr (principal_label bob))
-let n_b_secrecy tr alice bob n_b =
+let n_b_secrecy #invs tr alice bob n_b =
   attacker_only_knows_publishable_values tr n_b


### PR DESCRIPTION
Another fix for #37. All the post-conditions of the `protocol_invariants_nsl_has_...` lemmas are now in `has_nsl_invariants`, and all security theorems for NSL rely on the precondition `has_nsl_invariant`, so that they work for any protocol invariants that contain NSL invariants.
To prove that this precondition is not too strict, and there exists protocol invariants that satisfy `has_nsl_invariants`, we create one in `DY.Example.NSL.Invariants`.

The boilerplate of this is method is:
- 2 lines for each predicate (one in `has_nsl_invariants`, one in the list of `DY.Example.NSL.Invariants`), this is improved
- about 3 lines for each type of predicate (the `assert_norm`, the correctness lemma, and the normalization of the correctness lemma), same as before

Marking this as a draft, if we think this is a good idea:
- we need to do the same thing for ISO-DH
- and it would be nice to prove that the debug trace of NSL actually preserves the trace invariants