### PR TITLE
feat: generalize labels to be predicates

### DIFF
--- a/examples/iso_dh/DY.Example.DH.Protocol.Total.Proof.fst
+++ b/examples/iso_dh/DY.Example.DH.Protocol.Total.Proof.fst
@@ -165,7 +165,7 @@ let compute_message2_proof tr alice bob gx y sk_b n_sig =
   assert(is_publishable tr (compute_message2 alice bob gx gy sk_b n_sig));
   ()
 
-#push-options "--ifuel 1 --z3rlimit 10"
+#push-options "--ifuel 1 --z3rlimit 20"
 val decode_and_verify_message2_proof:
   tr:trace ->
   msg2_bytes:bytes ->

--- a/examples/nsl_pk/DY.Example.NSL.Protocol.Stateful.Proof.fst
+++ b/examples/nsl_pk/DY.Example.NSL.Protocol.Stateful.Proof.fst
@@ -55,14 +55,14 @@ let event_predicate_nsl: event_predicate nsl_event =
     | Initiate1 alice bob n_a -> (
       prin == alice /\
       is_secret (join (principal_label alice) (principal_label bob)) tr n_a /\
-      0 < DY.Core.Trace.Type.length tr /\
-      rand_generated_at tr (DY.Core.Trace.Type.length tr - 1) n_a
+      0 < DY.Core.Trace.Base.length tr /\
+      rand_generated_at tr (DY.Core.Trace.Base.length tr - 1) n_a
     )
     | Respond1 alice bob n_a n_b -> (
       prin == bob /\
       is_secret (join (principal_label alice) (principal_label bob)) tr n_b /\
-      0 < DY.Core.Trace.Type.length tr /\
-      rand_generated_at tr (DY.Core.Trace.Type.length tr - 1) n_b
+      0 < DY.Core.Trace.Base.length tr /\
+      rand_generated_at tr (DY.Core.Trace.Base.length tr - 1) n_b
     )
     | Initiate2 alice bob n_a n_b -> (
       prin == alice /\

--- a/src/core/DY.Core.Attacker.Knowledge.fst
+++ b/src/core/DY.Core.Attacker.Knowledge.fst
@@ -3,6 +3,7 @@ module DY.Core.Attacker.Knowledge
 open DY.Core.Bytes.Type
 open DY.Core.Bytes
 open DY.Core.Trace.Type
+open DY.Core.Trace.Base
 open DY.Core.Trace.Invariant
 open DY.Core.Label.Type
 open DY.Core.Label

--- a/src/core/DY.Core.Bytes.Type.fst
+++ b/src/core/DY.Core.Bytes.Type.fst
@@ -1,7 +1,5 @@
 module DY.Core.Bytes.Type
 
-open DY.Core.Label.Type
-
 /// This module defines the types associated with bytes.
 /// It is separated from functions and predicates on bytes
 /// in order to avoid dependency cycles.

--- a/src/core/DY.Core.Bytes.fst
+++ b/src/core/DY.Core.Bytes.fst
@@ -2,6 +2,7 @@ module DY.Core.Bytes
 
 open DY.Core.Bytes.Type
 open DY.Core.Trace.Type
+open DY.Core.Trace.Base
 open DY.Core.Label.Type
 open DY.Core.Label
 open DY.Core.Label.Derived
@@ -106,7 +107,7 @@ let rec bytes_well_formed tr b =
   | Literal buf ->
     True
   | Rand usg len time ->
-    time < DY.Core.Trace.Type.length tr /\
+    time < DY.Core.Trace.Base.length tr /\
     RandGen? (get_event_at tr time)
   | Concat left right ->
     bytes_well_formed tr left /\
@@ -389,7 +390,7 @@ let rec get_label #cusages tr b =
   | Literal buf ->
     public
   | Rand usg len time ->
-    if time < DY.Core.Trace.Type.length tr then (
+    if time < DY.Core.Trace.Base.length tr then (
       match get_event_at tr time with
       | RandGen _ lab _ -> lab
       | _ -> DY.Core.Label.Unknown.unknown_label

--- a/src/core/DY.Core.Label.Derived.fst
+++ b/src/core/DY.Core.Label.Derived.fst
@@ -1,7 +1,7 @@
 module DY.Core.Label.Derived
 
 open DY.Core.Label.Type
-open DY.Core.Trace.Type
+open DY.Core.Trace.Base
 open DY.Core.Label
 
 /// This module defines auxillary predicates and lemmas

--- a/src/core/DY.Core.Label.Type.fst
+++ b/src/core/DY.Core.Label.Type.fst
@@ -1,51 +1,35 @@
 module DY.Core.Label.Type
 
+open DY.Core.Trace.Type
+
 /// This module defines the types associated with labels.
 /// It is separated from functions and predicates on labels
 /// in order to avoid dependency cycles.
-
-/// Principals are described using strings (such as "Alice").
-
-type principal = string
-
-/// Type for session identifiers
-
-type state_id = { the_id: nat; }
-
-/// Pre-labels are used to refer to a particular state of a principal that may be compromised by the attacker,
-/// that is, a principal name and a session id (the `S` constructor).
 ///
-/// Pre-labels also include more general labels, such as the `P` constructor
-/// that is used to refer to any state of a principal.
-/// A pre-label for a principal (`P`) is weaker than a pre-label for principal and state (`S`).
-/// This is because `P prin` is considered to be corrupt when there exists any state of `prin` that is corrupt,
-/// whereas `S prin sess_id` is corrupt only when this particular state is corrupted by the attacker.
-/// For example, Alice may store her long-term private key in some state (with session id 0),
-/// and ephemeral keys in another state (with session id 1).
-/// If the ephemeral keys state is corrupt by the attacker, then
-/// - `P "Alice"` is corrupt
-/// - `S "Alice" 0` is not corrupt
-/// - `S "Alice" 1` is corrupt.
-/// We then see why `P "Alice"` is a weaker pre-label than `S "Alice" 0`.
+/// In full generality, a label is a predicate on the trace
+/// stating whether the attacker has performed some amount of corruption
+/// (see DY.Core.Label for more explanations).
 ///
-/// Advanced note: `P prin` roughly corresponds to an "infinite join":
-/// it is in practice behaving like `join (S prin 0) (join (S prin 1) (join ...))`.
-/// It is hard-coded like this because infinite joins are not supported:
-/// only finite joins are supported (via the binary join that can be folded on a list).
-
-type pre_label =
-  | P: principal -> pre_label
-  | S: principal -> state_id -> pre_label
-
-/// Labels are roughly a free lattice on pre-labels,
-/// with lower bound (meet) and upper bound (join),
-/// as well as a minima (secret) and maxima (public).
+/// We therefore want labels to be predicates `trace -> prop`,
+/// however this doesn't work with F*'s positivity checker.
+/// (see https://fstar-lang.org/tutorial/book/part2/part2_inductive_type_families.html#strictly-positive-definitions )
+/// Indeed, we want the trace to contain labels (see `RandGen` event),
+/// and we want labels to be predicates on the trace, namely `trace -> prop` (see DY.Core.Label.Type).
+/// A type `t` cannot contain `t -> prop` because this could be used to derive False (using Cantor's diagonal argument).
+/// To circumvent that, labels are predicates on traces with no labels (i.e. whose label type is `unit`).
+/// This solves the positivity issue because `trace_ label` contain labels that are `trace_ unit -> prop`,
+/// which respects the positivity condition.
+/// It means that labels cannot decide about their corruption depending on other labels in the trace,
+/// but this is not a problem in practice.
 
 [@@erasable]
 noeq
-type label =
-  | Secret: label
-  | State: pre_label -> label
-  | Meet: label -> label -> label
-  | Join: label -> label -> label
-  | Public: label
+type label = {
+  is_corrupt: trace_ unit -> prop;
+  is_corrupt_later:
+    tr:trace_ unit -> ev:trace_event_ unit ->
+    Lemma
+    (requires is_corrupt tr)
+    (ensures is_corrupt (Snoc tr ev))
+  ;
+}

--- a/src/core/DY.Core.Label.Unknown.fst
+++ b/src/core/DY.Core.Label.Unknown.fst
@@ -1,3 +1,10 @@
 module DY.Core.Label.Unknown
 
-let unknown_label = Public
+/// The unknown label is in reality public (i.e. always corrupt).
+/// However we can't reason on it because it's hidden behind an interface file,
+/// unless we `friend DY.Core.Label.Unknown`, which we shouldn't do.
+
+let unknown_label = {
+  is_corrupt = (fun tr -> True);
+  is_corrupt_later = (fun tr ev -> ());
+}

--- a/src/core/DY.Core.Trace.Base.fst
+++ b/src/core/DY.Core.Trace.Base.fst
@@ -1,0 +1,349 @@
+module DY.Core.Trace.Base
+
+open DY.Core.Trace.Type
+open DY.Core.Bytes.Type
+open DY.Core.Label.Type
+
+/// Shorthands for trace and trace events.
+
+type trace_event = trace_event_ label
+type trace = trace_ label
+
+/// The length of a trace.
+
+val length: #label_t:Type -> trace_ label_t -> nat
+let rec length tr =
+  match tr with
+  | Nil -> 0
+  | Snoc init last -> length init + 1
+
+/// a type macro for timestamps (indices on the trace)
+
+type timestamp = nat
+
+(*** Prefix and trace_ extension ***)
+
+/// Compute the prefix of a trace.
+
+[@@ "opaque_to_smt"]
+val prefix: #label_t:Type -> tr:trace_ label_t -> i:timestamp{i <= length tr} -> trace_ label_t
+let rec prefix tr i =
+  if length tr = i then
+    tr
+  else
+    let Snoc tr_init _ = tr in
+    prefix tr_init i
+
+/// Express whether a trace is the extension of another.
+/// This is a crucial relation between traces,
+/// because the trace only grows during a protocol execution.
+
+[@@ "opaque_to_smt"]
+val grows: #label_t:Type -> trace_ label_t -> trace_ label_t -> prop
+let grows tr1 tr2 =
+  length tr1 <= length tr2 /\
+  tr1 == prefix tr2 (length tr1)
+
+/// It is used a lot in DY*, therefore we define an operator shorthand.
+
+let (<$) = grows
+
+val grows_induction_principle:
+  #label_t:Type ->
+  p:(trace_ label_t -> prop) ->
+  (tr:trace_ label_t -> ev:trace_event_ label_t -> Lemma (requires p tr) (ensures p (Snoc tr ev))) ->
+  tr1:trace_ label_t -> tr2:trace_ label_t ->
+  Lemma
+  (requires
+    p tr1 /\
+    tr1 <$ tr2
+  )
+  (ensures p tr2)
+let rec grows_induction_principle #label_t p pf tr1 tr2 =
+  reveal_opaque (`%grows) (grows #label_t);
+  norm_spec [zeta; delta_only [`%prefix]] (prefix #label_t);
+  if length tr1 = length tr2 then ()
+  else (
+    let Snoc init2 last2 = tr2 in
+    grows_induction_principle p pf tr1 init2;
+    pf init2 last2
+  )
+
+/// The relation <$ is reflexive.
+
+val grows_reflexive:
+  tr:trace ->
+  Lemma (tr <$ tr)
+  [SMTPat (tr <$ tr)]
+let grows_reflexive tr =
+  reveal_opaque (`%grows) (grows #label);
+  norm_spec [zeta; delta_only [`%prefix]] (prefix #label)
+
+/// The relation <$ is transitive.
+
+val grows_transitive:
+  tr1:trace -> tr2:trace -> tr3:trace ->
+  Lemma
+  (requires tr1 <$ tr2 /\ tr2 <$ tr3)
+  (ensures tr1 <$ tr3)
+  [SMTPat (tr1 <$ tr2); SMTPat (tr1 <$ tr3)]
+let rec grows_transitive tr1 tr2 tr3 =
+  reveal_opaque (`%grows) (grows #label);
+  norm_spec [zeta; delta_only [`%prefix]] (prefix #label);
+  if length tr2 >= length tr3 then
+    ()
+  else (
+    let Snoc tr3_init _ = tr3 in
+    grows_transitive tr1 tr2 tr3_init
+  )
+
+/// The prefix function outputs traces of the correct length.
+
+val length_prefix:
+  tr:trace -> i:timestamp{i <= length tr} ->
+  Lemma
+  (ensures length (prefix tr i) == i)
+  [SMTPat (length (prefix tr i))]
+let rec length_prefix tr i =
+  norm_spec [zeta; delta_only [`%prefix]] (prefix #label);
+  if length tr = i then ()
+  else
+    let Snoc tr_init _ = tr in
+    length_prefix tr_init i
+
+/// A trace which is the prefix of another is shorter.
+
+val length_grows:
+  tr1:trace -> tr2:trace ->
+  Lemma
+  (requires tr1 <$ tr2)
+  (ensures length tr1 <= length tr2)
+  [SMTPat (tr1 <$ tr2)]
+let length_grows tr1 tr2 =
+  reveal_opaque (`%grows) (grows #label)
+
+/// The prefix function outputs traces that are prefixes of the input.
+
+val prefix_grows:
+  tr:trace -> i:timestamp{i <= length tr} ->
+  Lemma
+  (ensures (prefix tr i) <$ tr)
+  //TODO: is this SMTPat dangerous? Should we restrict it to the "safe" on below?
+  [SMTPat (prefix tr i)]
+  //[SMTPat ((prefix tr i) <$ tr)]
+let prefix_grows tr i =
+  reveal_opaque (`%grows) (grows #label);
+  norm_spec [zeta; delta_only [`%prefix]] (prefix #label)
+
+val prefix_prefix_grows:
+  tr1:trace -> tr2:trace -> i1:timestamp -> i2:timestamp ->
+  Lemma
+  (requires
+    tr1 <$ tr2 /\
+    i1 <= length tr1 /\
+    i2 <= length tr2 /\
+    i1 <= i2
+  )
+  (ensures prefix tr1 i1 <$ prefix tr2 i2)
+  [SMTPat (prefix tr1 i1 <$ prefix tr2 i2)]
+  // Alternative SMT pattern if the above one doesn't trigger enough
+  // [SMTPat (prefix tr1 i1);
+  //  SMTPat (prefix tr2 i2);
+  //  SMTPat (tr1 <$ tr2)]
+let rec prefix_prefix_grows tr1 tr2 i1 i2 =
+  reveal_opaque (`%grows) (grows #label);
+  norm_spec [zeta; delta_only [`%prefix]] (prefix #label);
+  if i2 = length tr2 then ()
+  else if length tr1 = length tr2 then (
+    let Snoc tr1_init _ = tr1 in
+    let Snoc tr2_init _ = tr2 in
+    prefix_prefix_grows tr1_init tr2_init i1 i2
+  ) else (
+    let Snoc tr2_init _ = tr2 in
+    prefix_prefix_grows tr1 tr2_init i1 i2
+  )
+
+val prefix_prefix_eq:
+  tr1:trace -> tr2:trace -> i:timestamp ->
+  Lemma
+  (requires
+    tr1 <$ tr2 /\
+    i <= length tr1
+  )
+  (ensures prefix tr1 i == prefix tr2 i)
+  [SMTPat (prefix tr1 i);
+   SMTPat (prefix tr2 i);
+   SMTPat (tr1 <$ tr2)]
+let rec prefix_prefix_eq tr1 tr2 i =
+  reveal_opaque (`%grows) (grows #label);
+  norm_spec [zeta; delta_only [`%prefix]] (prefix #label);
+  if length tr1 = length tr2 then ()
+  else (
+    let Snoc tr2_init _ = tr2 in
+    prefix_prefix_eq tr1 tr2_init i
+  )
+
+(*** Event in the trace predicates ***)
+
+/// Retrieve the event at some timestamp in the trace.
+
+val get_event_at:
+  #label_t:Type ->
+  tr:trace_ label_t -> i:timestamp{i < length tr} ->
+  trace_event_ label_t
+let rec get_event_at tr i =
+  if i+1 = length tr then
+    let Snoc _ last = tr in
+    last
+  else (
+    let Snoc tr_init _ = tr in
+    get_event_at tr_init i
+  )
+
+/// Has some particular event been triggered at a some particular timestamp in the trace?
+
+val event_at:
+  #label_t:Type ->
+  trace_ label_t -> timestamp -> trace_event_ label_t ->
+  prop
+let event_at tr i e =
+  if i >= length tr then
+    False
+  else
+    e == get_event_at tr i
+
+/// Has some particular event been triggered in the trace (at any timestamp)?
+
+val event_exists:
+  #label_t:Type ->
+  trace_ label_t -> trace_event_ label_t ->
+  prop
+let event_exists tr e =
+  exists i. event_at tr i e
+
+/// An event in the trace stays here when the trace grows.
+
+val event_at_grows:
+  #label_t:Type ->
+  tr1:trace_ label_t -> tr2:trace_ label_t ->
+  i:timestamp -> e:trace_event_ label_t ->
+  Lemma
+  (requires event_at tr1 i e /\ tr1 <$ tr2)
+  (ensures event_at tr2 i e)
+  [SMTPat (event_at tr1 i e); SMTPat (tr1 <$ tr2)]
+let rec event_at_grows #label_t tr1 tr2 i e =
+  reveal_opaque (`%grows) (grows #label_t);
+  norm_spec [zeta; delta_only [`%prefix]] (prefix #label_t);
+  if i >= length tr1 then ()
+  else if length tr1 >= length tr2 then ()
+  else (
+    let Snoc tr2_init _ = tr2 in
+    event_at_grows tr1 tr2_init i e
+  )
+
+/// Shorthand predicates.
+
+/// Has a message been sent on the network?
+
+val msg_sent_on_network: trace -> bytes -> prop
+let msg_sent_on_network tr msg =
+  event_exists tr (MsgSent msg)
+
+/// Has some state been stored by a principal?
+
+val state_was_set: trace -> principal -> state_id -> bytes -> prop
+let state_was_set tr prin sess_id content =
+  event_exists tr (SetState prin sess_id content)
+
+/// Has a principal been corrupt?
+
+val was_corrupt: #label_t:Type -> trace_ label_t -> principal -> state_id -> prop
+let was_corrupt tr prin sess_id =
+  event_exists tr (Corrupt prin sess_id)
+
+/// Has a (custom, protocol-specific) event been triggered at some timestamp?
+
+val event_triggered_at: trace -> timestamp -> principal -> string -> bytes -> prop
+let event_triggered_at tr i prin tag content =
+  event_at tr i (Event prin tag content)
+
+/// Has a (custom, protocol-specific) event been triggered (at any timestamp)?
+
+val event_triggered: trace -> principal -> string -> bytes -> prop
+let event_triggered tr prin tag content =
+  exists i. event_triggered_at tr i prin tag content
+
+/// An event being triggered at some time stays triggered as the trace grows.
+
+val event_triggered_grows:
+  tr1:trace -> tr2:trace ->
+  prin:principal -> tag:string -> content:bytes  ->
+  Lemma
+  (requires event_triggered tr1 prin tag content /\ tr1 <$ tr2)
+  (ensures event_triggered tr2 prin tag content)
+  [SMTPat (event_triggered tr1 prin tag content); SMTPat (tr1 <$ tr2)]
+let event_triggered_grows tr1 tr2 prin tag content = ()
+
+/// Has a random bytestring been generated at some timestamp?
+
+val rand_generated_at: trace -> timestamp -> bytes -> prop
+let rand_generated_at tr i b =
+  match b with
+  | Rand usg len time ->
+    time == i /\ (exists lab. event_at tr i (RandGen usg lab len))
+  | _ -> False
+
+(*** Forgetting labels ***)
+
+/// Functions to replace labels in a trace by `()`.
+/// This is useful to use labels that are predicates on `trace_ unit`
+/// with actual traces that are `trace_ label`.
+/// See `DY.Core.Label.Type` for more information
+
+val trace_event_forget_labels:
+  trace_event ->
+  trace_event_ unit
+let trace_event_forget_labels ev =
+  match ev with
+  | MsgSent msg -> MsgSent msg
+  | RandGen usg lab len -> RandGen usg () len
+  | Corrupt prin sess_id -> Corrupt prin sess_id
+  | SetState prin sess_id content -> SetState prin sess_id content
+  | Event prin tag content -> Event prin tag content
+
+val trace_forget_labels:
+  trace ->
+  trace_ unit
+let rec trace_forget_labels tr =
+  match tr with
+  | Nil -> Nil
+  | Snoc init last ->
+    Snoc (trace_forget_labels init) (trace_event_forget_labels last)
+
+val length_trace_forget_labels:
+  tr:trace ->
+  Lemma (length (trace_forget_labels tr) == length tr)
+let rec length_trace_forget_labels tr =
+  match tr with
+  | Nil -> ()
+  | Snoc init last -> length_trace_forget_labels init
+
+val trace_forget_labels_later:
+  tr1:trace -> tr2:trace ->
+  Lemma
+  (requires tr1 <$ tr2)
+  (ensures (trace_forget_labels tr1) <$ (trace_forget_labels tr2))
+let rec trace_forget_labels_later tr1 tr2 =
+  reveal_opaque (`%grows) (grows #unit);
+  norm_spec [zeta; delta_only [`%prefix]] (prefix #unit);
+  reveal_opaque (`%grows) (grows #label);
+  norm_spec [zeta; delta_only [`%prefix]] (prefix #label);
+  if length tr1 = length tr2 then (
+    match tr1, tr2 with
+    | Nil, Nil -> ()
+    | Snoc tr1_init _, Snoc tr2_init _ -> ()
+  ) else (
+    let Snoc tr2_init tr2_last = tr2 in
+    trace_forget_labels_later tr1 tr2_init
+  )
+

--- a/src/core/DY.Core.Trace.Invariant.fst
+++ b/src/core/DY.Core.Trace.Invariant.fst
@@ -1,6 +1,7 @@
 module DY.Core.Trace.Invariant
 
 open DY.Core.Trace.Type
+open DY.Core.Trace.Base
 open DY.Core.Bytes.Type
 open DY.Core.Bytes
 open DY.Core.Label.Type
@@ -126,8 +127,8 @@ val event_at_implies_trace_event_invariant:
   )
 let rec event_at_implies_trace_event_invariant #invs tr i event =
   norm_spec [zeta; delta_only [`%trace_invariant]] (trace_invariant);
-  norm_spec [zeta; delta_only [`%prefix]] (prefix);
-  if i+1 = DY.Core.Trace.Type.length tr then ()
+  norm_spec [zeta; delta_only [`%prefix]] (prefix #label);
+  if i+1 = DY.Core.Trace.Base.length tr then ()
   else (
     let Snoc tr_init _ = tr in
     event_at_implies_trace_event_invariant tr_init i event

--- a/src/core/DY.Core.Trace.Manipulation.fst
+++ b/src/core/DY.Core.Trace.Manipulation.fst
@@ -1,6 +1,7 @@
 module DY.Core.Trace.Manipulation
 
 open DY.Core.Trace.Type
+open DY.Core.Trace.Base
 open DY.Core.Trace.Invariant
 open DY.Core.Bytes.Type
 open DY.Core.Bytes
@@ -58,16 +59,16 @@ let (let*?) #a #b x f tr0 =
 
 val return: #a:Type -> a -> traceful a
 let return #a x tr =
-  reveal_opaque (`%grows) (grows);
-  norm_spec [zeta; delta_only [`%prefix]] (prefix);
+  reveal_opaque (`%grows) (grows #label);
+  norm_spec [zeta; delta_only [`%prefix]] (prefix #label);
   (x, tr)
 
 /// getter for the trace monad.
 
 val get_trace: traceful trace
 let get_trace tr =
-  reveal_opaque (`%grows) (grows);
-  norm_spec [zeta; delta_only [`%prefix]] (prefix);
+  reveal_opaque (`%grows) (grows #label);
+  norm_spec [zeta; delta_only [`%prefix]] (prefix #label);
   (tr, tr)
 
 /// guard function for the option monad.
@@ -102,8 +103,8 @@ let invert_traceful_option a =
 
 val add_event: trace_event -> traceful unit
 let add_event e tr =
-  reveal_opaque (`%grows) (grows);
-  norm_spec [zeta; delta_only [`%prefix]] (prefix);
+  reveal_opaque (`%grows) (grows #label);
+  norm_spec [zeta; delta_only [`%prefix]] (prefix #label);
   ((), Snoc tr e)
 
 /// Adding a trace event preserves the trace invariant
@@ -130,7 +131,7 @@ let add_event_invariant #invs e tr =
 val get_time: traceful timestamp
 let get_time =
   let* tr = get_trace in
-  return (DY.Core.Trace.Type.length tr)
+  return (DY.Core.Trace.Base.length tr)
 
 (*** Sending messages ***)
 
@@ -170,7 +171,7 @@ let send_msg_invariant #invs msg tr =
 val recv_msg: timestamp -> traceful (option bytes)
 let recv_msg i =
   let* tr = get_trace in
-  if i < DY.Core.Trace.Type.length tr then
+  if i < DY.Core.Trace.Base.length tr then
     match get_event_at tr i with
     | MsgSent msg -> return (Some msg)
     | _ -> return None
@@ -254,8 +255,8 @@ val mk_rand_trace_invariant:
   (ensures (
     let (b, tr_out) = mk_rand usg lab len tr in
     trace_invariant tr_out /\
-    1 <= DY.Core.Trace.Type.length tr_out /\
-    rand_generated_at tr_out (DY.Core.Trace.Type.length tr_out - 1) b
+    1 <= DY.Core.Trace.Base.length tr_out /\
+    rand_generated_at tr_out (DY.Core.Trace.Base.length tr_out - 1) b
   ))
   [SMTPat (mk_rand usg lab len tr); SMTPat (trace_invariant tr)]
 let mk_rand_trace_invariant #invs usg lab len tr =
@@ -441,9 +442,9 @@ val get_state_aux_state_invariant:
     | Some content -> state_pred.pred tr prin sess_id content
   ))
 let rec get_state_aux_state_invariant #invs prin sess_id tr =
-  reveal_opaque (`%grows) (grows);
+  reveal_opaque (`%grows) (grows #label);
   norm_spec [zeta; delta_only [`%trace_invariant]] (trace_invariant);
-  norm_spec [zeta; delta_only [`%prefix]] (prefix);
+  norm_spec [zeta; delta_only [`%prefix]] (prefix #label);
   match tr with
   | Nil -> ()
   | Snoc tr_init (SetState prin' sess_id' content) -> (

--- a/src/core/DY.Core.Trace.Type.fst
+++ b/src/core/DY.Core.Trace.Type.fst
@@ -1,9 +1,8 @@
 module DY.Core.Trace.Type
 
 open DY.Core.Bytes.Type
-open DY.Core.Label.Type
 
-/// This module defines the trace type, and simple predicates on it.
+/// This module defines the trace type.
 /// It is separated from functions and predicates on trace (manipulation, invariants)
 /// in order to avoid dependency cycles.
 ///
@@ -27,22 +26,33 @@ open DY.Core.Label.Type
 ///   in every trace resulting from an execution of the protocol,
 ///   if Alice has finished a handshake with Bob,
 ///   then Bob must have initiated a handshake with Alice.
+///
+/// The trace type is parametrized by the label type
+/// as a trick to avoid problems with the positivity checker.
+/// See `DY.Core.Label.Type` for more information.
 
+/// Principals are described using strings (such as "Alice").
+
+type principal = string
+
+/// Type for session identifiers
+
+type state_id = { the_id: nat; }
 
 /// The type for events in the trace.
 
 noeq
-type trace_event =
+type trace_event_ (label_t:Type) =
   // A message has been sent on the network.
-  | MsgSent: bytes -> trace_event
+  | MsgSent: bytes -> trace_event_ label_t
   // A random number has been generated, with some usage and label.
-  | RandGen: usg:usage -> lab:label -> len:nat{len <> 0} -> trace_event
+  | RandGen: usg:usage -> label_t -> len:nat{len <> 0} -> trace_event_ label_t
   // A state of a principal has been corrupt.
-  | Corrupt: prin:principal -> sess_id:state_id -> trace_event
+  | Corrupt: prin:principal -> sess_id:state_id -> trace_event_ label_t
   // A principal stored some state.
-  | SetState: prin:principal -> sess_id:state_id -> content:bytes -> trace_event
+  | SetState: prin:principal -> sess_id:state_id -> content:bytes -> trace_event_ label_t
   // A custom and protocol-specific event has been triggered by a principal.
-  | Event: prin:principal -> tag:string -> content:bytes -> trace_event
+  | Event: prin:principal -> tag:string -> content:bytes -> trace_event_ label_t
 
 /// The trace is a list of trace events.
 /// Because the trace grows with time and the time is often represented going from left to right,
@@ -50,259 +60,6 @@ type trace_event =
 /// To avoid confusions, we define a custom inductive to swap the arguments of the "cons" constructor.
 
 noeq
-type trace =
-  | Nil: trace
-  | Snoc: trace -> trace_event -> trace
-
-/// The length of a trace.
-
-val length: trace -> nat
-let rec length tr =
-  match tr with
-  | Nil -> 0
-  | Snoc init last -> length init + 1
-
-/// a type macro for timestamps (indices on the trace)
-
-type timestamp = nat
-
-(*** Prefix and trace extension ***)
-
-/// Compute the prefix of a trace.
-
-[@@ "opaque_to_smt"]
-val prefix: tr:trace -> i:timestamp{i <= length tr} -> trace
-let rec prefix tr i =
-  if length tr = i then
-    tr
-  else
-    let Snoc tr_init _ = tr in
-    prefix tr_init i
-
-/// Express whether a trace is the extension of another.
-/// This is a crucial relation between traces,
-/// because the trace only grows during a protocol execution.
-
-[@@ "opaque_to_smt"]
-val grows: trace -> trace -> prop
-let grows tr1 tr2 =
-  length tr1 <= length tr2 /\
-  tr1 == prefix tr2 (length tr1)
-
-/// It is used a lot in DY*, therefore we define an operator shorthand.
-
-let (<$) = grows
-
-/// The relation <$ is reflexive.
-
-val grows_reflexive:
-  tr:trace ->
-  Lemma (tr <$ tr)
-  [SMTPat (tr <$ tr)]
-let grows_reflexive tr =
-  reveal_opaque (`%grows) (grows);
-  norm_spec [zeta; delta_only [`%prefix]] (prefix)
-
-/// The relation <$ is transitive.
-
-val grows_transitive:
-  tr1:trace -> tr2:trace -> tr3:trace ->
-  Lemma
-  (requires tr1 <$ tr2 /\ tr2 <$ tr3)
-  (ensures tr1 <$ tr3)
-  [SMTPat (tr1 <$ tr2); SMTPat (tr1 <$ tr3)]
-let rec grows_transitive tr1 tr2 tr3 =
-  reveal_opaque (`%grows) (grows);
-  norm_spec [zeta; delta_only [`%prefix]] (prefix);
-  if length tr2 >= length tr3 then
-    ()
-  else (
-    let Snoc tr3_init _ = tr3 in
-    grows_transitive tr1 tr2 tr3_init
-  )
-
-/// The prefix function outputs traces of the correct length.
-
-val length_prefix:
-  tr:trace -> i:timestamp{i <= length tr} ->
-  Lemma
-  (ensures length (prefix tr i) == i)
-  [SMTPat (length (prefix tr i))]
-let rec length_prefix tr i =
-  norm_spec [zeta; delta_only [`%prefix]] (prefix);
-  if length tr = i then ()
-  else
-    let Snoc tr_init _ = tr in
-    length_prefix tr_init i
-
-/// A trace which is the prefix of another is shorter.
-
-val length_grows:
-  tr1:trace -> tr2:trace ->
-  Lemma
-  (requires tr1 <$ tr2)
-  (ensures length tr1 <= length tr2)
-  [SMTPat (tr1 <$ tr2)]
-let length_grows tr1 tr2 =
-  reveal_opaque (`%grows) (grows)
-
-/// The prefix function outputs traces that are prefixes of the input.
-
-val prefix_grows:
-  tr:trace -> i:timestamp{i <= length tr} ->
-  Lemma
-  (ensures (prefix tr i) <$ tr)
-  //TODO: is this SMTPat dangerous? Should we restrict it to the "safe" on below?
-  [SMTPat (prefix tr i)]
-  //[SMTPat ((prefix tr i) <$ tr)]
-let prefix_grows tr i =
-  reveal_opaque (`%grows) (grows);
-  norm_spec [zeta; delta_only [`%prefix]] (prefix)
-
-val prefix_prefix_grows:
-  tr1:trace -> tr2:trace -> i1:timestamp -> i2:timestamp ->
-  Lemma
-  (requires
-    tr1 <$ tr2 /\
-    i1 <= length tr1 /\
-    i2 <= length tr2 /\
-    i1 <= i2
-  )
-  (ensures prefix tr1 i1 <$ prefix tr2 i2)
-  [SMTPat (prefix tr1 i1 <$ prefix tr2 i2)]
-  // Alternative SMT pattern if the above one doesn't trigger enough
-  // [SMTPat (prefix tr1 i1);
-  //  SMTPat (prefix tr2 i2);
-  //  SMTPat (tr1 <$ tr2)]
-let rec prefix_prefix_grows tr1 tr2 i1 i2 =
-  reveal_opaque (`%grows) (grows);
-  norm_spec [zeta; delta_only [`%prefix]] (prefix);
-  if i2 = length tr2 then ()
-  else if length tr1 = length tr2 then (
-    let Snoc tr1_init _ = tr1 in
-    let Snoc tr2_init _ = tr2 in
-    prefix_prefix_grows tr1_init tr2_init i1 i2
-  ) else (
-    let Snoc tr2_init _ = tr2 in
-    prefix_prefix_grows tr1 tr2_init i1 i2
-  )
-
-val prefix_prefix_eq:
-  tr1:trace -> tr2:trace -> i:timestamp ->
-  Lemma
-  (requires
-    tr1 <$ tr2 /\
-    i <= length tr1
-  )
-  (ensures prefix tr1 i == prefix tr2 i)
-  [SMTPat (prefix tr1 i);
-   SMTPat (prefix tr2 i);
-   SMTPat (tr1 <$ tr2)]
-let rec prefix_prefix_eq tr1 tr2 i =
-  reveal_opaque (`%grows) (grows);
-  norm_spec [zeta; delta_only [`%prefix]] (prefix);
-  if length tr1 = length tr2 then ()
-  else (
-    let Snoc tr2_init _ = tr2 in
-    prefix_prefix_eq tr1 tr2_init i
-  )
-
-(*** Event in the trace predicates ***)
-
-/// Retrieve the event at some timestamp in the trace.
-
-val get_event_at: tr:trace -> i:timestamp{i < length tr} -> trace_event
-let rec get_event_at tr i =
-  if i+1 = length tr then
-    let Snoc _ last = tr in
-    last
-  else (
-    let Snoc tr_init _ = tr in
-    get_event_at tr_init i
-  )
-
-/// Has some particular event been triggered at a some particular timestamp in the trace?
-
-val event_at: trace -> timestamp -> trace_event -> prop
-let event_at tr i e =
-  if i >= length tr then
-    False
-  else
-    e == get_event_at tr i
-
-/// Has some particular event been triggered in the trace (at any timestamp)?
-
-val event_exists: trace -> trace_event -> prop
-let event_exists tr e =
-  exists i. event_at tr i e
-
-/// An event in the trace stays here when the trace grows.
-
-val event_at_grows:
-  tr1:trace -> tr2:trace ->
-  i:timestamp -> e:trace_event ->
-  Lemma
-  (requires event_at tr1 i e /\ tr1 <$ tr2)
-  (ensures event_at tr2 i e)
-  [SMTPat (event_at tr1 i e); SMTPat (tr1 <$ tr2)]
-let rec event_at_grows tr1 tr2 i e =
-  reveal_opaque (`%grows) (grows);
-  norm_spec [zeta; delta_only [`%prefix]] (prefix);
-  if i >= length tr1 then ()
-  else if length tr1 >= length tr2 then ()
-  else (
-    let Snoc tr2_init _ = tr2 in
-    event_at_grows tr1 tr2_init i e
-  )
-
-/// Shorthand predicates.
-
-/// Has a message been sent on the network?
-
-val msg_sent_on_network: trace -> bytes -> prop
-let msg_sent_on_network tr msg =
-  event_exists tr (MsgSent msg)
-
-/// Has some state been stored by a principal?
-
-val state_was_set: trace -> principal -> state_id -> bytes -> prop
-let state_was_set tr prin sess_id content =
-  event_exists tr (SetState prin sess_id content)
-
-/// Has a principal been corrupt?
-
-val was_corrupt: trace -> principal -> state_id -> prop
-let was_corrupt tr prin sess_id =
-  event_exists tr (Corrupt prin sess_id)
-
-/// Has a (custom, protocol-specific) event been triggered at some timestamp?
-
-val event_triggered_at: trace -> timestamp -> principal -> string -> bytes -> prop
-let event_triggered_at tr i prin tag content =
-  event_at tr i (Event prin tag content)
-
-/// Has a (custom, protocol-specific) event been triggered (at any timestamp)?
-
-val event_triggered: trace -> principal -> string -> bytes -> prop
-let event_triggered tr prin tag content =
-  exists i. event_triggered_at tr i prin tag content
-
-/// An event being triggered at some time stays triggered as the trace grows.
-
-val event_triggered_grows:
-  tr1:trace -> tr2:trace ->
-  prin:principal -> tag:string -> content:bytes  ->
-  Lemma
-  (requires event_triggered tr1 prin tag content /\ tr1 <$ tr2)
-  (ensures event_triggered tr2 prin tag content)
-  [SMTPat (event_triggered tr1 prin tag content); SMTPat (tr1 <$ tr2)]
-let event_triggered_grows tr1 tr2 prin tag content = ()
-
-/// Has a random bytestring been generated at some timestamp?
-
-val rand_generated_at: trace -> timestamp -> bytes -> prop
-let rand_generated_at tr i b =
-  match b with
-  | Rand usg len time ->
-    time == i /\ (exists lab. event_at tr i (RandGen usg lab len))
-  | _ -> False
+type trace_ (label_t:Type) =
+  | Nil: trace_ label_t
+  | Snoc: trace_ label_t -> trace_event_ label_t -> trace_ label_t

--- a/src/core/DY.Core.fst
+++ b/src/core/DY.Core.fst
@@ -111,6 +111,7 @@ include DY.Core.Label.Derived
 include DY.Core.Trace.Invariant
 include DY.Core.Trace.Manipulation
 include DY.Core.Trace.Type
+include DY.Core.Trace.Base
 // include Bytes after Trace because of shadowing `length` function
 include DY.Core.Bytes
 include DY.Core.Bytes.Type

--- a/src/lib/event/DY.Lib.Event.Typed.fst
+++ b/src/lib/event/DY.Lib.Event.Typed.fst
@@ -171,7 +171,7 @@ val event_triggered_at_implies_pred:
     has_event_pred epred /\
     trace_invariant tr
   )
-  (ensures i <= DY.Core.Trace.Type.length tr /\ epred (prefix tr i) prin e)
+  (ensures i <= DY.Core.Trace.Base.length tr /\ epred (prefix tr i) prin e)
   [SMTPat (event_triggered_at tr i prin e);
    SMTPat (has_event_pred epred);
    SMTPat (trace_invariant tr);
@@ -199,7 +199,7 @@ val event_triggered_at_implies_trace_event_at:
   Lemma
   (requires event_triggered_at tr i prin e)
   (ensures
-    i < DY.Core.Trace.Type.length tr /\
+    i < DY.Core.Trace.Base.length tr /\
     get_event_at tr i == Event prin ev.tag (serialize a e) /\
     parse #bytes a (serialize a e) == Some e
   )

--- a/src/lib/utils/DY.Lib.Printing.fst
+++ b/src/lib/utils/DY.Lib.Printing.fst
@@ -234,7 +234,7 @@ let trace_event_to_string printers tr_event i =
 
 val trace_to_string_helper:
   trace_to_string_printers ->
-  (tr:trace) -> (i:nat{i = DY.Core.Trace.Type.length tr}) ->
+  (tr:trace) -> (i:nat{i = DY.Core.Trace.Base.length tr}) ->
   string
 let rec trace_to_string_helper printers tr i =
   match tr with
@@ -257,7 +257,7 @@ let rec trace_to_string_helper printers tr i =
 
 val trace_to_string: trace_to_string_printers -> trace -> string
 let trace_to_string printers tr =
-  trace_to_string_helper printers tr (DY.Core.Trace.Type.length tr)
+  trace_to_string_helper printers tr (DY.Core.Trace.Base.length tr)
 
 
 (*** Helper Functions to Setup the Printer Functions Record ***)


### PR DESCRIPTION
This PR builds on #54.

The previous label construction works with the duo `label` / `is_corrupt`, where `is_corrupt` is a predicate on a trace stating whether a given label was corrupt, and `label` is an AST that represent a subset of such trace predicates.

Before #54, we used the fact that `label` is an AST to ensure it has decidable equality (hence `bytes` also has decidable equality), so we were stuck in the subset of corruption predicates that could be expressed using this AST.

This PR generalize labels, by saying labels are corruption predicates in their full generality, so roughly `type label = trace -> prop`.
In particular, it subsumes the previous attempts at adding new features to labels, such as branch [`label_before`](https://github.com/REPROSEC/dolev-yao-star-extrinsic/compare/main...label_before) or [`general_labels`](https://github.com/REPROSEC/dolev-yao-star-extrinsic/compare/main...twal/general_labels), which can now be implemented on the user side, without messing with `DY.Core`.

One technical difficulty we have to solve is the positivity checker (see [F* tutorial](https://fstar-lang.org/tutorial/book/part2/part2_inductive_type_families.html#strictly-positive-definitions)): in proof assistants, it is unsound to define types like
```fstar
type t =
  | Mk: (t -> prop) -> t
```
because otherwise
```fstar
val surj: t -> (t -> prop)
let surj x =
  match x with
  | Mk p -> p
```
would be a surjective function, but it is impossible to have a surjective function from `t` to `t -> prop` (e.g. via [Cantor diagonal argument](https://en.wikipedia.org/wiki/Cantor's_diagonal_argument))
```fstar
val diag: t -> prop
let diag x =
  ~(surj x x)

val falso: unit -> Lemma (False)
let falso () =
  assert(surj (Mk diag) (Mk diag) == ~(surj (Mk diag) (Mk diag)))
```

It turns out that with the new labels, the trace would have the same problem as our type `t` above: the `trace` would contain `trace_event`s, in particular the `RandGen` event, that contain a `label`, which is a `trace -> prop`. So we could build a surjection `trace -> (trace -> prop)` as we did for `t` above, which would be unsound for the same reasons.

To deal with this problem, labels do not have as input the actual trace, but a modified version of the trace where the labels are "forgotten" (replaced by unit). To do so, the type `trace_` is parametrized by the label type, and we forget labels using the function `val trace_forget_labels: trace_ label_t -> trace_ unit`.
It means that the corruption predicate of a label cannot depend on other labels present in the trace, this is why it is impossible to integrate these generalized labels with the erasure attempt in #52, where the label indirection is a label whose behavior depend on other labels in the trace.