### PR TITLE
cleanup: make PKI more aware of PrivateKeys

### DIFF
--- a/examples/iso_dh/DY.Example.DH.Debug.fst
+++ b/examples/iso_dh/DY.Example.DH.Debug.fst
@@ -13,27 +13,27 @@ let debug () : traceful (option unit)  =
 
   // Generate private key for Alice
   let* alice_global_session_priv_key_id = initialize_private_keys alice in
-  generate_private_key alice alice_global_session_priv_key_id (Sign "DH.SigningKey");*
+  generate_private_key alice alice_global_session_priv_key_id (LongTermSigKey "DH.SigningKey");*
   
   // Generate private key for Bob
   let* bob_global_session_priv_key_id = initialize_private_keys bob in
-  generate_private_key bob bob_global_session_priv_key_id (Sign "DH.SigningKey");*
+  generate_private_key bob bob_global_session_priv_key_id (LongTermSigKey "DH.SigningKey");*
 
   // Store Bob's public key in Alice's state
   // 1. Retrieve Bob's private key from his session
   // 2. Compute the public key from the private key
   // 3. Initialize Alice's session to store public keys
   // 4. Install Bob's public key in Alice's public key store
-  let*? priv_key_bob = get_private_key bob bob_global_session_priv_key_id (Sign "DH.SigningKey") in
-  let pub_key_bob = vk priv_key_bob in
+  let*? priv_key_bob = get_private_key bob bob_global_session_priv_key_id (LongTermSigKey "DH.SigningKey") in
+  let*? pub_key_bob = compute_public_key bob bob_global_session_priv_key_id (LongTermSigKey "DH.SigningKey") in
   let* alice_global_session_pub_key_id = initialize_pki alice in
-  install_public_key alice alice_global_session_pub_key_id (Verify "DH.SigningKey") bob pub_key_bob;*
+  install_public_key alice alice_global_session_pub_key_id (LongTermSigKey "DH.SigningKey") bob pub_key_bob;*
 
   // Store Alice's public key in Bob's state
-  let*? priv_key_alice = get_private_key alice alice_global_session_priv_key_id (Sign "DH.SigningKey") in
-  let pub_key_alice = vk priv_key_alice in
+  let*? priv_key_alice = get_private_key alice alice_global_session_priv_key_id (LongTermSigKey "DH.SigningKey") in
+  let*? pub_key_alice = compute_public_key alice alice_global_session_priv_key_id (LongTermSigKey "DH.SigningKey") in
   let* bob_global_session_pub_key_id = initialize_pki bob in
-  install_public_key bob bob_global_session_pub_key_id (Verify "DH.SigningKey") alice pub_key_alice;*
+  install_public_key bob bob_global_session_pub_key_id (LongTermSigKey "DH.SigningKey") alice pub_key_alice;*
 
   let alice_global_session_ids: dh_global_sess_ids = {pki=alice_global_session_pub_key_id; private_keys=alice_global_session_priv_key_id} in
   let bob_global_session_ids: dh_global_sess_ids = {pki=bob_global_session_pub_key_id; private_keys=bob_global_session_priv_key_id} in

--- a/examples/iso_dh/DY.Example.DH.Protocol.Stateful.Proof.fst
+++ b/examples/iso_dh/DY.Example.DH.Protocol.Stateful.Proof.fst
@@ -212,7 +212,7 @@ val send_msg2_proof:
 let send_msg2_proof tr global_sess_id bob bob_si =
   match get_state bob bob_si tr with
   | (Some (ResponderSentMsg2 alice gx gy y), tr) -> (
-    match get_private_key bob global_sess_id.private_keys (Sign "DH.SigningKey") tr with
+    match get_private_key bob global_sess_id.private_keys (LongTermSigKey "DH.SigningKey") tr with
     | (Some sk_b, tr) -> (
       let (n_sig, tr) = mk_rand SigNonce (principal_label bob) 32 tr in
       compute_message2_proof tr alice bob gx y sk_b n_sig
@@ -238,7 +238,7 @@ let prepare_msg3_proof tr global_sess_id alice alice_si bob msg_id =
   | (Some (InitiatorSentMsg1 bob x), tr) -> (
     match recv_msg msg_id tr with
     | (Some msg_bytes, tr) -> (
-      match get_public_key alice global_sess_id.pki (Verify "DH.SigningKey") bob tr with
+      match get_public_key alice global_sess_id.pki (LongTermSigKey "DH.SigningKey") bob tr with
       | (Some pk_b, tr) -> (
         match decode_and_verify_message2 msg_bytes alice x pk_b with
         | Some res -> (
@@ -301,7 +301,7 @@ val send_msg3_proof:
 let send_msg3_proof tr global_sess_id alice alice_si bob =
   match get_state alice alice_si tr with
   | (Some (InitiatorSendMsg3 bob gx gy k), tr') -> (
-    match get_private_key alice global_sess_id.private_keys (Sign "DH.SigningKey") tr' with
+    match get_private_key alice global_sess_id.private_keys (LongTermSigKey "DH.SigningKey") tr' with
     | (Some sk_a, tr') -> (
       let (n_sig, tr') = mk_rand SigNonce (principal_label alice) 32 tr' in
 
@@ -336,7 +336,7 @@ let verify_msg3_proof tr global_sess_id alice bob msg_id bob_si =
   | (Some (ResponderSentMsg2 alice gx gy y), tr) -> (
     match recv_msg msg_id tr with
     | (Some msg_bytes, tr) -> (
-      match get_public_key bob global_sess_id.pki (Verify "DH.SigningKey") alice tr with
+      match get_public_key bob global_sess_id.pki (LongTermSigKey "DH.SigningKey") alice tr with
       | (Some pk_a, tr) -> (
           decode_and_verify_message3_proof tr msg_bytes alice bob bob_si gx y pk_a;
           

--- a/examples/iso_dh/DY.Example.DH.Protocol.Stateful.fst
+++ b/examples/iso_dh/DY.Example.DH.Protocol.Stateful.fst
@@ -93,7 +93,7 @@ let send_msg2 global_sess_id bob bob_si =
   let*? session_state: dh_session = get_state bob bob_si in
   match session_state with
   | ResponderSentMsg2 alice gx gy y -> (
-    let*? sk_b = get_private_key bob global_sess_id.private_keys (Sign "DH.SigningKey") in
+    let*? sk_b = get_private_key bob global_sess_id.private_keys (LongTermSigKey "DH.SigningKey") in
     let* n_sig = mk_rand SigNonce (principal_label bob) 32 in
     let msg = compute_message2 alice bob gx gy sk_b n_sig in
     let* msg_id = send_msg msg in
@@ -109,7 +109,7 @@ let prepare_msg3 global_sess_id alice alice_si bob msg_id =
   let*? session_state: dh_session = get_state alice alice_si in
   match session_state with
   | InitiatorSentMsg1 bob x -> (
-    let*? pk_b = get_public_key alice global_sess_id.pki (Verify "DH.SigningKey") bob in
+    let*? pk_b = get_public_key alice global_sess_id.pki (LongTermSigKey "DH.SigningKey") bob in
     let*? msg = recv_msg msg_id in
     let*? res:verify_msg2_result = return (decode_and_verify_message2 msg alice x pk_b) in
     trigger_event alice (Initiate2 alice bob res.gx res.gy res.k);*
@@ -124,7 +124,7 @@ let send_msg3 global_sess_id alice bob alice_si =
   let*? session_state: dh_session = get_state alice alice_si in
   match session_state with
   | InitiatorSendMsg3 bob gx gy x -> (
-    let*? sk_a = get_private_key alice global_sess_id.private_keys (Sign "DH.SigningKey") in
+    let*? sk_a = get_private_key alice global_sess_id.private_keys (LongTermSigKey "DH.SigningKey") in
     let* n_sig = mk_rand SigNonce (principal_label alice) 32 in
     let msg = compute_message3 alice bob gx gy sk_a n_sig in
     let* msg_id = send_msg msg in
@@ -138,7 +138,7 @@ let verify_msg3 global_sess_id alice bob msg_id bob_si =
   let*? session_state: dh_session = get_state bob bob_si in
   match session_state with
   | ResponderSentMsg2 alice gx gy y -> (
-    let*? pk_a = get_public_key bob global_sess_id.pki (Verify "DH.SigningKey") alice in
+    let*? pk_a = get_public_key bob global_sess_id.pki (LongTermSigKey "DH.SigningKey") alice in
     let*? msg = recv_msg msg_id in
     let*? res:verify_msg3_result = return (decode_and_verify_message3 msg bob gx gy y pk_a) in
     trigger_event bob (Respond2 alice bob gx gy res.k);*

--- a/examples/iso_dh/DY.Example.DH.Protocol.Total.Proof.fst
+++ b/examples/iso_dh/DY.Example.DH.Protocol.Total.Proof.fst
@@ -248,7 +248,7 @@ let compute_message3_proof tr alice bob gx gy x sk_a n_sig =
   assert(is_publishable tr (serialize message msg));
   ()
 
-#push-options "--ifuel 1 --z3rlimit 10"
+#push-options "--ifuel 1 --z3rlimit 25"
 val decode_and_verify_message3_proof:
   tr:trace ->
   msg3_bytes:bytes ->

--- a/examples/iso_dh/DY.Example.DH.Protocol.Total.Proof.fst
+++ b/examples/iso_dh/DY.Example.DH.Protocol.Total.Proof.fst
@@ -130,7 +130,7 @@ val compute_message2_proof:
     event_triggered tr bob (Respond1 alice bob gx (dh_pk y) y) /\
     is_publishable tr gx /\
     bytes_invariant tr y /\
-    is_signature_key (SigKey "DH.SigningKey" empty) (principal_label bob) tr sk_b /\
+    is_private_key_for tr sk_b (LongTermSigKey "DH.SigningKey") bob /\
     is_secret (principal_label bob) tr n_sig /\
     SigNonce? (get_usage n_sig)
   )
@@ -175,7 +175,7 @@ val decode_and_verify_message2_proof:
   (requires
     is_publishable tr msg2_bytes /\
     is_secret (principal_state_label alice alice_si) tr x /\
-    is_verification_key (SigKey "DH.SigningKey" empty) (principal_label bob) tr pk_b
+    is_public_key_for tr pk_b (LongTermSigKey "DH.SigningKey") bob
   )
   (ensures (
     match decode_and_verify_message2 msg2_bytes alice x pk_b with
@@ -218,7 +218,7 @@ val compute_message3_proof:
     event_triggered tr alice (Initiate2 alice bob (dh_pk x) gy (dh x gy)) /\
     is_publishable tr gx /\ is_publishable tr gy /\
     gx = dh_pk x /\
-    is_signature_key (SigKey "DH.SigningKey" empty) (principal_label alice) tr sk_a /\
+    is_private_key_for tr sk_a (LongTermSigKey "DH.SigningKey") alice /\
     is_secret (principal_label alice) tr n_sig /\
     SigNonce? (get_usage n_sig)
   )
@@ -259,7 +259,7 @@ val decode_and_verify_message3_proof:
     is_publishable tr msg3_bytes /\
     is_publishable tr gx /\
     is_secret (principal_state_label bob bob_si) tr y /\
-    is_verification_key (SigKey "DH.SigningKey" empty) (principal_label alice) tr pk_a
+    is_public_key_for tr pk_a (LongTermSigKey "DH.SigningKey") alice
   )
   (ensures (
     let gy = dh_pk y in

--- a/examples/nsl_pk/DY.Example.NSL.Debug.fst
+++ b/examples/nsl_pk/DY.Example.NSL.Debug.fst
@@ -17,27 +17,27 @@ let debug () : traceful (option unit)  =
 
   // Generate private key for Alice
   let* alice_global_session_priv_key_id = initialize_private_keys alice in
-  generate_private_key alice alice_global_session_priv_key_id (PkDec "NSL.PublicKey");*
+  generate_private_key alice alice_global_session_priv_key_id (LongTermPkEncKey "NSL.PublicKey");*
   
   // Generate private key for Bob
   let* bob_global_session_priv_key_id = initialize_private_keys bob in
-  generate_private_key bob bob_global_session_priv_key_id (PkDec "NSL.PublicKey");*
+  generate_private_key bob bob_global_session_priv_key_id (LongTermPkEncKey "NSL.PublicKey");*
 
   // Store Bob's public key in Alice's state
   // 1. Retrieve Bob's private key from his session
   // 2. Compute the public key from the private key
   // 3. Initialize Alice's session to store public keys
   // 4. Install Bob's public key in Alice's public key store
-  let*? priv_key_bob = get_private_key bob bob_global_session_priv_key_id (PkDec "NSL.PublicKey") in
-  let pub_key_bob = pk priv_key_bob in
+  let*? priv_key_bob = get_private_key bob bob_global_session_priv_key_id (LongTermPkEncKey "NSL.PublicKey") in
+  let*? pub_key_bob = compute_public_key bob bob_global_session_priv_key_id (LongTermPkEncKey "NSL.PublicKey") in
   let* alice_global_session_pub_key_id = initialize_pki alice in
-  install_public_key alice alice_global_session_pub_key_id (PkEnc "NSL.PublicKey") bob pub_key_bob;*
+  install_public_key alice alice_global_session_pub_key_id (LongTermPkEncKey "NSL.PublicKey") bob pub_key_bob;*
 
   // Store Alice's public key in Bob's state
-  let*? priv_key_alice = get_private_key alice alice_global_session_priv_key_id (PkDec "NSL.PublicKey") in
-  let pub_key_alice = pk priv_key_alice in
+  let*? priv_key_alice = get_private_key alice alice_global_session_priv_key_id (LongTermPkEncKey "NSL.PublicKey") in
+  let*? pub_key_alice = compute_public_key alice alice_global_session_priv_key_id (LongTermPkEncKey "NSL.PublicKey") in
   let* bob_global_session_pub_key_id = initialize_pki bob in
-  install_public_key bob bob_global_session_pub_key_id (PkEnc "NSL.PublicKey") alice pub_key_alice;*
+  install_public_key bob bob_global_session_pub_key_id (LongTermPkEncKey "NSL.PublicKey") alice pub_key_alice;*
 
   let alice_global_session_ids: nsl_global_sess_ids = {pki=alice_global_session_pub_key_id; private_keys=alice_global_session_priv_key_id} in
   let bob_global_session_ids: nsl_global_sess_ids = {pki=bob_global_session_pub_key_id; private_keys=bob_global_session_priv_key_id} in

--- a/examples/nsl_pk/DY.Example.NSL.Protocol.Stateful.Proof.fst
+++ b/examples/nsl_pk/DY.Example.NSL.Protocol.Stateful.Proof.fst
@@ -167,7 +167,7 @@ val send_msg1_proof:
 let send_msg1_proof tr global_sess_id alice sess_id =
   match get_state alice sess_id tr with
   | (Some (InitiatorSentMsg1 bob n_a), tr) -> (
-    match get_public_key alice global_sess_id.pki (PkEnc "NSL.PublicKey") bob tr with
+    match get_public_key alice global_sess_id.pki (LongTermPkEncKey "NSL.PublicKey") bob tr with
     | (None, tr) -> ()
     | (Some pk_b, tr) -> (
       let (nonce, tr) = mk_rand PkNonce (principal_label alice) 32 tr in
@@ -189,7 +189,7 @@ let prepare_msg2_proof tr global_sess_id bob msg_id =
   match recv_msg msg_id tr with
   | (None, tr) -> ()
   | (Some msg, tr) -> (
-    match get_private_key bob global_sess_id.private_keys (PkDec "NSL.PublicKey") tr with
+    match get_private_key bob global_sess_id.private_keys (LongTermPkEncKey "NSL.PublicKey") tr with
     | (None, tr) -> ()
     | (Some sk_b, tr) -> (
       decode_message1_proof tr bob msg sk_b
@@ -208,7 +208,7 @@ val send_msg2_proof:
 let send_msg2_proof tr global_sess_id bob sess_id =
   match get_state bob sess_id tr with
   | (Some (ResponderSentMsg2 alice n_a n_b), tr) -> (
-    match get_public_key bob global_sess_id.pki (PkEnc "NSL.PublicKey") alice tr with
+    match get_public_key bob global_sess_id.pki (LongTermPkEncKey "NSL.PublicKey") alice tr with
     | (None, tr) -> ()
     | (Some pk_a, tr) -> (
       let (nonce, tr) = mk_rand PkNonce (principal_label bob) 32 tr in
@@ -230,7 +230,7 @@ let prepare_msg3_proof tr global_sess_id alice sess_id msg_id =
   match recv_msg msg_id tr with
   | (None, tr) -> ()
   | (Some msg, tr) -> (
-    match get_private_key alice global_sess_id.private_keys (PkDec "NSL.PublicKey") tr with
+    match get_private_key alice global_sess_id.private_keys (LongTermPkEncKey "NSL.PublicKey") tr with
     | (None, tr) -> ()
     | (Some sk_a, tr) -> (
       match get_state alice sess_id tr with
@@ -253,7 +253,7 @@ val send_msg3_proof:
 let send_msg3_proof tr global_sess_id alice sess_id =
   match get_state alice sess_id tr with
   | (Some (InitiatorSentMsg3 bob n_a n_b), tr) -> (
-    match get_public_key alice global_sess_id.pki (PkEnc "NSL.PublicKey") bob tr with
+    match get_public_key alice global_sess_id.pki (LongTermPkEncKey "NSL.PublicKey") bob tr with
     | (None, tr) -> ()
     | (Some pk_b, tr) -> (
       let (nonce, tr) = mk_rand PkNonce (principal_label alice) 32 tr in
@@ -292,7 +292,7 @@ let prepare_msg4 tr global_sess_id bob sess_id msg_id =
   match recv_msg msg_id tr with
   | (None, tr) -> ()
   | (Some msg, tr) -> (
-    match get_private_key bob global_sess_id.private_keys (PkDec "NSL.PublicKey") tr with
+    match get_private_key bob global_sess_id.private_keys (LongTermPkEncKey "NSL.PublicKey") tr with
     | (None, tr) -> ()
     | (Some sk_b, tr) -> (
       match get_state bob sess_id tr with

--- a/examples/nsl_pk/DY.Example.NSL.Protocol.Stateful.fst
+++ b/examples/nsl_pk/DY.Example.NSL.Protocol.Stateful.fst
@@ -71,7 +71,7 @@ let send_msg1 global_sess_id alice sess_id =
   let*? st: nsl_session = get_state alice sess_id in
   match st with
   | InitiatorSentMsg1 bob n_a -> (
-    let*? pk_b = get_public_key alice global_sess_id.pki (PkEnc "NSL.PublicKey") bob in
+    let*? pk_b = get_public_key alice global_sess_id.pki (LongTermPkEncKey "NSL.PublicKey") bob in
     let* nonce = mk_rand PkNonce (principal_label alice) 32 in
     let msg = compute_message1 alice bob pk_b n_a nonce in
     let* msg_id = send_msg msg in
@@ -82,7 +82,7 @@ let send_msg1 global_sess_id alice sess_id =
 val prepare_msg2: nsl_global_sess_ids -> principal -> timestamp -> traceful (option state_id)
 let prepare_msg2 global_sess_id bob msg_id =
   let*? msg = recv_msg msg_id in
-  let*? sk_b = get_private_key bob global_sess_id.private_keys (PkDec "NSL.PublicKey") in
+  let*? sk_b = get_private_key bob global_sess_id.private_keys (LongTermPkEncKey "NSL.PublicKey") in
   let*? msg1: message1 = return (decode_message1 bob msg sk_b) in
   let* n_b = mk_rand NoUsage (join (principal_label msg1.alice) (principal_label bob)) 32 in
   trigger_event bob (Respond1 msg1.alice bob msg1.n_a n_b);*
@@ -95,7 +95,7 @@ let send_msg2 global_sess_id bob sess_id =
   let*? st: nsl_session = get_state bob sess_id in
   match st with
   | ResponderSentMsg2 alice n_a n_b -> (
-    let*? pk_a = get_public_key bob global_sess_id.pki (PkEnc "NSL.PublicKey") alice in
+    let*? pk_a = get_public_key bob global_sess_id.pki (LongTermPkEncKey "NSL.PublicKey") alice in
     let* nonce = mk_rand PkNonce (principal_label bob) 32 in
     let msg = compute_message2 bob {n_a; alice;} pk_a n_b nonce in
     let* msg_id = send_msg msg in
@@ -106,7 +106,7 @@ let send_msg2 global_sess_id bob sess_id =
 val prepare_msg3: nsl_global_sess_ids -> principal -> state_id -> timestamp -> traceful (option unit)
 let prepare_msg3 global_sess_id alice sess_id msg_id =
   let*? msg = recv_msg msg_id in
-  let*? sk_a = get_private_key alice global_sess_id.private_keys (PkDec "NSL.PublicKey") in
+  let*? sk_a = get_private_key alice global_sess_id.private_keys (LongTermPkEncKey "NSL.PublicKey") in
   let*? st: nsl_session = get_state alice sess_id in
   match st with
   | InitiatorSentMsg1 bob n_a -> (
@@ -122,7 +122,7 @@ let send_msg3 global_sess_id alice sess_id =
   let*? st: nsl_session = get_state alice sess_id in
   match st with
   | InitiatorSentMsg3 bob n_a n_b -> (
-    let*? pk_b = get_public_key alice global_sess_id.pki (PkEnc "NSL.PublicKey") bob in
+    let*? pk_b = get_public_key alice global_sess_id.pki (LongTermPkEncKey "NSL.PublicKey") bob in
     let* nonce = mk_rand PkNonce (principal_label alice) 32 in
     let msg = compute_message3 alice bob pk_b n_b nonce in
     let* msg_id = send_msg msg in
@@ -133,7 +133,7 @@ let send_msg3 global_sess_id alice sess_id =
 val prepare_msg4: nsl_global_sess_ids -> principal -> state_id -> timestamp -> traceful (option unit)
 let prepare_msg4 global_sess_id bob sess_id msg_id =
   let*? msg = recv_msg msg_id in
-  let*? sk_b = get_private_key bob global_sess_id.private_keys (PkDec "NSL.PublicKey") in
+  let*? sk_b = get_private_key bob global_sess_id.private_keys (LongTermPkEncKey "NSL.PublicKey") in
   let*? st: nsl_session = get_state bob sess_id in
   match st with
   | ResponderSentMsg2 alice n_a n_b -> (

--- a/examples/nsl_pk/DY.Example.NSL.Protocol.Total.Proof.fst
+++ b/examples/nsl_pk/DY.Example.NSL.Protocol.Total.Proof.fst
@@ -73,7 +73,7 @@ val compute_message1_proof:
     // From random generation
     PkNonce? (get_usage nonce) /\
     // From PKI invariants
-    is_encryption_key (PkKey "NSL.PublicKey" empty) (principal_label bob) tr pk_b
+    is_public_key_for tr pk_b (LongTermPkEncKey "NSL.PublicKey") bob
   )
   (ensures is_publishable tr (compute_message1 alice bob pk_b n_a nonce))
 let compute_message1_proof tr alice bob pk_b n_a nonce =
@@ -93,7 +93,7 @@ val decode_message1_proof:
   Lemma
   (requires
     // From PrivateKeys invariants
-    is_decryption_key (PkKey "NSL.PublicKey" empty) (principal_label bob) tr sk_b /\
+    is_private_key_for tr sk_b (LongTermPkEncKey "NSL.PublicKey") bob /\
     // From the network
     bytes_invariant tr msg_cipher
   )
@@ -129,7 +129,7 @@ val compute_message2_proof:
     // From the random generation
     PkNonce? (get_usage nonce) /\
     // From the PKI
-    is_encryption_key (PkKey "NSL.PublicKey" empty) (principal_label msg1.alice) tr pk_a
+    is_public_key_for tr pk_a (LongTermPkEncKey "NSL.PublicKey") msg1.alice
   )
   (ensures
     is_publishable tr (compute_message2 bob msg1 pk_a n_b nonce)
@@ -153,7 +153,7 @@ val decode_message2_proof:
     // From the NSL state invariant
     is_secret (join (principal_label alice) (principal_label bob)) tr n_a /\
     // From the PrivateKeys invariant
-    is_decryption_key (PkKey "NSL.PublicKey" empty) (principal_label alice) tr sk_a /\
+    is_private_key_for tr sk_a (LongTermPkEncKey "NSL.PublicKey") alice /\
     // From the network
     bytes_invariant tr msg_cipher
   )
@@ -192,7 +192,7 @@ val compute_message3_proof:
     // From the random generation
     PkNonce? (get_usage nonce) /\
     // From the PKI
-    is_encryption_key (PkKey "NSL.PublicKey" empty) (principal_label bob) tr pk_b
+    is_public_key_for tr pk_b (LongTermPkEncKey "NSL.PublicKey") bob
   )
   (ensures
     is_publishable tr (compute_message3 alice bob pk_b n_b nonce)
@@ -217,7 +217,7 @@ val decode_message3_proof:
     // From the NSL state invariant
     get_label tr n_b == join (principal_label alice) (principal_label bob) /\
     // From the PrivateKeys invariant
-    is_decryption_key (PkKey "NSL.PublicKey" empty) (principal_label bob) tr sk_b /\
+    is_private_key_for tr sk_b (LongTermPkEncKey "NSL.PublicKey") bob /\
     // From the network
     bytes_invariant tr msg_cipher
   )

--- a/src/lib/state/DY.Lib.State.PKI.fst
+++ b/src/lib/state/DY.Lib.State.PKI.fst
@@ -26,7 +26,7 @@ open DY.Lib.State.PrivateKeys
 
 [@@ with_bytes bytes]
 type pki_key = {
-  ty:public_key_type;
+  ty:long_term_key_type;
   who:principal;
 }
 
@@ -71,12 +71,12 @@ val initialize_pki: prin:principal -> traceful state_id
 let initialize_pki = initialize_map pki_key pki_value #_ // another workaround for FStarLang/FStar#3286
 
 [@@ "opaque_to_smt"]
-val install_public_key: principal -> state_id -> public_key_type -> principal -> bytes -> traceful (option unit)
+val install_public_key: principal -> state_id -> long_term_key_type -> principal -> bytes -> traceful (option unit)
 let install_public_key prin sess_id pk_type who pk =
   add_key_value prin sess_id ({ty = pk_type; who;}) ({public_key = pk;})
 
 [@@ "opaque_to_smt"]
-val get_public_key: principal -> state_id -> public_key_type -> principal -> traceful (option bytes)
+val get_public_key: principal -> state_id -> long_term_key_type -> principal -> traceful (option bytes)
 let get_public_key prin sess_id pk_type who =
   let*? res = find_value prin sess_id ({ty = pk_type; who;}) in
   return (Some res.public_key)
@@ -101,7 +101,7 @@ let initialize_pki_invariant #invs prin tr =
 
 val install_public_key_invariant:
   {|protocol_invariants|} ->
-  prin:principal -> sess_id:state_id -> pk_type:public_key_type -> who:principal -> pk:bytes -> tr:trace ->
+  prin:principal -> sess_id:state_id -> pk_type:long_term_key_type -> who:principal -> pk:bytes -> tr:trace ->
   Lemma
   (requires
     is_public_key_for tr pk pk_type who /\
@@ -120,7 +120,7 @@ let install_public_key_invariant #invs prin sess_id pk_type who pk tr =
 
 val get_public_key_invariant:
   {|protocol_invariants|} ->
-  prin:principal -> sess_id:state_id -> pk_type:public_key_type -> who:principal -> tr:trace ->
+  prin:principal -> sess_id:state_id -> pk_type:long_term_key_type -> who:principal -> tr:trace ->
   Lemma
   (requires
     trace_invariant tr /\

--- a/src/lib/state/DY.Lib.State.PrivateKeys.fst
+++ b/src/lib/state/DY.Lib.State.PrivateKeys.fst
@@ -7,6 +7,7 @@ open DY.Lib.Comparse.Parsers
 open DY.Lib.State.Tagged
 open DY.Lib.State.Typed
 open DY.Lib.State.Map
+open DY.Lib.State.PKI
 
 #set-options "--fuel 1 --ifuel 1"
 
@@ -17,16 +18,8 @@ open DY.Lib.State.Map
 (*** Private keys types & invariants ***)
 
 [@@ with_bytes bytes]
-type private_key_type =
-  | PkDec: [@@@with_parser #bytes ps_string] usage:string -> private_key_type
-  | Sign: [@@@with_parser #bytes ps_string] usage:string -> private_key_type
-
-%splice [ps_private_key_type] (gen_parser (`private_key_type))
-%splice [ps_private_key_type_is_well_formed] (gen_is_well_formed_lemma (`private_key_type))
-
-[@@ with_bytes bytes]
 type private_key_key = {
-  ty:private_key_type;
+  ty:public_key_type;
 }
 
 %splice [ps_private_key_key] (gen_parser (`private_key_key))
@@ -48,14 +41,14 @@ instance map_types_private_keys: map_types private_key_key private_key_value = {
 
 val is_private_key_for:
   {|crypto_invariants|} -> trace ->
-  bytes -> private_key_type -> principal -> prop
+  bytes -> public_key_type -> principal -> prop
 let is_private_key_for #cinvs tr sk sk_type who =
   match sk_type with
-  | PkDec usg -> (
-    is_decryption_key (PkKey usg empty) (principal_label who) tr sk
+  | LongTermPkEncKey usg -> (
+    is_decryption_key (public_key_type_to_usage sk_type) (principal_label who) tr sk
   )
-  | Sign usg -> (
-    is_signature_key (SigKey usg empty) (principal_label who) tr sk
+  | LongTermSigKey usg -> (
+    is_signature_key (public_key_type_to_usage sk_type) (principal_label who) tr sk
   )
 
 // The `#_` at the end is a workaround for FStarLang/FStar#3286
@@ -75,14 +68,6 @@ let has_private_keys_invariant #invs =
 val private_keys_tag_and_invariant: {|crypto_invariants|} -> string & local_bytes_state_predicate
 let private_keys_tag_and_invariant #ci = (map_types_private_keys.tag, local_state_predicate_to_local_bytes_state_predicate (map_session_invariant private_keys_pred))
 
-val private_key_type_to_usage:
-  private_key_type ->
-  usage
-let private_key_type_to_usage sk_type =
-  match sk_type with
-  | PkDec usg -> PkKey usg empty
-  | Sign usg -> SigKey usg empty
-
 (*** Private Keys API ***)
 
 [@@ "opaque_to_smt"]
@@ -90,16 +75,26 @@ val initialize_private_keys: prin:principal -> traceful state_id
 let initialize_private_keys = initialize_map private_key_key private_key_value #_ // another workaround for FStarLang/FStar#3286
 
 [@@ "opaque_to_smt"]
-val generate_private_key: principal -> state_id -> private_key_type -> traceful (option unit)
+val generate_private_key: principal -> state_id -> public_key_type -> traceful (option unit)
 let generate_private_key prin sess_id sk_type =
-  let* sk = mk_rand (private_key_type_to_usage sk_type) (principal_label prin) 64 in //TODO
+  let* sk = mk_rand (public_key_type_to_usage sk_type) (principal_label prin) 64 in //TODO
   add_key_value prin sess_id ({ty = sk_type}) ({private_key = sk;})
 
 [@@ "opaque_to_smt"]
-val get_private_key: principal -> state_id -> private_key_type -> traceful (option bytes)
+val get_private_key: principal -> state_id -> public_key_type -> traceful (option bytes)
 let get_private_key prin sess_id sk_type =
   let*? res = find_value prin sess_id ({ty = sk_type}) in
   return (Some res.private_key)
+
+[@@ "opaque_to_smt"]
+val compute_public_key: principal -> state_id -> public_key_type -> traceful (option bytes)
+let compute_public_key prin sess_id sk_type =
+  let*? res = find_value prin sess_id ({ty = sk_type}) in
+  match sk_type with
+  | LongTermPkEncKey _ ->
+    return (Some (pk res.private_key))
+  | LongTermSigKey _ ->
+    return (Some (vk res.private_key))
 
 val initialize_private_keys_invariant:
   {|protocol_invariants|} ->
@@ -121,7 +116,7 @@ let initialize_private_keys_invariant #invs prin tr =
 
 val generate_private_key_invariant:
   {|protocol_invariants|} ->
-  prin:principal -> sess_id:state_id -> sk_type:private_key_type -> tr:trace ->
+  prin:principal -> sess_id:state_id -> sk_type:public_key_type -> tr:trace ->
   Lemma
   (requires
     trace_invariant tr /\
@@ -139,7 +134,7 @@ let generate_private_key_invariant #invs prin sess_id sk_type tr =
 
 val get_private_key_invariant:
   {|protocol_invariants|} ->
-  prin:principal -> sess_id:state_id -> pk_type:private_key_type -> tr:trace ->
+  prin:principal -> sess_id:state_id -> pk_type:public_key_type -> tr:trace ->
   Lemma
   (requires
     trace_invariant tr /\
@@ -159,3 +154,26 @@ val get_private_key_invariant:
    SMTPat (trace_invariant tr)]
 let get_private_key_invariant #invs prin sess_id pk_type tr =
   reveal_opaque (`%get_private_key) (get_private_key)
+
+val compute_public_key_invariant:
+  {|protocol_invariants|} ->
+  prin:principal -> sess_id:state_id -> pk_type:public_key_type -> tr:trace ->
+  Lemma
+  (requires
+    trace_invariant tr /\
+    has_private_keys_invariant
+  )
+  (ensures (
+    let (opt_private_key, tr_out) = compute_public_key prin sess_id pk_type tr in
+    tr_out == tr /\ (
+      match opt_private_key with
+      | None -> True
+      | Some private_key ->
+        is_public_key_for tr private_key pk_type prin
+    )
+  ))
+  [SMTPat (compute_public_key prin sess_id pk_type tr);
+   SMTPat (has_private_keys_invariant);
+   SMTPat (trace_invariant tr)]
+let compute_public_key_invariant #invs prin sess_id pk_type tr =
+  reveal_opaque (`%compute_public_key) (compute_public_key)

--- a/src/lib/utils/DY.Lib.Printing.fst
+++ b/src/lib/utils/DY.Lib.Printing.fst
@@ -116,11 +116,11 @@ let rec usage_to_string u =
 /// in DY.Lib and DY.Core. This causes
 /// conflicts with the bytes_to_string function.
 
-val public_key_type_to_string: DY.Lib.State.PKI.public_key_type -> string
+val public_key_type_to_string: DY.Lib.State.PrivateKeys.public_key_type -> string
 let public_key_type_to_string t =
   match t with
-  | DY.Lib.State.PKI.LongTermPkEncKey u -> "LongTermPkEncKey " ^ u
-  | DY.Lib.State.PKI.LongTermSigKey u -> "LongTermSigKey " ^ u
+  | DY.Lib.State.PrivateKeys.LongTermPkEncKey u -> "LongTermPkEncKey " ^ u
+  | DY.Lib.State.PrivateKeys.LongTermSigKey u -> "LongTermSigKey " ^ u
 
 // The `#_` at the end is a workaround for FStarLang/FStar#3286
 val private_keys_types_to_string: (list (map_elem DY.Lib.State.PrivateKeys.private_key_key DY.Lib.State.PrivateKeys.private_key_value #_)) -> string

--- a/src/lib/utils/DY.Lib.Printing.fst
+++ b/src/lib/utils/DY.Lib.Printing.fst
@@ -116,11 +116,11 @@ let rec usage_to_string u =
 /// in DY.Lib and DY.Core. This causes
 /// conflicts with the bytes_to_string function.
 
-val private_key_type_to_string: DY.Lib.State.PrivateKeys.private_key_type -> string
-let private_key_type_to_string t =
+val public_key_type_to_string: DY.Lib.State.PKI.public_key_type -> string
+let public_key_type_to_string t =
   match t with
-  | DY.Lib.State.PrivateKeys.PkDec u -> "PkDec " ^ u
-  | DY.Lib.State.PrivateKeys.Sign u -> "Sign " ^ u
+  | DY.Lib.State.PKI.LongTermPkEncKey u -> "LongTermPkEncKey " ^ u
+  | DY.Lib.State.PKI.LongTermSigKey u -> "LongTermSigKey " ^ u
 
 // The `#_` at the end is a workaround for FStarLang/FStar#3286
 val private_keys_types_to_string: (list (map_elem DY.Lib.State.PrivateKeys.private_key_key DY.Lib.State.PrivateKeys.private_key_value #_)) -> string
@@ -129,14 +129,8 @@ let rec private_keys_types_to_string m =
   | [] -> ""
   | hd :: tl -> (
     (private_keys_types_to_string tl) ^ 
-    Printf.sprintf "%s = (%s)," (private_key_type_to_string hd.key.ty) (bytes_to_string hd.value.private_key)
+    Printf.sprintf "%s = (%s)," (public_key_type_to_string hd.key.ty) (bytes_to_string hd.value.private_key)
   )
-
-val public_key_type_to_string: DY.Lib.State.PKI.public_key_type -> string
-let public_key_type_to_string t =
-  match t with
-  | DY.Lib.State.PKI.PkEnc u -> "PkEnc " ^ u
-  | DY.Lib.State.PKI.Verify u -> "Verify " ^ u
 
 // The `#_` at the end is a workaround for FStarLang/FStar#3286
 val pki_types_to_string: (list (map_elem DY.Lib.State.PKI.pki_key DY.Lib.State.PKI.pki_value #_)) -> string

--- a/src/lib/utils/DY.Lib.Printing.fst
+++ b/src/lib/utils/DY.Lib.Printing.fst
@@ -116,8 +116,8 @@ let rec usage_to_string u =
 /// in DY.Lib and DY.Core. This causes
 /// conflicts with the bytes_to_string function.
 
-val public_key_type_to_string: DY.Lib.State.PrivateKeys.public_key_type -> string
-let public_key_type_to_string t =
+val long_term_key_type_to_string: DY.Lib.State.PrivateKeys.long_term_key_type -> string
+let long_term_key_type_to_string t =
   match t with
   | DY.Lib.State.PrivateKeys.LongTermPkEncKey u -> "LongTermPkEncKey " ^ u
   | DY.Lib.State.PrivateKeys.LongTermSigKey u -> "LongTermSigKey " ^ u
@@ -129,7 +129,7 @@ let rec private_keys_types_to_string m =
   | [] -> ""
   | hd :: tl -> (
     (private_keys_types_to_string tl) ^ 
-    Printf.sprintf "%s = (%s)," (public_key_type_to_string hd.key.ty) (bytes_to_string hd.value.private_key)
+    Printf.sprintf "%s = (%s)," (long_term_key_type_to_string hd.key.ty) (bytes_to_string hd.value.private_key)
   )
 
 // The `#_` at the end is a workaround for FStarLang/FStar#3286
@@ -139,7 +139,7 @@ let rec pki_types_to_string m =
   | [] -> ""
   | hd :: tl -> (
     (pki_types_to_string tl) ^ 
-    Printf.sprintf "%s [%s] = (%s)," (public_key_type_to_string hd.key.ty) hd.key.who (bytes_to_string hd.value.public_key)
+    Printf.sprintf "%s [%s] = (%s)," (long_term_key_type_to_string hd.key.ty) hd.key.who (bytes_to_string hd.value.public_key)
   )
 
 val default_private_keys_state_to_string: bytes -> option string


### PR DESCRIPTION
Slight cleanup for a follow-up PR (in the spirit of "make the change easy, then make the easy change"), although I believe it is good in itself.

This is merging some parts of `PKI` and `PrivateKeys`:
- `public_key_type` and `private_key_type` are now the same type
- `public_key_type` are now prefixed with `LongTerm` so that the name are clearly different than the constructors of `usage` (it was the case before, but only because of bad conventions e.g. `Sig` vs `Sign`)
- `PrivateKeys` is now computing the key to install in the `PKI` of other principals. This is the change that motivates this PR, because otherwise the debug code has to call `pk` or `vk` by hand, and prove the `is_public_key_for` precondition of PKI using the `is_private_key_for` post-condition of PrivateKeys.
- in the NSL or ISO-DH example, rely more on `is_private_key_for` or `is_public_key_for` when possible to be more resilient to future changes