### PR TITLE
feat: make labels extensional

### DIFF
--- a/examples/iso_dh/DY.Example.DH.Protocol.Stateful.Proof.fst
+++ b/examples/iso_dh/DY.Example.DH.Protocol.Stateful.Proof.fst
@@ -15,11 +15,7 @@ open DY.Example.DH.Protocol.Stateful
 
 val is_dh_shared_key: trace -> principal -> principal -> bytes -> prop
 let is_dh_shared_key tr alice bob k = exists si sj.
-  // We are using the equivalent relation here because depending on the party we are looking at
-  // the label is either ``join (principal_state_label alice si) (principal_state_label bob sj)`` or
-  // ``join (principal_state_label bob sj) (principal_state_label alice si)``.
-  // This is because k is either build from ``dh x (dh_pk y)`` or ``dh y (dh_pk x)``.
-  get_label tr k `equivalent tr` join (principal_state_label alice si) (principal_state_label bob sj) /\ 
+  get_label tr k == join (principal_state_label alice si) (principal_state_label bob sj) /\ 
   get_usage k == AeadKey "DH.aead_key" empty
 
 let dh_session_pred: local_state_predicate dh_session = {
@@ -277,7 +273,7 @@ let prepare_msg3_proof tr global_sess_id alice alice_si bob msg_id =
               assert(dh y res.gx == dh x res.gy);
               assert(k == k');
               
-              assert(exists si sj. get_label tr k `equivalent tr` join (principal_state_label alice si) (principal_state_label bob sj));
+              assert(exists si sj. get_label tr k == join (principal_state_label alice si) (principal_state_label bob sj));
 
               assert(dh_key_and_event_respond1);
               ()
@@ -376,7 +372,7 @@ let verify_msg3_proof tr global_sess_id alice bob msg_id bob_si =
             );
 
             assert(is_corrupt tr (principal_label alice) \/
-              (exists si. get_label tr res.k `equivalent tr` join (principal_state_label alice si) (principal_state_label bob bob_si)));
+              (exists si. get_label tr res.k == join (principal_state_label alice si) (principal_state_label bob bob_si)));
             assert(get_usage res.k == AeadKey "DH.aead_key" empty);
             assert(is_corrupt tr (principal_label alice) \/
               (is_dh_shared_key tr alice bob res.k /\ event_triggered tr alice (Initiate2 alice bob gx gy res.k)));

--- a/examples/iso_dh/DY.Example.DH.SecurityProperties.fst
+++ b/examples/iso_dh/DY.Example.DH.SecurityProperties.fst
@@ -77,7 +77,7 @@ let initiator_forward_secrecy tr alice alice_si bob gx gy k =
   // (this assert is not needed and only there for pedagogical purposes)
   assert(
     is_corrupt tr (principal_label bob) \/
-    (exists bob_si. get_label tr k `equivalent tr` join (principal_state_label alice alice_si) (principal_state_label bob bob_si))
+    (exists bob_si. get_label tr k == join (principal_state_label alice alice_si) (principal_state_label bob bob_si))
   );
 
   // We deduce from the following this assertion,
@@ -124,7 +124,7 @@ let responder_forward_secrecy tr alice bob bob_si gx gy k =
   // (this assert is not needed and only there for pedagogical purposes)
   assert(
     is_corrupt tr (principal_label alice) \/
-    (exists alice_si. get_label tr k `equivalent tr` join (principal_state_label alice alice_si) (principal_state_label bob bob_si))
+    (exists alice_si. get_label tr k == join (principal_state_label alice alice_si) (principal_state_label bob bob_si))
   );
 
   // We deduce from the following this assertion,

--- a/src/core/DY.Core.Bytes.fst
+++ b/src/core/DY.Core.Bytes.fst
@@ -2284,21 +2284,20 @@ let bytes_invariant_dh tr sk pk =
 
 /// User lemma (dh bytes label)
 
-#push-options "--z3rlimit 25"
 val get_label_dh:
   {|crypto_usages|} ->
   tr:trace ->
   sk:bytes -> pk:bytes ->
   Lemma
-  (ensures (get_label tr (dh sk pk)) `always_equivalent` ((get_label tr sk) `join` (get_dh_label tr pk)))
+  (ensures (get_label tr (dh sk pk)) == ((get_label tr sk) `join` (get_dh_label tr pk)))
   [SMTPat (get_label tr (dh sk pk))]
 let get_label_dh tr sk pk =
   reveal_opaque (`%dh_pk) (dh_pk);
   reveal_opaque (`%dh) (dh);
   normalize_term_spec get_dh_label;
   normalize_term_spec get_label;
-  join_always_commutes (get_label tr sk) (get_dh_label tr pk)
-#pop-options
+  join_commutes (get_label tr sk) (get_dh_label tr pk);
+  join_public (get_label tr sk)
 
 /// User lemma (dh bytes usage with known peer)
 

--- a/src/core/DY.Core.Label.Derived.fst
+++ b/src/core/DY.Core.Label.Derived.fst
@@ -14,49 +14,6 @@ let equivalent tr l1 l2 =
   l1 `can_flow tr` l2 /\
   l2 `can_flow tr` l1
 
-val always_equivalent: label -> label -> prop
-let always_equivalent l1 l2 =
-  forall tr. l1 `equivalent tr` l2
-
-val introduce_always_equivalent:
-  l1:label -> l2:label ->
-  (tr:trace -> Lemma(l1 `equivalent tr` l2)) ->
-  Lemma (l1 `always_equivalent` l2)
-let introduce_always_equivalent l1 l2 pf =
-  introduce forall tr. l1 `equivalent tr` l2 with pf tr
-
-val join_commutes:
-  tr:trace ->
-  l1:label -> l2:label ->
-  Lemma
-  ((l1 `join` l2) `equivalent tr` (l2 `join` l1))
-let join_commutes tr l1 l2 =
-  join_eq tr l1 l2 (join l1 l2);
-  join_eq tr l2 l1 (join l2 l1)
-
-val join_always_commutes:
-  l1:label -> l2:label ->
-  Lemma
-  ((l1 `join` l2) `always_equivalent` (l2 `join` l1))
-let join_always_commutes l1 l2 =
-  introduce_always_equivalent (l1 `join` l2) (l2 `join` l1) (fun tr -> join_commutes tr l1 l2)
-
-val meet_commutes:
-  tr:trace ->
-  l1:label -> l2:label ->
-  Lemma
-  ((l1 `meet` l2) `equivalent tr` (l2 `meet` l1))
-let meet_commutes tr l1 l2 =
-  meet_eq tr (meet l1 l2) l1 l2;
-  meet_eq tr (meet l2 l1) l2 l1
-
-val meet_always_commutes:
-  l1:label -> l2:label ->
-  Lemma
-  ((l1 `meet` l2) `always_equivalent` (l2 `meet` l1))
-let meet_always_commutes l1 l2 =
-  introduce_always_equivalent (l1 `meet` l2) (l2 `meet` l1) (fun tr -> meet_commutes tr l1 l2)
-
 val join_flows_to_left:
   tr:trace ->
   l1:label -> l2:label ->
@@ -88,6 +45,91 @@ val right_flows_to_meet:
   [SMTPat (l2 `can_flow tr` (l1 `meet` l2))]
 let right_flows_to_meet tr l1 l2 =
   meet_eq tr (meet l1 l2) l1 l2
+
+(*** Equational theory for join ***)
+
+val join_associative:
+  l1:label -> l2:label -> l3:label ->
+  Lemma
+  (((l1 `join` l2) `join` l3) == (l1 `join` (l2 `join` l3)))
+let join_associative l1 l2 l3 =
+  intro_label_equal ((l1 `join` l2) `join` l3) (l1 `join` (l2 `join` l3)) (fun tr ->
+    join_flows_to_left tr (l1 `join` l2) l3;
+    join_eq tr l1 (l2 `join` l3) ((l1 `join` l2) `join` l3);
+    join_flows_to_right tr l1 (l2 `join` l3);
+    join_eq tr (l1 `join` l2) l3 (l1 `join` (l2 `join` l3))
+  )
+
+val join_commutes:
+  l1:label -> l2:label ->
+  Lemma
+  ((l1 `join` l2) == (l2 `join` l1))
+let join_commutes l1 l2 =
+  intro_label_equal (l1 `join` l2) (l2 `join` l1) (fun tr -> ())
+
+val join_public:
+  l:label ->
+  Lemma (
+    (l `join` public) == public /\
+    (public `join` l) == public
+  )
+let join_public l =
+  intro_label_equal (l `join` public) public (fun tr -> ());
+  intro_label_equal (public `join` l) public (fun tr -> ())
+
+val join_secret:
+  l:label ->
+  Lemma (
+    (l `join` secret) == l /\
+    (secret `join` l) == l
+  )
+let join_secret l =
+  intro_label_equal (l `join` secret) l (fun tr -> ());
+  intro_label_equal (secret `join` l) l (fun tr -> ())
+
+(*** Equational theory for meet ***)
+
+val meet_associative:
+  l1:label -> l2:label -> l3:label ->
+  Lemma
+  (((l1 `meet` l2) `meet` l3) == (l1 `meet` (l2 `meet` l3)))
+let meet_associative l1 l2 l3 =
+  intro_label_equal ((l1 `meet` l2) `meet` l3) (l1 `meet` (l2 `meet` l3)) (fun tr ->
+    left_flows_to_meet tr (l1 `meet` l2) l3;
+    meet_eq tr ((l1 `meet` l2) `meet` l3) l1 (l2 `meet` l3);
+    right_flows_to_meet tr l1 (l2 `meet` l3);
+    meet_eq tr (l1 `meet` (l2 `meet` l3)) (l1 `meet` l2) l3
+  )
+
+val meet_commutes:
+  tr:trace ->
+  l1:label -> l2:label ->
+  Lemma
+  ((l1 `meet` l2) == (l2 `meet` l1))
+let meet_commutes tr l1 l2 =
+  intro_label_equal (l1 `meet` l2) (l2 `meet` l1) (fun tr -> ())
+
+val meet_public:
+  l:label ->
+  Lemma (
+    (l `meet` public) == l /\
+    (public `meet` l) == l
+  )
+let meet_public l =
+  intro_label_equal (l `meet` public) l (fun tr -> ());
+  intro_label_equal (public `meet` l) l (fun tr -> ())
+
+val meet_secret:
+  l:label ->
+  Lemma (
+    (l `meet` secret) == secret /\
+    (secret `meet` l) == secret
+  )
+let meet_secret l =
+  intro_label_equal (l `meet` secret) secret (fun tr -> ());
+  intro_label_equal (secret `meet` l) secret (fun tr -> ())
+
+(*** Can flow and corruption ***)
 
 val can_flow_propagates_is_corrupt:
   tr:trace -> l1:label -> l2:label ->

--- a/src/core/DY.Core.Label.Unknown.fst
+++ b/src/core/DY.Core.Label.Unknown.fst
@@ -5,6 +5,10 @@ module DY.Core.Label.Unknown
 /// unless we `friend DY.Core.Label.Unknown`, which we shouldn't do.
 
 let unknown_label = {
-  is_corrupt = (fun tr -> True);
-  is_corrupt_later = (fun tr ev -> ());
+  is_corrupt = FStar.FunctionalExtensionality.on _ (fun tr ->
+    True <: prop
+  );
+  is_corrupt_later = (
+    reveal_opaque (`%is_monotonic) is_monotonic
+  );
 }


### PR DESCRIPTION
Builds on #55.

Here, we exploit the fact that labels are predicate to use extensionality, meaning that if two labels are always equivalent (i.e. always flow in both directions, or that their corruption predicates are always equivalent), then they are equal.

We further use that to prove that `join` is commutative, or that `public` is an absorber for `join` (among other things). This leads to nicer theorems for the label of `dh`, where we can actually have label equality instead of the previous `always_equivalent`.

In turn this allows to use `==` instead of `equivalent tr` in the ISO-DH example, thereby simplifying its proof.