### PR TITLE
feat: introduce content-aware labels

### DIFF
--- a/examples/iso_dh/DY.Example.DH.Protocol.Stateful.Proof.fst
+++ b/examples/iso_dh/DY.Example.DH.Protocol.Stateful.Proof.fst
@@ -15,7 +15,7 @@ open DY.Example.DH.Protocol.Stateful
 
 val is_dh_shared_key: trace -> principal -> principal -> bytes -> prop
 let is_dh_shared_key tr alice bob k = exists si sj.
-  get_label tr k == join (principal_state_label alice si) (principal_state_label bob sj) /\ 
+  get_label tr k == join (ephemeral_dh_key_label alice si) (ephemeral_dh_key_label bob sj) /\
   get_usage k == AeadKey "DH.aead_key" empty
 
 let dh_session_pred: local_state_predicate dh_session = {
@@ -23,34 +23,34 @@ let dh_session_pred: local_state_predicate dh_session = {
     match st with
     | InitiatorSentMsg1 bob x -> (
       let alice = prin in
-      is_secret (principal_state_label alice sess_id) tr x /\
+      is_secret (ephemeral_dh_key_label alice sess_id) tr x /\
       get_usage x == DhKey "DH.dh_key" empty /\
       event_triggered tr alice (Initiate1 alice bob x)
     )
     | ResponderSentMsg2 alice gx gy y -> (
       let bob = prin in
       is_publishable tr gx /\ is_publishable tr gy /\
-      is_secret (principal_state_label bob sess_id) tr y /\ get_usage y  == DhKey "DH.dh_key" empty /\
+      is_secret (ephemeral_dh_key_label bob sess_id) tr y /\ get_usage y  == DhKey "DH.dh_key" empty /\
       gy == dh_pk y /\
       event_triggered tr bob (Respond1 alice bob gx gy y)
     )
     | InitiatorSendMsg3 bob gx gy k -> (
       let alice = prin in
       is_publishable tr gx /\ is_publishable tr gy /\
-      is_knowable_by (principal_state_label alice sess_id) tr k /\
-      (exists x. gx == dh_pk x /\ k == dh x gy /\ is_secret (principal_state_label alice sess_id) tr x) /\
+      is_knowable_by (ephemeral_dh_key_label alice sess_id) tr k /\
+      (exists x. gx == dh_pk x /\ k == dh x gy /\ is_secret (ephemeral_dh_key_label alice sess_id) tr x) /\
       event_triggered tr alice (Initiate2 alice bob gx gy k) /\
-      (is_corrupt tr (principal_label bob) \/ is_corrupt tr (principal_state_label alice sess_id) \/
+      (is_corrupt tr (long_term_key_label bob) \/ is_corrupt tr (ephemeral_dh_key_label alice sess_id) \/
       (exists y. k == dh y gx /\ is_dh_shared_key tr alice bob k /\ 
         event_triggered tr bob (Respond1 alice bob gx gy y)))
     )
     | ResponderReceivedMsg3 alice gx gy k -> (
       let bob = prin in
       is_publishable tr gx /\ is_publishable tr gy /\
-      is_knowable_by (principal_state_label bob sess_id) tr k /\
-      (exists y. gy == dh_pk y /\ k == dh y gx /\ is_secret (principal_state_label bob sess_id) tr y) /\
+      is_knowable_by (ephemeral_dh_key_label bob sess_id) tr k /\
+      (exists y. gy == dh_pk y /\ k == dh y gx /\ is_secret (ephemeral_dh_key_label bob sess_id) tr y) /\
       event_triggered tr bob (Respond2 alice bob gx gy k) /\
-      (is_corrupt tr (principal_label alice) \/ is_corrupt tr (principal_state_label bob sess_id) \/
+      (is_corrupt tr (long_term_key_label alice) \/ is_corrupt tr (ephemeral_dh_key_label bob sess_id) \/
         (is_dh_shared_key tr alice bob k /\ 
         event_triggered tr alice (Initiate2 alice bob gx gy k)))
     )
@@ -67,19 +67,19 @@ let dh_event_pred: event_predicate dh_event =
     | Initiate1 alice bob x -> True
     | Respond1 alice bob gx gy y -> (
       is_publishable tr gx /\ is_publishable tr gy /\
-      (exists sess_id. is_secret (principal_state_label bob sess_id) tr y) /\
+      (exists sess_id. is_secret (ephemeral_dh_key_label bob sess_id) tr y) /\
       get_usage y == DhKey "DH.dh_key" empty /\
       gy = dh_pk y
     )
     | Initiate2 alice bob gx gy k -> (
       is_publishable tr gx /\ is_publishable tr gy /\
-      (exists x sess_id. is_secret (principal_state_label alice sess_id) tr x /\
+      (exists x sess_id. is_secret (ephemeral_dh_key_label alice sess_id) tr x /\
       gx = dh_pk x /\ k == dh x gy) /\
-      (is_corrupt tr (principal_label bob) \/
+      (is_corrupt tr (long_term_key_label bob) \/
         (exists y. k == dh y gx /\ is_dh_shared_key tr alice bob k /\ event_triggered tr bob (Respond1 alice bob gx gy y)))
     )
     | Respond2 alice bob gx gy k -> (
-      is_corrupt tr (principal_label alice) \/
+      is_corrupt tr (long_term_key_label alice) \/
       (is_dh_shared_key tr alice bob k /\
         event_triggered tr alice (Initiate2 alice bob gx gy k))
     )
@@ -89,7 +89,7 @@ let dh_event_pred: event_predicate dh_event =
 let all_sessions = [
   pki_tag_and_invariant;
   private_keys_tag_and_invariant;
-  (local_state_dh_session.tag, local_state_predicate_to_local_bytes_state_predicate dh_session_pred);
+  (|local_state_dh_session.tag, local_state_predicate_to_local_bytes_state_predicate dh_session_pred|);
 ]
 
 /// List of all local event predicates.
@@ -118,7 +118,7 @@ instance dh_protocol_invs: protocol_invariants = {
 
 val all_sessions_has_all_sessions: unit -> Lemma (norm [delta_only [`%all_sessions; `%for_allP]; iota; zeta] (for_allP (has_local_bytes_state_predicate #dh_protocol_invs) all_sessions))
 let all_sessions_has_all_sessions () =
-  assert_norm(List.Tot.no_repeats_p (List.Tot.map fst (all_sessions)));
+  assert_norm(List.Tot.no_repeats_p (List.Tot.map dfst (all_sessions)));
   mk_state_pred_correct #dh_protocol_invs all_sessions;
   norm_spec [delta_only [`%all_sessions; `%for_allP]; iota; zeta] (for_allP (has_local_bytes_state_predicate #dh_protocol_invs) all_sessions)
 
@@ -214,7 +214,7 @@ let send_msg2_proof tr global_sess_id bob bob_si =
   | (Some (ResponderSentMsg2 alice gx gy y), tr) -> (
     match get_private_key bob global_sess_id.private_keys (LongTermSigKey "DH.SigningKey") tr with
     | (Some sk_b, tr) -> (
-      let (n_sig, tr) = mk_rand SigNonce (principal_label bob) 32 tr in
+      let (n_sig, tr) = mk_rand SigNonce (long_term_key_label bob) 32 tr in
       compute_message2_proof tr alice bob gx y sk_b n_sig
     )
     | (None, tr) -> ()
@@ -246,18 +246,18 @@ let prepare_msg3_proof tr global_sess_id alice alice_si bob msg_id =
           
           let k = dh x res.gy in
 
-          assert((exists x. res.gx == dh_pk x /\ k == dh x res.gy /\ is_secret (principal_state_label alice alice_si) tr x));
+          assert((exists x. res.gx == dh_pk x /\ k == dh x res.gy /\ is_secret (ephemeral_dh_key_label alice alice_si) tr x));
 
           assert(is_publishable tr res.gx);
           assert(is_publishable tr res.gy);
-          assert(is_knowable_by (principal_state_label alice alice_si) tr k);
+          assert(is_knowable_by (ephemeral_dh_key_label alice alice_si) tr k);
 
-          assert((exists x sess_id. is_secret (principal_state_label alice sess_id) tr x /\
+          assert((exists x sess_id. is_secret (ephemeral_dh_key_label alice sess_id) tr x /\
             res.gx = dh_pk x));
           assert(get_usage k = AeadKey "DH.aead_key" empty);
-          assert(exists si. is_knowable_by (principal_state_label alice si) tr k);
+          assert(exists si. is_knowable_by (ephemeral_dh_key_label alice si) tr k);
 
-          let bob_not_corrupt = (~(is_corrupt tr (principal_label bob))) in
+          let bob_not_corrupt = (~(is_corrupt tr (long_term_key_label bob))) in
           let dh_key_and_event_respond1 = (exists y. k == dh y res.gx /\ is_dh_shared_key tr alice bob k /\ event_triggered tr bob (Respond1 alice bob res.gx res.gy y)) in
           introduce bob_not_corrupt ==> dh_key_and_event_respond1
           with _. (
@@ -273,7 +273,7 @@ let prepare_msg3_proof tr global_sess_id alice alice_si bob msg_id =
               assert(dh y res.gx == dh x res.gy);
               assert(k == k');
               
-              assert(exists si sj. get_label tr k == join (principal_state_label alice si) (principal_state_label bob sj));
+              assert(exists si sj. get_label tr k == join (ephemeral_dh_key_label alice si) (ephemeral_dh_key_label bob sj));
 
               assert(dh_key_and_event_respond1);
               ()
@@ -303,7 +303,7 @@ let send_msg3_proof tr global_sess_id alice alice_si bob =
   | (Some (InitiatorSendMsg3 bob gx gy k), tr') -> (
     match get_private_key alice global_sess_id.private_keys (LongTermSigKey "DH.SigningKey") tr' with
     | (Some sk_a, tr') -> (
-      let (n_sig, tr') = mk_rand SigNonce (principal_label alice) 32 tr' in
+      let (n_sig, tr') = mk_rand SigNonce (long_term_key_label alice) 32 tr' in
 
       // The following code is not needed for the proof.
       // It just shows what we need to show to prove the lemma.
@@ -342,7 +342,7 @@ let verify_msg3_proof tr global_sess_id alice bob msg_id bob_si =
           
           match decode_and_verify_message3 msg_bytes bob gx gy y pk_a with
           | Some res -> (
-            assert(exists y. gy == dh_pk y /\ res.k == dh y gx /\ is_secret (principal_state_label bob bob_si) tr y);
+            assert(exists y. gy == dh_pk y /\ res.k == dh y gx /\ is_secret (ephemeral_dh_key_label bob bob_si) tr y);
 
             assert(event_triggered tr bob (Respond1 alice bob gx gy y));
             // The decode_message3_proof gives us that there exists a k' such that 
@@ -350,11 +350,11 @@ let verify_msg3_proof tr global_sess_id alice bob msg_id bob_si =
             // On a high level we need to show now that this event was triggered
             // for our concrete k.
             assert(exists x. gx == dh_pk x /\ event_triggered tr alice (Initiate2 alice bob gx gy (dh x gy)) \/ 
-              is_corrupt tr (principal_label alice)  \/ is_corrupt tr (principal_state_label bob bob_si));
+              is_corrupt tr (long_term_key_label alice)  \/ is_corrupt tr (ephemeral_dh_key_label bob bob_si));
 
             // Proof strategy: We want to work without the corruption case
             // so we introduce this implication.
-            let alice_not_corrupt = ~(is_corrupt tr (principal_label alice)) in
+            let alice_not_corrupt = ~(is_corrupt tr (long_term_key_label alice)) in
             let event_initiate2 = event_triggered tr alice (Initiate2 alice bob gx gy res.k) in
             introduce alice_not_corrupt ==> event_initiate2
             with _. (
@@ -371,10 +371,10 @@ let verify_msg3_proof tr global_sess_id alice bob msg_id bob_si =
               )
             );
 
-            assert(is_corrupt tr (principal_label alice) \/
-              (exists si. get_label tr res.k == join (principal_state_label alice si) (principal_state_label bob bob_si)));
+            assert(is_corrupt tr (long_term_key_label alice) \/
+              (exists si. get_label tr res.k == join (ephemeral_dh_key_label alice si) (ephemeral_dh_key_label bob bob_si)));
             assert(get_usage res.k == AeadKey "DH.aead_key" empty);
-            assert(is_corrupt tr (principal_label alice) \/
+            assert(is_corrupt tr (long_term_key_label alice) \/
               (is_dh_shared_key tr alice bob res.k /\ event_triggered tr alice (Initiate2 alice bob gx gy res.k)));
             ()
           )

--- a/examples/iso_dh/DY.Example.DH.Protocol.Total.Proof.fst
+++ b/examples/iso_dh/DY.Example.DH.Protocol.Total.Proof.fst
@@ -130,7 +130,7 @@ val compute_message2_proof:
     is_publishable tr gx /\
     bytes_invariant tr y /\
     is_private_key_for tr sk_b (LongTermSigKey "DH.SigningKey") bob /\
-    is_secret (principal_label bob) tr n_sig /\
+    is_secret (long_term_key_label bob) tr n_sig /\
     SigNonce? (get_usage n_sig)
   )
   (ensures
@@ -173,7 +173,7 @@ val decode_and_verify_message2_proof:
   Lemma
   (requires
     is_publishable tr msg2_bytes /\
-    is_secret (principal_state_label alice alice_si) tr x /\
+    is_secret (ephemeral_dh_key_label alice alice_si) tr x /\
     is_public_key_for tr pk_b (LongTermSigKey "DH.SigningKey") bob
   )
   (ensures (
@@ -181,7 +181,7 @@ val decode_and_verify_message2_proof:
     | Some res -> (
       let sig_msg = SigMsg2 {alice; gx=(dh_pk x); gy=res.gy} in
       is_publishable tr res.gy /\
-      (is_corrupt tr (principal_label bob) \/
+      (is_corrupt tr (long_term_key_label bob) \/
       (exists y. event_triggered tr bob (Respond1 alice bob (dh_pk x) res.gy y)))
     )
     | None -> True
@@ -199,7 +199,7 @@ let decode_and_verify_message2_proof tr msg2_bytes alice alice_si bob x pk_b =
       assert(is_publishable tr res.gy);
       
       assert(
-        is_corrupt tr (principal_label bob) \/
+        is_corrupt tr (long_term_key_label bob) \/
         (exists y. res.gy == dh_pk y /\ event_triggered tr bob (Respond1 alice bob gx gy y))
       );
       ()
@@ -218,7 +218,7 @@ val compute_message3_proof:
     is_publishable tr gx /\ is_publishable tr gy /\
     gx = dh_pk x /\
     is_private_key_for tr sk_a (LongTermSigKey "DH.SigningKey") alice /\
-    is_secret (principal_label alice) tr n_sig /\
+    is_secret (long_term_key_label alice) tr n_sig /\
     SigNonce? (get_usage n_sig)
   )
   (ensures
@@ -257,7 +257,7 @@ val decode_and_verify_message3_proof:
   (requires
     is_publishable tr msg3_bytes /\
     is_publishable tr gx /\
-    is_secret (principal_state_label bob bob_si) tr y /\
+    is_secret (ephemeral_dh_key_label bob bob_si) tr y /\
     is_public_key_for tr pk_a (LongTermSigKey "DH.SigningKey") alice
   )
   (ensures (
@@ -265,7 +265,7 @@ val decode_and_verify_message3_proof:
     match decode_and_verify_message3 msg3_bytes bob gx gy y pk_a with
     | Some res -> (
       let sig_msg = SigMsg3 {bob; gx; gy} in
-      (is_corrupt tr (principal_label alice) \/
+      (is_corrupt tr (long_term_key_label alice) \/
       (exists x. gx == dh_pk x /\ event_triggered tr alice (Initiate2 alice bob gx gy (dh x gy))))
     )
     | None -> True

--- a/examples/nsl_pk/DY.Example.NSL.Protocol.Total.Proof.fst
+++ b/examples/nsl_pk/DY.Example.NSL.Protocol.Total.Proof.fst
@@ -28,17 +28,17 @@ let crypto_predicates_nsl = {
         | Some (Msg1 msg1) -> (
           let (alice, bob) = (msg1.alice, prin) in
           event_triggered tr alice (Initiate1 alice bob msg1.n_a) /\
-          get_label tr msg1.n_a == join (principal_label alice) (principal_label bob)
+          get_label tr msg1.n_a == join (nsl_nonce_label alice) (nsl_nonce_label bob)
         )
         | Some (Msg2 msg2) -> (
           let (alice, bob) = (prin, msg2.bob) in
           event_triggered tr bob (Respond1 alice bob msg2.n_a msg2.n_b) /\
-          get_label tr msg2.n_b == join (principal_label alice) (principal_label bob)
+          get_label tr msg2.n_b == join (nsl_nonce_label alice) (nsl_nonce_label bob)
         )
         | Some (Msg3 msg3) -> (
           let bob = prin in
           exists alice n_a.
-            get_label tr msg3.n_b `can_flow tr` (principal_label alice) /\
+            get_label tr msg3.n_b `can_flow tr` (nsl_nonce_label alice) /\
             event_triggered tr alice (Initiate2 alice bob n_a msg3.n_b)
         )
         | None -> False
@@ -66,9 +66,9 @@ val compute_message1_proof:
     // From the stateful code
     event_triggered tr alice (Initiate1 alice bob n_a) /\
     // From random generation
-    is_secret (join (principal_label alice) (principal_label bob)) tr n_a  /\
+    is_secret (join (nsl_nonce_label alice) (nsl_nonce_label bob)) tr n_a  /\
     // From random generation
-    is_secret (principal_label alice) tr nonce /\
+    is_secret (long_term_key_label alice) tr nonce /\
     // From random generation
     PkNonce? (get_usage nonce) /\
     // From PKI invariants
@@ -77,8 +77,10 @@ val compute_message1_proof:
   (ensures is_publishable tr (compute_message1 alice bob pk_b n_a nonce))
 let compute_message1_proof tr alice bob pk_b n_a nonce =
   let msg = Msg1 {n_a; alice;} in
-  serialize_wf_lemma message (is_knowable_by (principal_label alice) tr) msg;
-  serialize_wf_lemma message (is_knowable_by (principal_label bob) tr) msg
+  assert(join (nsl_nonce_label alice) (nsl_nonce_label bob) `can_flow tr` (nsl_nonce_label alice));
+  assert(join (nsl_nonce_label alice) (nsl_nonce_label bob) `can_flow tr` (nsl_nonce_label bob));
+  serialize_wf_lemma message (is_knowable_by (long_term_key_label alice) tr) msg;
+  serialize_wf_lemma message (is_knowable_by (long_term_key_label bob) tr) msg
 
 // If bob successfully decrypt the first message,
 // then n_a is knownable both by alice (in the message) and bob (the principal)
@@ -100,7 +102,7 @@ val decode_message1_proof:
     match decode_message1 bob msg_cipher sk_b with
     | None -> True
     | Some msg1 -> (
-      is_knowable_by (join (principal_label msg1.alice) (principal_label bob)) tr msg1.n_a
+      is_knowable_by (join (nsl_nonce_label msg1.alice) (nsl_nonce_label bob)) tr msg1.n_a
     )
   ))
 let decode_message1_proof tr bob msg_cipher sk_b =
@@ -120,11 +122,11 @@ val compute_message2_proof:
     // From the stateful code
     event_triggered tr bob (Respond1 msg1.alice bob msg1.n_a n_b) /\
     // From decode_message1_proof
-    is_knowable_by (join (principal_label msg1.alice) (principal_label bob)) tr msg1.n_a /\
+    is_knowable_by (join (nsl_nonce_label msg1.alice) (nsl_nonce_label bob)) tr msg1.n_a /\
     // From the random generation
-    is_secret (join (principal_label msg1.alice) (principal_label bob)) tr n_b /\
+    is_secret (join (nsl_nonce_label msg1.alice) (nsl_nonce_label bob)) tr n_b /\
     // From the random generation
-    is_secret (principal_label bob) tr nonce /\
+    is_secret (long_term_key_label bob) tr nonce /\
     // From the random generation
     PkNonce? (get_usage nonce) /\
     // From the PKI
@@ -135,8 +137,8 @@ val compute_message2_proof:
   )
 let compute_message2_proof tr bob msg1 pk_a n_b nonce =
   let msg = Msg2 {n_a = msg1.n_a;  n_b; bob;} in
-  serialize_wf_lemma message (is_knowable_by (principal_label msg1.alice) tr) msg;
-  serialize_wf_lemma message (is_knowable_by (principal_label bob) tr) msg
+  serialize_wf_lemma message (is_knowable_by (nsl_nonce_label msg1.alice) tr) msg;
+  serialize_wf_lemma message (is_knowable_by (nsl_nonce_label bob) tr) msg
 
 // If alice successfully decrypt the second message,
 // then n_b is knownable both by alice (in the message) and bob (the principal)
@@ -150,7 +152,7 @@ val decode_message2_proof:
   Lemma
   (requires
     // From the NSL state invariant
-    is_secret (join (principal_label alice) (principal_label bob)) tr n_a /\
+    is_secret (join (nsl_nonce_label alice) (nsl_nonce_label bob)) tr n_a /\
     // From the PrivateKeys invariant
     is_private_key_for tr sk_a (LongTermPkEncKey "NSL.PublicKey") alice /\
     // From the network
@@ -160,8 +162,8 @@ val decode_message2_proof:
     match decode_message2 alice bob msg_cipher sk_a n_a with
     | None -> True
     | Some msg2 -> (
-      is_knowable_by (join (principal_label alice) (principal_label bob)) tr msg2.n_b /\ (
-      (is_corrupt tr (principal_label alice) \/ is_corrupt tr (principal_label bob)) \/ (
+      is_knowable_by (join (nsl_nonce_label alice) (nsl_nonce_label bob)) tr msg2.n_b /\ (
+      (is_corrupt tr (nsl_nonce_label alice) \/ is_corrupt tr (nsl_nonce_label bob)) \/ (
         event_triggered tr bob (Respond1 alice bob n_a msg2.n_b)
       )
       )
@@ -185,9 +187,9 @@ val compute_message3_proof:
     // From the stateful code
     (exists n_a. event_triggered tr alice (Initiate2 alice bob n_a n_b)) /\
     // From decode_message2_proof
-    is_knowable_by (join (principal_label alice) (principal_label bob)) tr n_b /\
+    is_knowable_by (join (nsl_nonce_label alice) (nsl_nonce_label bob)) tr n_b /\
     // From the random generation
-    is_secret (principal_label alice) tr nonce /\
+    is_secret (long_term_key_label alice) tr nonce /\
     // From the random generation
     PkNonce? (get_usage nonce) /\
     // From the PKI
@@ -199,8 +201,8 @@ val compute_message3_proof:
 let compute_message3_proof tr alice bob pk_b n_b nonce =
   assert(exists alice n_a. event_triggered tr alice (Initiate2 alice bob n_a n_b));
   let msg = Msg3 {n_b;} in
-  serialize_wf_lemma message (is_knowable_by (principal_label alice) tr) msg;
-  serialize_wf_lemma message (is_knowable_by (principal_label bob) tr) msg;
+  serialize_wf_lemma message (is_knowable_by (long_term_key_label alice) tr) msg;
+  serialize_wf_lemma message (is_knowable_by (long_term_key_label bob) tr) msg;
   let msg3: message3 = {n_b;} in
   assert(msg3.n_b == n_b)
 
@@ -214,7 +216,7 @@ val decode_message3_proof:
   Lemma
   (requires
     // From the NSL state invariant
-    get_label tr n_b == join (principal_label alice) (principal_label bob) /\
+    get_label tr n_b == join (nsl_nonce_label alice) (nsl_nonce_label bob) /\
     // From the PrivateKeys invariant
     is_private_key_for tr sk_b (LongTermPkEncKey "NSL.PublicKey") bob /\
     // From the network
@@ -224,9 +226,9 @@ val decode_message3_proof:
     match decode_message3 alice bob msg_cipher sk_b n_b with
     | None -> True
     | Some msg3 -> (
-      (is_corrupt tr (principal_label alice) \/ is_corrupt tr (principal_label bob)) \/ (
+      (is_corrupt tr (nsl_nonce_label alice) \/ is_corrupt tr (nsl_nonce_label bob)) \/ (
         (exists alice n_a.
-          get_label tr msg3.n_b `can_flow tr` (principal_label alice) /\
+          get_label tr msg3.n_b `can_flow tr` (nsl_nonce_label alice) /\
           event_triggered tr alice (Initiate2 alice bob n_a n_b))
       )
     )

--- a/examples/nsl_pk/DY.Example.NSL.Protocol.Total.Proof.fst
+++ b/examples/nsl_pk/DY.Example.NSL.Protocol.Total.Proof.fst
@@ -28,17 +28,17 @@ let crypto_predicates_nsl = {
         | Some (Msg1 msg1) -> (
           let (alice, bob) = (msg1.alice, prin) in
           event_triggered tr alice (Initiate1 alice bob msg1.n_a) /\
-          get_label tr msg1.n_a == join (nsl_nonce_label alice) (nsl_nonce_label bob)
+          get_label tr msg1.n_a == nsl_nonce_label alice bob
         )
         | Some (Msg2 msg2) -> (
           let (alice, bob) = (prin, msg2.bob) in
           event_triggered tr bob (Respond1 alice bob msg2.n_a msg2.n_b) /\
-          get_label tr msg2.n_b == join (nsl_nonce_label alice) (nsl_nonce_label bob)
+          get_label tr msg2.n_b == nsl_nonce_label alice bob
         )
         | Some (Msg3 msg3) -> (
           let bob = prin in
           exists alice n_a.
-            get_label tr msg3.n_b `can_flow tr` (nsl_nonce_label alice) /\
+            get_label tr msg3.n_b `can_flow tr` (nsl_nonce_label alice bob) /\
             event_triggered tr alice (Initiate2 alice bob n_a msg3.n_b)
         )
         | None -> False
@@ -66,7 +66,7 @@ val compute_message1_proof:
     // From the stateful code
     event_triggered tr alice (Initiate1 alice bob n_a) /\
     // From random generation
-    is_secret (join (nsl_nonce_label alice) (nsl_nonce_label bob)) tr n_a  /\
+    is_secret (nsl_nonce_label alice bob) tr n_a  /\
     // From random generation
     is_secret (long_term_key_label alice) tr nonce /\
     // From random generation
@@ -77,8 +77,8 @@ val compute_message1_proof:
   (ensures is_publishable tr (compute_message1 alice bob pk_b n_a nonce))
 let compute_message1_proof tr alice bob pk_b n_a nonce =
   let msg = Msg1 {n_a; alice;} in
-  assert(join (nsl_nonce_label alice) (nsl_nonce_label bob) `can_flow tr` (nsl_nonce_label alice));
-  assert(join (nsl_nonce_label alice) (nsl_nonce_label bob) `can_flow tr` (nsl_nonce_label bob));
+  assert(nsl_nonce_label alice bob `can_flow tr` (principal_label alice));
+  assert(nsl_nonce_label alice bob `can_flow tr` (principal_label bob));
   serialize_wf_lemma message (is_knowable_by (long_term_key_label alice) tr) msg;
   serialize_wf_lemma message (is_knowable_by (long_term_key_label bob) tr) msg
 
@@ -102,7 +102,7 @@ val decode_message1_proof:
     match decode_message1 bob msg_cipher sk_b with
     | None -> True
     | Some msg1 -> (
-      is_knowable_by (join (nsl_nonce_label msg1.alice) (nsl_nonce_label bob)) tr msg1.n_a
+      is_knowable_by (nsl_nonce_label msg1.alice bob) tr msg1.n_a
     )
   ))
 let decode_message1_proof tr bob msg_cipher sk_b =
@@ -122,9 +122,9 @@ val compute_message2_proof:
     // From the stateful code
     event_triggered tr bob (Respond1 msg1.alice bob msg1.n_a n_b) /\
     // From decode_message1_proof
-    is_knowable_by (join (nsl_nonce_label msg1.alice) (nsl_nonce_label bob)) tr msg1.n_a /\
+    is_knowable_by (nsl_nonce_label msg1.alice bob) tr msg1.n_a /\
     // From the random generation
-    is_secret (join (nsl_nonce_label msg1.alice) (nsl_nonce_label bob)) tr n_b /\
+    is_secret (nsl_nonce_label msg1.alice bob) tr n_b /\
     // From the random generation
     is_secret (long_term_key_label bob) tr nonce /\
     // From the random generation
@@ -137,8 +137,7 @@ val compute_message2_proof:
   )
 let compute_message2_proof tr bob msg1 pk_a n_b nonce =
   let msg = Msg2 {n_a = msg1.n_a;  n_b; bob;} in
-  serialize_wf_lemma message (is_knowable_by (nsl_nonce_label msg1.alice) tr) msg;
-  serialize_wf_lemma message (is_knowable_by (nsl_nonce_label bob) tr) msg
+  serialize_wf_lemma message (is_knowable_by (nsl_nonce_label msg1.alice bob) tr) msg
 
 // If alice successfully decrypt the second message,
 // then n_b is knownable both by alice (in the message) and bob (the principal)
@@ -152,7 +151,7 @@ val decode_message2_proof:
   Lemma
   (requires
     // From the NSL state invariant
-    is_secret (join (nsl_nonce_label alice) (nsl_nonce_label bob)) tr n_a /\
+    is_secret (nsl_nonce_label alice bob) tr n_a /\
     // From the PrivateKeys invariant
     is_private_key_for tr sk_a (LongTermPkEncKey "NSL.PublicKey") alice /\
     // From the network
@@ -162,8 +161,8 @@ val decode_message2_proof:
     match decode_message2 alice bob msg_cipher sk_a n_a with
     | None -> True
     | Some msg2 -> (
-      is_knowable_by (join (nsl_nonce_label alice) (nsl_nonce_label bob)) tr msg2.n_b /\ (
-      (is_corrupt tr (nsl_nonce_label alice) \/ is_corrupt tr (nsl_nonce_label bob)) \/ (
+      is_knowable_by (nsl_nonce_label alice bob) tr msg2.n_b /\ (
+      (is_corrupt tr (nsl_nonce_label alice bob)) \/ (
         event_triggered tr bob (Respond1 alice bob n_a msg2.n_b)
       )
       )
@@ -187,7 +186,7 @@ val compute_message3_proof:
     // From the stateful code
     (exists n_a. event_triggered tr alice (Initiate2 alice bob n_a n_b)) /\
     // From decode_message2_proof
-    is_knowable_by (join (nsl_nonce_label alice) (nsl_nonce_label bob)) tr n_b /\
+    is_knowable_by (nsl_nonce_label alice bob) tr n_b /\
     // From the random generation
     is_secret (long_term_key_label alice) tr nonce /\
     // From the random generation
@@ -216,7 +215,7 @@ val decode_message3_proof:
   Lemma
   (requires
     // From the NSL state invariant
-    get_label tr n_b == join (nsl_nonce_label alice) (nsl_nonce_label bob) /\
+    get_label tr n_b == nsl_nonce_label alice bob /\
     // From the PrivateKeys invariant
     is_private_key_for tr sk_b (LongTermPkEncKey "NSL.PublicKey") bob /\
     // From the network
@@ -226,9 +225,9 @@ val decode_message3_proof:
     match decode_message3 alice bob msg_cipher sk_b n_b with
     | None -> True
     | Some msg3 -> (
-      (is_corrupt tr (nsl_nonce_label alice) \/ is_corrupt tr (nsl_nonce_label bob)) \/ (
+      (is_corrupt tr (nsl_nonce_label alice bob)) \/ (
         (exists alice n_a.
-          get_label tr msg3.n_b `can_flow tr` (nsl_nonce_label alice) /\
+          get_label tr msg3.n_b `can_flow tr` (nsl_nonce_label alice bob) /\
           event_triggered tr alice (Initiate2 alice bob n_a n_b))
       )
     )

--- a/examples/nsl_pk/DY.Example.NSL.SecurityProperties.fst
+++ b/examples/nsl_pk/DY.Example.NSL.SecurityProperties.fst
@@ -30,7 +30,8 @@ val initiator_authentication:
     trace_invariant tr
   )
   (ensures
-    is_corrupt tr (principal_label alice) \/ is_corrupt tr (principal_label bob) \/
+    is_corrupt (prefix tr i) (nsl_nonce_label alice) \/
+    is_corrupt (prefix tr i) (nsl_nonce_label bob) \/
     event_triggered (prefix tr i) alice (Initiate2 alice bob n_a n_b)
   )
 let initiator_authentication tr i alice bob n_a n_b = ()
@@ -48,7 +49,8 @@ val responder_authentication:
     trace_invariant tr
   )
   (ensures
-    is_corrupt tr (principal_label alice) \/ is_corrupt tr (principal_label bob) \/
+    is_corrupt (prefix tr i) (nsl_nonce_label alice) \/
+    is_corrupt (prefix tr i) (nsl_nonce_label bob) \/
     event_triggered (prefix tr i) bob (Respond1 alice bob n_a n_b)
   )
 let responder_authentication tr i alice bob n_a n_b = ()
@@ -67,7 +69,7 @@ val n_a_secrecy:
       (exists sess_id n_b. state_was_set tr bob sess_id (ResponderReceivedMsg3 alice n_a n_b))
     )
   )
-  (ensures is_corrupt tr (principal_label alice) \/ is_corrupt tr (principal_label bob))
+  (ensures is_corrupt tr (nsl_nonce_label alice) \/ is_corrupt tr (nsl_nonce_label bob))
 let n_a_secrecy tr alice bob n_a =
   attacker_only_knows_publishable_values tr n_a
 
@@ -85,6 +87,6 @@ val n_b_secrecy:
       (exists sess_id n_a. state_was_set tr alice sess_id (InitiatorSentMsg3 bob n_a n_b))
     )
   )
-  (ensures is_corrupt tr (principal_label alice) \/ is_corrupt tr (principal_label bob))
+  (ensures is_corrupt tr (nsl_nonce_label alice) \/ is_corrupt tr (nsl_nonce_label bob))
 let n_b_secrecy tr alice bob n_b =
   attacker_only_knows_publishable_values tr n_b

--- a/examples/nsl_pk/DY.Example.NSL.SecurityProperties.fst
+++ b/examples/nsl_pk/DY.Example.NSL.SecurityProperties.fst
@@ -30,11 +30,12 @@ val initiator_authentication:
     trace_invariant tr
   )
   (ensures
-    is_corrupt (prefix tr i) (nsl_nonce_label alice) \/
-    is_corrupt (prefix tr i) (nsl_nonce_label bob) \/
+    is_corrupt (prefix tr i) (principal_label alice) \/
+    is_corrupt (prefix tr i) (principal_label bob) \/
     event_triggered (prefix tr i) alice (Initiate2 alice bob n_a n_b)
   )
-let initiator_authentication tr i alice bob n_a n_b = ()
+let initiator_authentication tr i alice bob n_a n_b =
+  flow_to_public_eq (prefix tr i) (nsl_nonce_label alice bob)
 
 /// If Alice thinks she talks with Bob,
 /// then Bob thinks he talk to Alice (with the same nonces),
@@ -49,11 +50,12 @@ val responder_authentication:
     trace_invariant tr
   )
   (ensures
-    is_corrupt (prefix tr i) (nsl_nonce_label alice) \/
-    is_corrupt (prefix tr i) (nsl_nonce_label bob) \/
+    is_corrupt (prefix tr i) (principal_label alice) \/
+    is_corrupt (prefix tr i) (principal_label bob) \/
     event_triggered (prefix tr i) bob (Respond1 alice bob n_a n_b)
   )
-let responder_authentication tr i alice bob n_a n_b = ()
+let responder_authentication tr i alice bob n_a n_b =
+  flow_to_public_eq (prefix tr i) (nsl_nonce_label alice bob)
 
 /// The nonce n_a is unknown to the attacker,
 /// unless the attacker corrupted Alice or Bob.
@@ -69,8 +71,9 @@ val n_a_secrecy:
       (exists sess_id n_b. state_was_set tr bob sess_id (ResponderReceivedMsg3 alice n_a n_b))
     )
   )
-  (ensures is_corrupt tr (nsl_nonce_label alice) \/ is_corrupt tr (nsl_nonce_label bob))
+  (ensures is_corrupt tr (principal_label alice) \/ is_corrupt tr (principal_label bob))
 let n_a_secrecy tr alice bob n_a =
+  flow_to_public_eq tr (nsl_nonce_label alice bob);
   attacker_only_knows_publishable_values tr n_a
 
 /// The nonce n_b is unknown to the attacker,
@@ -87,6 +90,7 @@ val n_b_secrecy:
       (exists sess_id n_a. state_was_set tr alice sess_id (InitiatorSentMsg3 bob n_a n_b))
     )
   )
-  (ensures is_corrupt tr (nsl_nonce_label alice) \/ is_corrupt tr (nsl_nonce_label bob))
+  (ensures is_corrupt tr (principal_label alice) \/ is_corrupt tr (principal_label bob))
 let n_b_secrecy tr alice bob n_b =
+  flow_to_public_eq tr (nsl_nonce_label alice bob);
   attacker_only_knows_publishable_values tr n_b

--- a/src/core/DY.Core.Attacker.Knowledge.fst
+++ b/src/core/DY.Core.Attacker.Knowledge.fst
@@ -36,8 +36,7 @@ let rec attacker_knows_aux step tr msg =
     // - states that the attacker has corrupt
     (
       exists prin sess_id.
-        is_corrupt tr (principal_state_label prin sess_id) /\
-        state_was_set tr prin sess_id msg
+        was_corrupt tr prin sess_id msg
     ) \/
     // - public literals
     (
@@ -196,13 +195,17 @@ val corrupted_state_is_publishable:
   tr:trace -> prin:principal -> sess_id:state_id -> content:bytes ->
   Lemma
   (requires
-    is_corrupt tr (principal_state_label prin sess_id) /\
-    state_was_set tr prin sess_id content /\
+    was_corrupt tr prin sess_id content /\
     trace_invariant tr
   )
   (ensures is_publishable tr content)
 let corrupted_state_is_publishable #invs tr prin sess_id content =
-  state_is_knowable_by tr prin sess_id content
+  eliminate exists time. event_exists tr (Corrupt time) /\ event_at tr time (SetState prin sess_id content)
+  returns is_publishable tr content
+  with _. (
+    state_is_knowable_by tr prin sess_id content;
+    state_pred_label_can_flow_public tr (principal_state_content_label_pred prin sess_id content)
+  )
 
 #push-options "--z3rlimit 25"
 val attacker_only_knows_publishable_values_aux:

--- a/src/core/DY.Core.Attacker.Knowledge.fst
+++ b/src/core/DY.Core.Attacker.Knowledge.fst
@@ -36,7 +36,7 @@ let rec attacker_knows_aux step tr msg =
     // - states that the attacker has corrupt
     (
       exists prin sess_id.
-        was_corrupt tr prin sess_id msg
+        state_was_corrupt tr prin sess_id msg
     ) \/
     // - public literals
     (
@@ -195,12 +195,13 @@ val corrupted_state_is_publishable:
   tr:trace -> prin:principal -> sess_id:state_id -> content:bytes ->
   Lemma
   (requires
-    was_corrupt tr prin sess_id content /\
+    state_was_corrupt tr prin sess_id content /\
     trace_invariant tr
   )
   (ensures is_publishable tr content)
 let corrupted_state_is_publishable #invs tr prin sess_id content =
-  state_is_knowable_by tr prin sess_id content
+  state_is_knowable_by tr prin sess_id content;
+  state_pred_label_can_flow_public tr (principal_state_content_label_input prin sess_id content)
 
 #push-options "--z3rlimit 25"
 val attacker_only_knows_publishable_values_aux:

--- a/src/core/DY.Core.Attacker.Knowledge.fst
+++ b/src/core/DY.Core.Attacker.Knowledge.fst
@@ -200,12 +200,7 @@ val corrupted_state_is_publishable:
   )
   (ensures is_publishable tr content)
 let corrupted_state_is_publishable #invs tr prin sess_id content =
-  eliminate exists time. event_exists tr (Corrupt time) /\ event_at tr time (SetState prin sess_id content)
-  returns is_publishable tr content
-  with _. (
-    state_is_knowable_by tr prin sess_id content;
-    state_pred_label_can_flow_public tr (principal_state_content_label_pred prin sess_id content)
-  )
+  state_is_knowable_by tr prin sess_id content
 
 #push-options "--z3rlimit 25"
 val attacker_only_knows_publishable_values_aux:

--- a/src/core/DY.Core.Label.fst
+++ b/src/core/DY.Core.Label.fst
@@ -312,18 +312,18 @@ let state_pred_label p = mk_label {
   is_corrupt_later = (fun tr1 tr2 -> ());
 }
 
-val state_pred_label_can_flow:
+val state_pred_label_pred_can_flow:
   (principal -> state_id -> bytes -> prop) ->
   (principal -> state_id -> bytes -> prop) ->
   prop
-let state_pred_label_can_flow p1 p2 =
+let state_pred_label_pred_can_flow p1 p2 =
   forall p s c. p2 p s c ==> p1 p s c
 
 val state_pred_label_can_flow_state_pred_label:
   tr:trace ->
   p1:(principal -> state_id -> bytes -> prop) -> p2:(principal -> state_id -> bytes -> prop) ->
   Lemma
-  (requires state_pred_label_can_flow p1 p2)
+  (requires state_pred_label_pred_can_flow p1 p2)
   (ensures state_pred_label p1 `can_flow tr` state_pred_label p2)
   [SMTPat (state_pred_label p1 `can_flow tr` state_pred_label p2)]
 let state_pred_label_can_flow_state_pred_label tr p1 p2 =
@@ -363,7 +363,8 @@ val principal_state_label_pred:
   principal -> state_id ->
   principal -> state_id -> bytes -> prop
 let principal_state_label_pred prin1 sess_id1 prin2 sess_id2 _ =
-  prin1 == prin2 /\ sess_id1 == sess_id2
+  prin1 == prin2 /\
+  sess_id1 == sess_id2
 
 val principal_state_label: principal -> state_id -> label
 let principal_state_label prin sess_id =
@@ -373,7 +374,9 @@ val principal_state_content_label_pred:
   principal -> state_id -> bytes ->
   principal -> state_id -> bytes -> prop
 let principal_state_content_label_pred prin1 sess_id1 content1 prin2 sess_id2 content2 =
-  prin1 == prin2 /\ sess_id1 == sess_id2 /\ content1 == content2
+  prin1 == prin2 /\
+  sess_id1 == sess_id2 /\
+  content1 == content2
 
 val principal_state_content_label: principal -> state_id -> bytes -> label
 let principal_state_content_label prin sess_id content =

--- a/src/core/DY.Core.Label.fst
+++ b/src/core/DY.Core.Label.fst
@@ -1,6 +1,7 @@
 module DY.Core.Label
 
 open DY.Core.Label.Type
+open DY.Core.Bytes.Type
 open DY.Core.Trace.Type
 open DY.Core.Trace.Base
 
@@ -184,20 +185,6 @@ let join l1 l2 = mk_label {
   );
 }
 
-[@@"opaque_to_smt"]
-val principal_label: principal -> label
-let principal_label prin = mk_label {
-  is_corrupt = (fun tr -> exists sess_id. was_corrupt tr prin sess_id);
-  is_corrupt_later = (fun tr1 tr2 -> ());
-}
-
-[@@"opaque_to_smt"]
-val principal_state_label: principal -> state_id -> label
-let principal_state_label prin sess_id = mk_label {
-  is_corrupt = (fun tr -> was_corrupt tr prin sess_id);
-  is_corrupt_later = (fun tr1 tr2 -> ());
-}
-
 /// `can_flow tr` is reflexive.
 
 val can_flow_reflexive:
@@ -291,19 +278,6 @@ let flow_to_public_eq tr prin =
   reveal_opaque (`%can_flow) (can_flow);
   reveal_opaque (`%public) (public)
 
-/// A principal flows to a particular state of this principal.
-
-val principal_flow_to_principal_state:
-  tr:trace -> prin:principal -> sess_id:state_id ->
-  Lemma
-  (ensures (principal_label prin) `can_flow tr` (principal_state_label prin sess_id))
-  [SMTPat ((principal_label prin) `can_flow tr` (principal_state_label prin sess_id))]
-let principal_flow_to_principal_state tr prin sess_id =
-  reveal_opaque (`%is_corrupt) is_corrupt;
-  reveal_opaque (`%can_flow) can_flow;
-  reveal_opaque (`%principal_label) principal_label;
-  reveal_opaque (`%principal_state_label) principal_state_label
-
 /// A `join` flows to `public` iff. one of its operands flows to `public`.
 /// This is a property specific to labels,
 /// that is not implied by the standard lattice properties.
@@ -318,3 +292,89 @@ let join_flow_to_public_eq tr x1 x2 =
   reveal_opaque (`%can_flow) (can_flow);
   reveal_opaque (`%join) (join);
   reveal_opaque (`%public) (public)
+
+/// Generic label for states:
+/// `state_pred_label p` is corrupt when
+/// there exists a corrupt `SetState` event satisfying the predicate `p`.
+/// It can for example be used to depict any state of a principal
+/// (e.g. as done by `principal_label`)
+
+[@@"opaque_to_smt"]
+val state_pred_label:
+  (principal -> state_id -> bytes -> prop) ->
+  label
+let state_pred_label p = mk_label {
+  is_corrupt = (fun tr ->
+    exists prin sess_id content.
+      was_corrupt tr prin sess_id content /\
+      p prin sess_id content
+  );
+  is_corrupt_later = (fun tr1 tr2 -> ());
+}
+
+val state_pred_label_can_flow:
+  (principal -> state_id -> bytes -> prop) ->
+  (principal -> state_id -> bytes -> prop) ->
+  prop
+let state_pred_label_can_flow p1 p2 =
+  forall p s c. p2 p s c ==> p1 p s c
+
+val state_pred_label_can_flow_state_pred_label:
+  tr:trace ->
+  p1:(principal -> state_id -> bytes -> prop) -> p2:(principal -> state_id -> bytes -> prop) ->
+  Lemma
+  (requires state_pred_label_can_flow p1 p2)
+  (ensures state_pred_label p1 `can_flow tr` state_pred_label p2)
+  [SMTPat (state_pred_label p1 `can_flow tr` state_pred_label p2)]
+let state_pred_label_can_flow_state_pred_label tr p1 p2 =
+  reveal_opaque (`%is_corrupt) is_corrupt;
+  reveal_opaque (`%can_flow) (can_flow);
+  reveal_opaque (`%state_pred_label) (state_pred_label)
+
+val state_pred_label_can_flow_public:
+  tr:trace ->
+  p:(principal -> state_id -> bytes -> prop) ->
+  Lemma (
+    (state_pred_label p) `can_flow tr` public
+    <==> (
+      exists prin sess_id content.
+        was_corrupt tr prin sess_id content /\
+        p prin sess_id content
+    )
+  )
+  [SMTPat ((state_pred_label p) `can_flow tr` public)]
+let state_pred_label_can_flow_public tr p =
+  reveal_opaque (`%is_corrupt) is_corrupt;
+  reveal_opaque (`%state_pred_label) (state_pred_label);
+  FStar.Classical.forall_intro (FStar.Classical.move_requires (event_exists_fmap_trace_eq forget_label tr));
+  FStar.Classical.forall_intro_2 (FStar.Classical.move_requires_2 (event_at_fmap_trace_eq forget_label tr))
+
+val principal_label_pred:
+  principal ->
+  principal -> state_id -> bytes -> prop
+let principal_label_pred prin1 prin2 _ _ =
+  prin1 == prin2
+
+val principal_label: principal -> label
+let principal_label prin =
+  state_pred_label (principal_label_pred prin)
+
+val principal_state_label_pred:
+  principal -> state_id ->
+  principal -> state_id -> bytes -> prop
+let principal_state_label_pred prin1 sess_id1 prin2 sess_id2 _ =
+  prin1 == prin2 /\ sess_id1 == sess_id2
+
+val principal_state_label: principal -> state_id -> label
+let principal_state_label prin sess_id =
+  state_pred_label (principal_state_label_pred prin sess_id)
+
+val principal_state_content_label_pred:
+  principal -> state_id -> bytes ->
+  principal -> state_id -> bytes -> prop
+let principal_state_content_label_pred prin1 sess_id1 content1 prin2 sess_id2 content2 =
+  prin1 == prin2 /\ sess_id1 == sess_id2 /\ content1 == content2
+
+val principal_state_content_label: principal -> state_id -> bytes -> label
+let principal_state_content_label prin sess_id content =
+  state_pred_label (principal_state_content_label_pred prin sess_id content)

--- a/src/core/DY.Core.Label.fst
+++ b/src/core/DY.Core.Label.fst
@@ -310,7 +310,7 @@ val state_pred_label:
 let state_pred_label p = mk_label {
   is_corrupt = (fun tr ->
     exists prin sess_id content.
-      was_corrupt tr prin sess_id content /\
+      state_was_corrupt tr prin sess_id content /\
       p prin sess_id content
   );
   is_corrupt_later = (fun tr1 tr2 -> ());
@@ -342,11 +342,10 @@ val state_pred_label_can_flow_public:
     (state_pred_label p) `can_flow tr` public
     <==> (
       exists prin sess_id content.
-        was_corrupt tr prin sess_id content /\
+        state_was_corrupt tr prin sess_id content /\
         p prin sess_id content
     )
   )
-  [SMTPat ((state_pred_label p) `can_flow tr` public)]
 let state_pred_label_can_flow_public tr p =
   reveal_opaque (`%is_corrupt) is_corrupt;
   reveal_opaque (`%state_pred_label) (state_pred_label);

--- a/src/core/DY.Core.Trace.Base.fst
+++ b/src/core/DY.Core.Trace.Base.fst
@@ -19,10 +19,6 @@ let rec length tr =
   | Nil -> 0
   | Snoc init last -> length init + 1
 
-/// a type macro for timestamps (indices on the trace)
-
-type timestamp = nat
-
 (*** Prefix and trace_ extension ***)
 
 /// Compute the prefix of a trace.
@@ -282,10 +278,12 @@ let state_was_set #label_t tr prin sess_id content =
 
 val was_corrupt:
   #label_t:Type ->
-  trace_ label_t -> principal -> state_id ->
+  trace_ label_t -> principal -> state_id -> bytes ->
   prop
-let was_corrupt #label_t tr prin sess_id =
-  event_exists tr (Corrupt prin sess_id)
+let was_corrupt tr prin sess_id content =
+  exists time.
+    event_exists tr (Corrupt time) /\
+    event_at tr time (SetState prin sess_id content)
 
 /// Has a (custom, protocol-specific) event been triggered at some timestamp?
 
@@ -419,7 +417,7 @@ let fmap_trace_event #a #b f ev =
   match ev with
   | MsgSent msg -> MsgSent msg
   | RandGen usg lab len -> RandGen usg (f lab) len
-  | Corrupt prin sess_id -> Corrupt prin sess_id
+  | Corrupt time -> Corrupt time
   | SetState prin sess_id content -> SetState prin sess_id content
   | Event prin tag content -> Event prin tag content
 

--- a/src/core/DY.Core.Trace.Base.fst
+++ b/src/core/DY.Core.Trace.Base.fst
@@ -276,11 +276,11 @@ let state_was_set #label_t tr prin sess_id content =
 
 /// Has a principal been corrupt?
 
-val was_corrupt:
+val state_was_corrupt:
   #label_t:Type ->
   trace_ label_t -> principal -> state_id -> bytes ->
   prop
-let was_corrupt tr prin sess_id content =
+let state_was_corrupt tr prin sess_id content =
   exists time.
     event_exists tr (Corrupt time) /\
     event_at tr time (SetState prin sess_id content)

--- a/src/core/DY.Core.Trace.Invariant.fst
+++ b/src/core/DY.Core.Trace.Invariant.fst
@@ -45,7 +45,7 @@ type state_predicate {|crypto_invariants|} = {
     Lemma
     (requires pred tr prin sess_id content)
     (ensures
-      is_knowable_by (principal_state_label prin sess_id) tr content
+      is_knowable_by (principal_state_content_label prin sess_id content) tr content
     )
   ;
 }
@@ -187,7 +187,7 @@ val state_is_knowable_by:
     trace_invariant tr /\
     state_was_set tr prin sess_id content
   )
-  (ensures is_knowable_by (principal_state_label prin sess_id) tr content)
+  (ensures is_knowable_by (principal_state_content_label prin sess_id content) tr content)
 let state_is_knowable_by #invs tr prin sess_id content =
   state_pred.pred_knowable tr prin sess_id content
 

--- a/src/core/DY.Core.Trace.Manipulation.fst
+++ b/src/core/DY.Core.Trace.Manipulation.fst
@@ -216,29 +216,29 @@ let recv_msg_invariant #invs i tr =
 
 (*** Corruption ***)
 
-/// Corrupt a session of a principal.
+/// Corrupt a state set at a given timestamp
 
 [@@ "opaque_to_smt"]
-val corrupt: principal -> state_id -> traceful unit
-let corrupt prin sess_id =
-  add_event (Corrupt prin sess_id)
+val corrupt: timestamp -> traceful unit
+let corrupt time =
+  add_event (Corrupt time)
 
-/// Corrupting a principal always preserve the trace invariant.
+/// Corrupting a state always preserve the trace invariant.
 
 val corrupt_invariant:
   {|protocol_invariants|} ->
-  prin:principal -> sess_id:state_id -> tr:trace ->
+  time:timestamp -> tr:trace ->
   Lemma
   (requires
     trace_invariant tr
   )
   (ensures (
-    let ((), tr_out) = corrupt prin sess_id tr in
+    let ((), tr_out) = corrupt time tr in
     trace_invariant tr_out
   ))
-  [SMTPat (corrupt prin sess_id tr); SMTPat (trace_invariant tr)]
-let corrupt_invariant #invs prin sess_id tr =
-  add_event_invariant (Corrupt prin sess_id) tr;
+  [SMTPat (corrupt time tr); SMTPat (trace_invariant tr)]
+let corrupt_invariant #invs time tr =
+  add_event_invariant (Corrupt time) tr;
   normalize_term_spec corrupt
 
 (*** Random number generation ***)

--- a/src/core/DY.Core.Trace.Type.fst
+++ b/src/core/DY.Core.Trace.Type.fst
@@ -39,6 +39,10 @@ type principal = string
 
 type state_id = { the_id: nat; }
 
+/// a type macro for timestamps (indices on the trace)
+
+type timestamp = nat
+
 /// The type for events in the trace.
 
 noeq
@@ -48,7 +52,7 @@ type trace_event_ (label_t:Type) =
   // A random number has been generated, with some usage and label.
   | RandGen: usg:usage -> label_t -> len:nat{len <> 0} -> trace_event_ label_t
   // A state of a principal has been corrupt.
-  | Corrupt: prin:principal -> sess_id:state_id -> trace_event_ label_t
+  | Corrupt: time:timestamp -> trace_event_ label_t
   // A principal stored some state.
   | SetState: prin:principal -> sess_id:state_id -> content:bytes -> trace_event_ label_t
   // A custom and protocol-specific event has been triggered by a principal.

--- a/src/lib/state/DY.Lib.State.PKI.fst
+++ b/src/lib/state/DY.Lib.State.PKI.fst
@@ -7,7 +7,7 @@ open DY.Lib.Comparse.Parsers
 open DY.Lib.State.Tagged
 open DY.Lib.State.Typed
 open DY.Lib.State.Map
-open DY.Lib.State.PrivateKeys
+open DY.Lib.State.PrivateKeys // is_public_key_for
 
 #set-options "--fuel 1 --ifuel 1"
 
@@ -61,8 +61,8 @@ val has_pki_invariant: {|protocol_invariants|} -> prop
 let has_pki_invariant #invs =
   has_map_session_invariant pki_pred
 
-val pki_tag_and_invariant: {|crypto_invariants|} -> string & local_bytes_state_predicate
-let pki_tag_and_invariant #ci = (map_types_pki.tag, local_state_predicate_to_local_bytes_state_predicate (map_session_invariant pki_pred))
+val pki_tag_and_invariant: {|crypto_invariants|} -> dtuple2 string local_bytes_state_predicate
+let pki_tag_and_invariant #ci = (|map_types_pki.tag, local_state_predicate_to_local_bytes_state_predicate (map_session_invariant pki_pred)|)
 
 (*** PKI API ***)
 

--- a/src/lib/state/DY.Lib.State.Tagged.fst
+++ b/src/lib/state/DY.Lib.State.Tagged.fst
@@ -47,8 +47,8 @@ val tagged_state_pred_label_pred_allow_inversion:
     inversion tagged_state
   )
   [SMTPatOr [
-    [SMTPat (state_pred_label_can_flow p2 (tagged_state_pred_label_pred p1))];
-    [SMTPat (state_pred_label_can_flow (tagged_state_pred_label_pred p1) p2)];
+    [SMTPat (state_pred_label_pred_can_flow p2 (tagged_state_pred_label_pred p1))];
+    [SMTPat (state_pred_label_pred_can_flow (tagged_state_pred_label_pred p1) p2)];
   ]]
 let tagged_state_pred_label_pred_allow_inversion p1 p2 =
   allow_inversion (option tagged_state);

--- a/src/lib/state/DY.Lib.State.Typed.fst
+++ b/src/lib/state/DY.Lib.State.Typed.fst
@@ -56,8 +56,8 @@ val typed_state_pred_label_pred_allow_inversion:
   Lemma
   (inversion (option a))
   [SMTPatOr [
-    [SMTPat (state_pred_label_can_flow p2 (tagged_state_pred_label_pred (typed_state_pred_label_pred p1)))];
-    [SMTPat (state_pred_label_can_flow (tagged_state_pred_label_pred (typed_state_pred_label_pred p1)) p2)];
+    [SMTPat (state_pred_label_pred_can_flow p2 (tagged_state_pred_label_pred (typed_state_pred_label_pred p1)))];
+    [SMTPat (state_pred_label_pred_can_flow (tagged_state_pred_label_pred (typed_state_pred_label_pred p1)) p2)];
   ]]
 let typed_state_pred_label_pred_allow_inversion #a #ps_a p1 p2 =
   allow_inversion (option a)

--- a/src/lib/state/DY.Lib.State.Typed.fst
+++ b/src/lib/state/DY.Lib.State.Typed.fst
@@ -42,16 +42,13 @@ val typed_state_pred_label:
 let typed_state_pred_label p =
   tagged_state_pred_label (compile_typed_state_pred_label_input p)
 
-val was_corrupt:
+val state_was_corrupt:
   #a:Type0 -> {|parseable_serializeable bytes a|} ->
   trace ->
   principal -> string -> state_id -> a ->
   prop
-let was_corrupt #a #ps tr prin tag sid content =
-  DY.Core.was_corrupt tr prin sid (serialize tagged_state {
-    tag;
-    content = serialize a content;
-  })
+let state_was_corrupt #a #ps tr prin tag sid content =
+  tagged_state_was_corrupt tr prin tag sid (serialize a content)
 
 // This lemma is useful to keep ifuel low
 // when reasoning on `typed_state_pred_label`.
@@ -76,14 +73,14 @@ val typed_state_pred_label_can_flow_public:
     typed_state_pred_label p `can_flow tr` public
     <==> (
       exists prin tag sid content.
-        was_corrupt tr prin tag sid content /\
+        state_was_corrupt tr prin tag sid content /\
         p prin tag sid content
     )
   )
   [SMTPat (typed_state_pred_label p `can_flow tr` public)]
 let typed_state_pred_label_can_flow_public #a #ps tr p =
   FStar.Classical.forall_intro (FStar.Classical.move_requires (serialize_parse_inv_lemma #bytes a));
-  FStar.Classical.forall_intro (FStar.Classical.move_requires (serialize_parse_inv_lemma #bytes tagged_state))
+  tagged_state_pred_label_can_flow_public tr (compile_typed_state_pred_label_input p)
 
 val principal_typed_state_content_label_input:
   #a:Type0 -> {|parseable_serializeable bytes a|} ->

--- a/src/lib/state/DY.Lib.State.Typed.fst
+++ b/src/lib/state/DY.Lib.State.Typed.fst
@@ -19,8 +19,85 @@ let mk_local_state_instance #a #format tag = {
   format;
 }
 
+val typed_state_pred_label_pred:
+  #a:Type0 -> {|parseable_serializeable bytes a|} ->
+  (principal -> string -> state_id -> a -> prop) ->
+  (principal -> string -> state_id -> bytes -> prop)
+let typed_state_pred_label_pred #a #ps_a p prin sess_id tag content =
+  match parse a content with
+  | None -> False
+  | Some parsed_content ->
+    p prin sess_id tag parsed_content
+
+val typed_state_pred_label:
+  #a:Type0 -> {|parseable_serializeable bytes a|} ->
+  (principal -> string -> state_id -> a -> prop) ->
+  label
+let typed_state_pred_label p =
+  tagged_state_pred_label (typed_state_pred_label_pred p)
+
+val was_corrupt:
+  #a:Type0 -> {|parseable_serializeable bytes a|} ->
+  trace ->
+  principal -> string -> state_id -> a ->
+  prop
+let was_corrupt #a #ps tr prin tag sid content =
+  DY.Core.was_corrupt tr prin sid (serialize tagged_state {
+    tag;
+    content = serialize a content;
+  })
+
+// This lemma is useful to keep ifuel low
+// when reasoning on `typed_state_pred_label`.
+val typed_state_pred_label_pred_allow_inversion:
+  #a:Type0 -> {|parseable_serializeable bytes a|} ->
+  p1:(principal -> string -> state_id -> a -> prop) ->
+  p2:(principal -> state_id -> bytes -> prop) ->
+  Lemma
+  (inversion (option a))
+  [SMTPatOr [
+    [SMTPat (state_pred_label_can_flow p2 (tagged_state_pred_label_pred (typed_state_pred_label_pred p1)))];
+    [SMTPat (state_pred_label_can_flow (tagged_state_pred_label_pred (typed_state_pred_label_pred p1)) p2)];
+  ]]
+let typed_state_pred_label_pred_allow_inversion #a #ps_a p1 p2 =
+  allow_inversion (option a)
+
+val typed_state_pred_label_can_flow_public:
+  #a:Type0 -> {|parseable_serializeable bytes a|} ->
+  tr:trace ->
+  p:(principal -> string -> state_id -> a -> prop) ->
+  Lemma (
+    typed_state_pred_label p `can_flow tr` public
+    <==> (
+      exists prin tag sid content.
+        was_corrupt tr prin tag sid content /\
+        p prin tag sid content
+    )
+  )
+  [SMTPat (typed_state_pred_label p `can_flow tr` public)]
+let typed_state_pred_label_can_flow_public #a #ps tr p =
+  FStar.Classical.forall_intro (FStar.Classical.move_requires (serialize_parse_inv_lemma #bytes a));
+  FStar.Classical.forall_intro (FStar.Classical.move_requires (serialize_parse_inv_lemma #bytes tagged_state))
+
+val principal_typed_state_content_label_pred:
+  #a:Type0 -> {|parseable_serializeable bytes a|} ->
+  principal -> string -> state_id -> a ->
+  principal -> string -> state_id -> a -> prop
+let principal_typed_state_content_label_pred #a #ps_a prin1 tag1 sess_id1 content1 prin2 tag2 sess_id2 content2 =
+  prin1 == prin2 /\
+  tag1 == tag2 /\
+  sess_id1 == sess_id2 /\
+  content1 == content2
+
+val principal_typed_state_content_label:
+  #a:Type0 -> {|parseable_serializeable bytes a|} ->
+  principal -> string -> state_id -> a ->
+  label
+let principal_typed_state_content_label prin tag sess_id content =
+  typed_state_pred_label (principal_typed_state_content_label_pred prin tag sess_id content)
+
 noeq
-type local_state_predicate {|crypto_invariants|} (a:Type) {|parseable_serializeable bytes a|} = {
+type local_state_predicate {|crypto_invariants|} (a:Type) {|local_state a|} = {
   pred: trace -> principal -> state_id -> a -> prop;
   pred_later:
     tr1:trace -> tr2:trace ->
@@ -33,14 +110,14 @@ type local_state_predicate {|crypto_invariants|} (a:Type) {|parseable_serializea
     tr:trace -> prin:principal -> sess_id:state_id -> content:a ->
     Lemma
     (requires pred tr prin sess_id content)
-    (ensures is_well_formed _ (is_knowable_by (principal_state_label prin sess_id) tr) content)
+    (ensures is_well_formed _ (is_knowable_by (principal_typed_state_content_label prin (tag #a) sess_id content) tr) content)
   ;
 }
 
 val local_state_predicate_to_local_bytes_state_predicate:
   {|crypto_invariants|} ->
-  #a:Type -> {|parseable_serializeable bytes a|} ->
-  local_state_predicate a -> local_bytes_state_predicate
+  #a:Type -> {|local_state a|} ->
+  local_state_predicate a -> local_bytes_state_predicate (tag #a)
 let local_state_predicate_to_local_bytes_state_predicate #cinvs #a #ps_a tspred =
   {
     pred = (fun tr prin sess_id content_bytes ->
@@ -56,7 +133,7 @@ let local_state_predicate_to_local_bytes_state_predicate #cinvs #a #ps_a tspred 
       let Some content = parse a content_bytes in
       tspred.pred_knowable tr prin sess_id content;
       serialize_parse_inv_lemma a content_bytes;
-      serialize_wf_lemma a (is_knowable_by (principal_state_label prin sess_id) tr) content
+      serialize_wf_lemma a (is_knowable_by (principal_typed_state_content_label prin (tag #a) sess_id content) tr) content
     );
   }
 
@@ -65,7 +142,7 @@ val has_local_state_predicate:
   {|protocol_invariants|} -> local_state_predicate a ->
   prop
 let has_local_state_predicate #a #ls #invs spred =
-  has_local_bytes_state_predicate (ls.tag, (local_state_predicate_to_local_bytes_state_predicate spred))
+  has_local_bytes_state_predicate (|ls.tag, (local_state_predicate_to_local_bytes_state_predicate spred)|)
 
 [@@ "opaque_to_smt"]
 val state_was_set:

--- a/src/lib/utils/DY.Lib.Printing.fst
+++ b/src/lib/utils/DY.Lib.Printing.fst
@@ -210,7 +210,7 @@ let trace_event_to_string printers tr_event i =
     Printf.sprintf "{\"TraceID\": %d, \"Type\": \"Nonce\", \"Usage\": %s}\n" 
     i (usage_to_string usg)
   )
-  | Corrupt prin sess_id -> ""
+  | Corrupt time -> ""
   | SetState prin sess_id full_content -> (
     let content_str = state_to_string printers.state_to_string full_content in
     Printf.sprintf "{\"TraceID\": %d, \"Type\": \"Session\", \"SessionID\": %d, \"Principal\": \"%s\", \"Content\": \"%s\"}\n"

--- a/src/lib/utils/DY.Lib.SplitFunction.fst
+++ b/src/lib/utils/DY.Lib.SplitFunction.fst
@@ -280,6 +280,26 @@ val local_eq_global_lemma:
   (ensures params.apply_global_fun global_fun tagged_data == params.apply_local_fun local_fun raw_data)
 let local_eq_global_lemma params global_fun tag_set tagged_local_fun tagged_data tag raw_data = ()
 
+/// The tag set returned by `find_local_fun` contains the tag given as parameter.
+
+val find_local_fun_returns_belonging_tag_set:
+  params:split_function_parameters ->
+  tagged_local_funs:list (dtuple2 params.tag_set_t params.local_fun_t) ->
+  tag:params.tag_t ->
+  Lemma (
+    match find_local_fun params tagged_local_funs tag with
+    | None -> True
+    | Some (|tag_set, local_fun|) -> tag `params.tag_belong_to` tag_set
+  )
+let rec find_local_fun_returns_belonging_tag_set params tagged_local_funs tag =
+  match tagged_local_funs with
+  | [] -> ()
+  | (|h_tag_set, h_local_fun|)::t_tagged_local_funs -> (
+    if tag `params.tag_belong_to` h_tag_set then ()
+    else find_local_fun_returns_belonging_tag_set params t_tagged_local_funs tag
+  )
+
+
 /// In the common case where tag disjointness is unequality,
 /// the `no_repeats_p` predicate from F*'s standard library
 /// implies `for_all_pairsP unequal`.


### PR DESCRIPTION
This PR builds on #56 and #59.
Although I found how to have a nice diff in GitHub when a PR depends on another, I don't know how to do when it depends on two others, so the diff will have a combination of #59 and #60 (this PR). Hopefully it's not too bad because #59 is a small change.

To explain what this PR does, first a small refresher on labels (or at least, on one way to understand labels): the label associated with a `bytes` is a restriction on where this `bytes` can be stored, or more generally, on the data that could be used to derive this `bytes`. For example:
- `get_label buf == principal_label "Alice"` means `buf` may only be stored by Alice, and may only be encrypted to keys that can only be stored by Alice, etc
- `get_label buf == principal_state_label "Alice" 4` means `buf` may only be stored in the 4th state of Alice, etc

We introduce "content-aware labels", to use for `bytes` that may only appear in a state that contain some other data. For example, now, we are able to express that a private key generated in `DY.Lib.State.PrivateKeys` may only appear in a PrivateKeys state and can't be stored in other states. This allows to have a more precise ISO-DH proof, where we are now able to distinguish "the signature key was compromised" from "an ephemeral DH key was compromised".

This is a draft because there are some `assume` in the code, about injectivity of `long_signature_key_label` that replaced `principal_label` on which we have injectivity.
We could prove the injectivity, because it is injective, however I think this is the wrong approach and we should use the approach done in #52, where the principal holding a key also appear in the usage.