### PR TITLE
cleanup: make more predicates agnostic on label type

### DIFF
--- a/src/core/DY.Core.Label.fst
+++ b/src/core/DY.Core.Label.fst
@@ -110,7 +110,7 @@ val is_corrupt_later:
   [SMTPat (is_corrupt tr1 l); SMTPat (tr1 <$ tr2)]
 let is_corrupt_later tr1 tr2 l =
   reveal_opaque (`%is_corrupt) (is_corrupt);
-  trace_forget_labels_later tr1 tr2;
+  fmap_trace_later (forget_label ()) tr1 tr2;
   label_is_corrupt_later l (trace_forget_labels tr1) (trace_forget_labels tr2)
 
 /// A label `l1` can flow to a label `l2` when `l2` will always be more secret than `l1` in the future,
@@ -136,7 +136,7 @@ let intro_label_equal l1 l2 pf =
     pf (fmap_trace (forget_label unknown_label) tr);
     // These two lines prove surjectivity of `trace_forget_labels`
     // by showing that fmap_trace (forget_label public) is a right-inverse
-    // (we could replace `public` with anything)
+    // (we could replace `unknown_label` with anything)
     fmap_trace_compose (forget_label unknown_label) (forget_label ()) (forget_label ()) tr;
     fmap_trace_identity (forget_label ()) tr;
     FStar.PropositionalExtensionality.apply (l1.is_corrupt tr) (l2.is_corrupt tr)

--- a/src/core/DY.Core.Trace.Base.fst
+++ b/src/core/DY.Core.Trace.Base.fst
@@ -360,6 +360,10 @@ val find_event_triggered_at_timestamp_later:
     tr1 <$ tr2
   )
   (ensures find_event_triggered_at_timestamp tr1 prin tag content == find_event_triggered_at_timestamp tr2 prin tag content)
+  [SMTPat (find_event_triggered_at_timestamp tr1 prin tag content);
+   SMTPat (find_event_triggered_at_timestamp tr2 prin tag content);
+   SMTPat (tr1 <$ tr2)
+  ]
 let rec find_event_triggered_at_timestamp_later #label_t tr1 tr2 prin tag content =
   if length tr1 = length tr2 then ()
   else (

--- a/src/core/DY.Core.Trace.Base.fst
+++ b/src/core/DY.Core.Trace.Base.fst
@@ -522,6 +522,31 @@ let rec get_event_at_fmap_trace #a #b f tr i =
     get_event_at_fmap_trace f tr_init i
   )
 
+val event_at_fmap_trace:
+  #a:Type -> #b:Type ->
+  f:(a -> b) -> tr:trace_ a -> i:timestamp -> ev:trace_event_ a ->
+  Lemma
+  (requires event_at tr i ev)
+  (ensures event_at (fmap_trace f tr) i (fmap_trace_event f ev))
+let event_at_fmap_trace #a #b f tr i ev =
+  if i >= length tr then ()
+  else (
+    get_event_at_fmap_trace f tr i
+  )
+
+val event_exists_fmap_trace:
+  #a:Type -> #b:Type ->
+  f:(a -> b) -> tr:trace_ a -> ev:trace_event_ a ->
+  Lemma
+  (requires event_exists tr ev)
+  (ensures event_exists (fmap_trace f tr) (fmap_trace_event f ev))
+let event_exists_fmap_trace #a #b f tr ev =
+  eliminate exists i. event_at tr i ev
+  returns event_exists (fmap_trace f tr) (fmap_trace_event f ev)
+  with _. (
+    event_at_fmap_trace f tr i ev
+  )
+
 val forget_label:
   #a:Type -> #b:Type ->
   b ->

--- a/src/core/DY.Core.Trace.Base.fst
+++ b/src/core/DY.Core.Trace.Base.fst
@@ -538,6 +538,18 @@ let event_at_fmap_trace #a #b f tr i ev =
     get_event_at_fmap_trace f tr i
   )
 
+val event_at_fmap_trace_eq:
+  #a:Type -> #b:Type ->
+  f:(a -> b) -> tr:trace_ a -> i:timestamp -> ev:trace_event_ a ->
+  Lemma
+  (requires ~(RandGen? ev))
+  (ensures event_at tr i ev <==> event_at (fmap_trace f tr) i (fmap_trace_event f ev))
+let event_at_fmap_trace_eq #a #b f tr i ev =
+  if i >= length tr then ()
+  else (
+    get_event_at_fmap_trace f tr i
+  )
+
 val event_exists_fmap_trace:
   #a:Type -> #b:Type ->
   f:(a -> b) -> tr:trace_ a -> ev:trace_event_ a ->
@@ -549,6 +561,17 @@ let event_exists_fmap_trace #a #b f tr ev =
   returns event_exists (fmap_trace f tr) (fmap_trace_event f ev)
   with _. (
     event_at_fmap_trace f tr i ev
+  )
+
+val event_exists_fmap_trace_eq:
+  #a:Type -> #b:Type ->
+  f:(a -> b) -> tr:trace_ a -> ev:trace_event_ a ->
+  Lemma
+  (requires ~(RandGen? ev))
+  (ensures event_exists tr ev <==> event_exists (fmap_trace f tr) (fmap_trace_event f ev))
+let event_exists_fmap_trace_eq #a #b f tr ev =
+  introduce forall i. event_at tr i ev <==> event_at (fmap_trace f tr) i (fmap_trace_event f ev) with (
+    event_at_fmap_trace_eq f tr i ev
   )
 
 val replace_label:
@@ -567,3 +590,4 @@ val trace_forget_labels:
   trace_ unit
 let trace_forget_labels tr =
   fmap_trace forget_label tr
+

--- a/src/lib/event/DY.Lib.Event.Typed.fst
+++ b/src/lib/event/DY.Lib.Event.Typed.fst
@@ -235,6 +235,10 @@ val find_event_triggered_at_timestamp_later:
     tr1 <$ tr2
   )
   (ensures find_event_triggered_at_timestamp tr1 prin content == find_event_triggered_at_timestamp tr2 prin content)
+  [SMTPat (find_event_triggered_at_timestamp tr1 prin content);
+   SMTPat (find_event_triggered_at_timestamp tr2 prin content);
+   SMTPat (tr1 <$ tr2)
+  ]
 let find_event_triggered_at_timestamp_later #a #ev_a tr1 tr2 prin content =
   reveal_opaque (`%find_event_triggered_at_timestamp) (find_event_triggered_at_timestamp #a);
   DY.Core.find_event_triggered_at_timestamp_later tr1 tr2 prin ev_a.tag (serialize a content)

--- a/src/lib/event/DY.Lib.Event.Typed.fst
+++ b/src/lib/event/DY.Lib.Event.Typed.fst
@@ -207,3 +207,32 @@ val event_triggered_at_implies_trace_event_at:
 let event_triggered_at_implies_trace_event_at #a #ev tr i prin e =
   reveal_opaque (`%event_triggered_at) (event_triggered_at #a);
   ()
+
+[@@ "opaque_to_smt"]
+val find_event_triggered_at_timestamp:
+  #a:Type -> {|event a|} ->
+  tr:trace ->
+  prin:principal -> content:a ->
+  Pure timestamp
+  (requires event_triggered tr prin content)
+  (ensures fun i ->
+    event_triggered_at tr i prin content /\
+    ~(event_triggered (prefix tr i) prin content)
+  )
+let find_event_triggered_at_timestamp #a #ev_a tr prin content =
+  reveal_opaque (`%event_triggered_at) (event_triggered_at #a);
+  DY.Core.find_event_triggered_at_timestamp tr prin ev_a.tag (serialize a content)
+
+val find_event_triggered_at_timestamp_later:
+  #a:Type -> {|event a|} ->
+  tr1:trace -> tr2:trace ->
+  prin:principal -> content:a ->
+  Lemma
+  (requires
+    event_triggered tr1 prin content /\
+    tr1 <$ tr2
+  )
+  (ensures find_event_triggered_at_timestamp tr1 prin content == find_event_triggered_at_timestamp tr2 prin content)
+let find_event_triggered_at_timestamp_later #a #ev_a tr1 tr2 prin content =
+  reveal_opaque (`%find_event_triggered_at_timestamp) (find_event_triggered_at_timestamp #a);
+  DY.Core.find_event_triggered_at_timestamp_later tr1 tr2 prin ev_a.tag (serialize a content)


### PR DESCRIPTION
This is useful when defining new labels, to prove the `is_corrupt_later` lemma.

While I was at it, I added some useful lemmas about `fmap_trace`, and a function that find a protocol event in the trace (handy when debugging a proof and transform a `event_triggered` into a `event_triggered_at` without having to `eliminate exists. …`).