### PR TITLE
cleanup: stop relying on label injectivity

### DIFF
--- a/examples/iso_dh/DY.Example.DH.Protocol.Total.Proof.fst
+++ b/examples/iso_dh/DY.Example.DH.Protocol.Total.Proof.fst
@@ -37,8 +37,7 @@ let dh_crypto_preds = {
 
   sign_pred = {
     pred = (fun tr vk sig_msg ->
-      get_signkey_usage vk == SigKey "DH.SigningKey" empty /\
-      (exists prin. get_signkey_label tr vk == principal_label prin /\ (
+      (exists prin. get_signkey_usage vk == long_term_key_type_to_usage (LongTermSigKey "DH.SigningKey") prin /\ (
         match parse sig_message sig_msg with
         | Some (SigMsg2 sig_msg2) -> (
           exists y. sig_msg2.gy == (dh_pk y) /\ event_triggered tr prin (Respond1 sig_msg2.alice prin sig_msg2.gx sig_msg2.gy y)

--- a/examples/nsl_pk/DY.Example.NSL.Protocol.Total.Proof.fst
+++ b/examples/nsl_pk/DY.Example.NSL.Protocol.Total.Proof.fst
@@ -23,8 +23,7 @@ let crypto_predicates_nsl = {
 
   pkenc_pred = {
     pred = (fun tr pk msg ->
-      get_sk_usage pk == PkKey "NSL.PublicKey" empty /\
-      (exists prin. get_sk_label tr pk == principal_label prin /\ (
+      (exists prin. get_sk_usage pk == long_term_key_type_to_usage (LongTermPkEncKey "NSL.PublicKey") prin /\ (
         match parse message msg with
         | Some (Msg1 msg1) -> (
           let (alice, bob) = (msg1.alice, prin) in

--- a/src/lib/comparse/DY.Lib.Comparse.Glue.fst
+++ b/src/lib/comparse/DY.Lib.Comparse.Glue.fst
@@ -118,6 +118,6 @@ val parse_serialize_inv_lemma_smtpat:
   x:a ->
   Lemma
   (ensures parse a (serialize #bytes a x) == Some x)
-  [SMTPat (parse #bytes #bl a #ps_a (serialize #bytes a #ps_a x))]
+  [SMTPat ((serialize #bytes a #ps_a x))]
 let parse_serialize_inv_lemma_smtpat #bytes #bl a #ps_a x =
   parse_serialize_inv_lemma #bytes a #ps_a x

--- a/src/lib/state/DY.Lib.State.PKI.fst
+++ b/src/lib/state/DY.Lib.State.PKI.fst
@@ -50,7 +50,7 @@ instance map_types_pki: map_types pki_key pki_value = {
 // The `#_` at the end is a workaround for FStarLang/FStar#3286
 val pki_pred: {|crypto_invariants|} -> map_predicate pki_key pki_value #_
 let pki_pred #cinvs = {
-  pred = (fun tr prin sess_id key value ->
+  pred = (fun tr prin sess_id (key: pki_key) value ->
     is_public_key_for tr value.public_key key.ty key.who
   );
   pred_later = (fun tr1 tr2 prin sess_id key value -> ());


### PR DESCRIPTION
Builds on #65.

In many proofs, we rely on the injectivity of `principal_label`, via the pattern
```fstar
pred = (fun tr pk msg ->
  exists prin. get_sk_label pk == principal_label prin /\
  ... // something that involves `prin`
);
```
Because of the injectivity of `principal_label` if we know that `get_sk_label pk == principal_label "Alice"`, then we can use the predicate above with `prin == "Alice"`. This is done in both NSL and ISO-DH.

I now believe that this is more a hack than an actual feature: the labels are used to prove that two keys are distinct (the private key of Alice and the private key of Bob), whereas the goal of labels is initially to prove secrecy.
Proving that two keys are distinct is the role of usages: we already use them to prove that two keys in distinct protocols are distinct (via the "usage tag", e.g. `"NSL.PublicKey"`), we can also use them to prove that Alice's key is distinct from Bob's key.
This PR uses the "usage data" to store the principal owning the key.