### PR TITLE
fix: strengthen the authentication theorems of ISO-DH

### DIFF
--- a/examples/iso_dh/DY.Example.DH.Protocol.Total.Proof.fst
+++ b/examples/iso_dh/DY.Example.DH.Protocol.Total.Proof.fst
@@ -182,7 +182,7 @@ val decode_and_verify_message2_proof:
     | Some res -> (
       let sig_msg = SigMsg2 {alice; gx=(dh_pk x); gy=res.gy} in
       is_publishable tr res.gy /\
-      (is_corrupt tr (principal_state_label alice alice_si) \/ is_corrupt tr (principal_label bob) \/
+      (is_corrupt tr (principal_label bob) \/
       (exists y. event_triggered tr bob (Respond1 alice bob (dh_pk x) res.gy y)))
     )
     | None -> True
@@ -199,7 +199,7 @@ let decode_and_verify_message2_proof tr msg2_bytes alice alice_si bob x pk_b =
       // It just shows what we need to show to prove the lemma.
       assert(is_publishable tr res.gy);
       
-      assert(is_corrupt tr (principal_label alice) \/
+      assert(
         is_corrupt tr (principal_label bob) \/
         (exists y. res.gy == dh_pk y /\ event_triggered tr bob (Respond1 alice bob gx gy y))
       );
@@ -266,7 +266,7 @@ val decode_and_verify_message3_proof:
     match decode_and_verify_message3 msg3_bytes bob gx gy y pk_a with
     | Some res -> (
       let sig_msg = SigMsg3 {bob; gx; gy} in
-      (is_corrupt tr (principal_label alice) \/ is_corrupt tr (principal_state_label bob bob_si) \/
+      (is_corrupt tr (principal_label alice) \/
       (exists x. gx == dh_pk x /\ event_triggered tr alice (Initiate2 alice bob gx gy (dh x gy))))
     )
     | None -> True

--- a/examples/iso_dh/DY.Example.DH.SecurityProperties.fst
+++ b/examples/iso_dh/DY.Example.DH.SecurityProperties.fst
@@ -22,7 +22,6 @@ val initiator_authentication:
     event_triggered_at tr i alice (Initiate2 alice bob gx gy k)
   )
   (ensures 
-    (exists alice_si. is_corrupt tr (principal_state_label alice alice_si)) \/ 
     is_corrupt tr (principal_label bob) \/
     (exists y. event_triggered (prefix tr i) bob (Respond1 alice bob gx gy y) /\
     k == dh y gx)
@@ -40,7 +39,6 @@ val responder_authentication:
   )
   (ensures 
     is_corrupt tr (principal_label alice) \/ 
-    (exists bob_si. is_corrupt tr (principal_state_label bob bob_si)) \/
     event_triggered (prefix tr i) alice (Initiate2 alice bob gx gy k)
   )
 let responder_authentication tr i alice bob gx gy k = ()

--- a/examples/iso_dh/DY.Example.DH.SecurityProperties.fst
+++ b/examples/iso_dh/DY.Example.DH.SecurityProperties.fst
@@ -12,7 +12,7 @@ open DY.Example.DH.Protocol.Stateful.Proof
 
 (*** Authentication Properties ***)
 
-val initiator_authentication:
+val responder_authentication:
   tr:trace -> i:nat ->
   alice:principal -> bob:principal ->
   gx:bytes -> gy:bytes -> k:bytes ->
@@ -26,9 +26,9 @@ val initiator_authentication:
     (exists y. event_triggered (prefix tr i) bob (Respond1 alice bob gx gy y) /\
     k == dh y gx)
   )
-let initiator_authentication tr i alice bob gx gy k = ()
+let responder_authentication tr i alice bob gx gy k = ()
 
-val responder_authentication: 
+val initiator_authentication:
   tr:trace -> i:nat ->
   alice:principal -> bob:principal ->
   gx:bytes -> gy:bytes -> k:bytes ->
@@ -41,7 +41,7 @@ val responder_authentication:
     is_corrupt tr (principal_label alice) \/ 
     event_triggered (prefix tr i) alice (Initiate2 alice bob gx gy k)
   )
-let responder_authentication tr i alice bob gx gy k = ()
+let initiator_authentication tr i alice bob gx gy k = ()
 
 (*** Forward Secrecy Properties ***)
 
@@ -66,7 +66,6 @@ let initiator_forward_secrecy tr alice alice_si bob gx gy k =
     (exists x. gx == dh_pk x /\ k == dh x gy /\ is_secret (principal_state_label alice alice_si) tr x) /\
     (
       is_corrupt tr (principal_label bob) \/
-      is_corrupt tr (principal_state_label alice alice_si) \/
       (exists y.
         (exists bob_si. is_secret (principal_state_label bob bob_si) tr y) /\
         gy = dh_pk y
@@ -78,7 +77,6 @@ let initiator_forward_secrecy tr alice alice_si bob gx gy k =
   // (this assert is not needed and only there for pedagogical purposes)
   assert(
     is_corrupt tr (principal_label bob) \/
-    is_corrupt tr (principal_state_label alice alice_si) \/
     (exists bob_si. get_label k `equivalent tr` join (principal_state_label alice alice_si) (principal_state_label bob bob_si))
   );
 
@@ -86,7 +84,6 @@ let initiator_forward_secrecy tr alice alice_si bob gx gy k =
   // that will trigger transitivity of `can_flow tr` from `join ...` to `get_label k` to `public`
   assert(
     is_corrupt tr (principal_label bob) \/
-    is_corrupt tr (principal_state_label alice alice_si) \/
     (exists bob_si. join (principal_state_label alice alice_si) (principal_state_label bob bob_si) `can_flow tr` public)
   );
 
@@ -116,7 +113,6 @@ let responder_forward_secrecy tr alice bob bob_si gx gy k =
     (exists y. gy == dh_pk y /\ k == dh y gx /\ is_secret (principal_state_label bob bob_si) tr y) /\
     (
       is_corrupt tr (principal_label alice) \/
-      is_corrupt tr (principal_state_label bob bob_si) \/
       (exists x.
         (exists alice_si. is_secret (principal_state_label alice alice_si) tr x) /\
         k == dh x gy
@@ -128,7 +124,6 @@ let responder_forward_secrecy tr alice bob bob_si gx gy k =
   // (this assert is not needed and only there for pedagogical purposes)
   assert(
     is_corrupt tr (principal_label alice) \/
-    is_corrupt tr (principal_state_label bob bob_si) \/
     (exists alice_si. get_label k `equivalent tr` join (principal_state_label alice alice_si) (principal_state_label bob bob_si))
   );
 
@@ -136,7 +131,6 @@ let responder_forward_secrecy tr alice bob bob_si gx gy k =
   // that will trigger transitivity of `can_flow tr` from `join ...` to `get_label k` to `public`
   assert(
     is_corrupt tr (principal_label alice) \/
-    is_corrupt tr (principal_state_label bob bob_si) \/
     (exists alice_si. join (principal_state_label alice alice_si) (principal_state_label bob bob_si) `can_flow tr` public)
   );
 


### PR DESCRIPTION
I noticed that in the authentication theorems of ISO-DH we only need to talk about corruption of signature keys of the other party, the attacker cannot use corrupted DH private keys to break authentication (unlike NSL where corrupting a nonce can be used to break authentication).