### PR TITLE
cleanup: rework label SMT patterns

### DIFF
--- a/examples/nsl_pk/DY.Example.NSL.Protocol.Total.Proof.fst
+++ b/examples/nsl_pk/DY.Example.NSL.Protocol.Total.Proof.fst
@@ -77,8 +77,6 @@ val compute_message1_proof:
   (ensures is_publishable tr (compute_message1 alice bob pk_b n_a nonce))
 let compute_message1_proof tr alice bob pk_b n_a nonce =
   let msg = Msg1 {n_a; alice;} in
-  assert(nsl_nonce_label alice bob `can_flow tr` (principal_label alice));
-  assert(nsl_nonce_label alice bob `can_flow tr` (principal_label bob));
   serialize_wf_lemma message (is_knowable_by (long_term_key_label alice) tr) msg;
   serialize_wf_lemma message (is_knowable_by (long_term_key_label bob) tr) msg
 

--- a/examples/nsl_pk/DY.Example.NSL.SecurityProperties.fst
+++ b/examples/nsl_pk/DY.Example.NSL.SecurityProperties.fst
@@ -34,8 +34,7 @@ val initiator_authentication:
     is_corrupt (prefix tr i) (principal_label bob) \/
     event_triggered (prefix tr i) alice (Initiate2 alice bob n_a n_b)
   )
-let initiator_authentication tr i alice bob n_a n_b =
-  flow_to_public_eq (prefix tr i) (nsl_nonce_label alice bob)
+let initiator_authentication tr i alice bob n_a n_b = ()
 
 /// If Alice thinks she talks with Bob,
 /// then Bob thinks he talk to Alice (with the same nonces),
@@ -54,8 +53,7 @@ val responder_authentication:
     is_corrupt (prefix tr i) (principal_label bob) \/
     event_triggered (prefix tr i) bob (Respond1 alice bob n_a n_b)
   )
-let responder_authentication tr i alice bob n_a n_b =
-  flow_to_public_eq (prefix tr i) (nsl_nonce_label alice bob)
+let responder_authentication tr i alice bob n_a n_b = ()
 
 /// The nonce n_a is unknown to the attacker,
 /// unless the attacker corrupted Alice or Bob.
@@ -73,7 +71,6 @@ val n_a_secrecy:
   )
   (ensures is_corrupt tr (principal_label alice) \/ is_corrupt tr (principal_label bob))
 let n_a_secrecy tr alice bob n_a =
-  flow_to_public_eq tr (nsl_nonce_label alice bob);
   attacker_only_knows_publishable_values tr n_a
 
 /// The nonce n_b is unknown to the attacker,
@@ -92,5 +89,4 @@ val n_b_secrecy:
   )
   (ensures is_corrupt tr (principal_label alice) \/ is_corrupt tr (principal_label bob))
 let n_b_secrecy tr alice bob n_b =
-  flow_to_public_eq tr (nsl_nonce_label alice bob);
   attacker_only_knows_publishable_values tr n_b

--- a/src/core/DY.Core.Bytes.fst
+++ b/src/core/DY.Core.Bytes.fst
@@ -2422,8 +2422,7 @@ let get_label_dh tr sk pk =
   reveal_opaque (`%dh) (dh);
   normalize_term_spec get_dh_label;
   normalize_term_spec get_label;
-  join_commutes (get_label tr sk) (get_dh_label tr pk);
-  join_public (get_label tr sk)
+  join_commutes (get_label tr sk) (get_dh_label tr pk)
 
 /// User lemma (dh bytes usage with known peer)
 

--- a/src/core/DY.Core.Label.fst
+++ b/src/core/DY.Core.Label.fst
@@ -248,7 +248,7 @@ val meet_eq:
   tr:trace -> x:label -> y1:label -> y2:label ->
   Lemma
   (ensures meet y1 y2 `can_flow tr` x <==> (y1 `can_flow tr` x /\ y2 `can_flow tr` x))
-  [SMTPat (meet y1 y2 `can_flow tr` x)] //Not sure about this
+  [SMTPat (meet y1 y2 `can_flow tr` x)]
 let meet_eq tr x y1 y2 =
   reveal_opaque (`%is_corrupt) (is_corrupt);
   reveal_opaque (`%can_flow) (can_flow);
@@ -260,7 +260,7 @@ val join_eq:
   tr:trace -> x1:label -> x2:label -> y:label ->
   Lemma
   (ensures y `can_flow tr` join x1 x2 <==> (y `can_flow tr` x1 /\ y `can_flow tr` x2))
-  [SMTPat (y `can_flow tr` join x1 x2)] //Not sure about this
+  [SMTPat (y `can_flow tr` join x1 x2)]
 let join_eq tr x1 x2 y =
   reveal_opaque (`%is_corrupt) (is_corrupt);
   reveal_opaque (`%can_flow) (can_flow);
@@ -272,7 +272,7 @@ val flow_to_public_eq:
   tr:trace -> l:label ->
   Lemma
   (ensures l `can_flow tr` public <==> is_corrupt tr l)
-  [SMTPat (l `can_flow tr` public)] //Not sure about this
+  [SMTPat (is_corrupt tr l)]
 let flow_to_public_eq tr prin =
   reveal_opaque (`%is_corrupt) (is_corrupt);
   reveal_opaque (`%can_flow) (can_flow);
@@ -286,8 +286,10 @@ val join_flow_to_public_eq:
   tr:trace -> x1:label -> x2:label ->
   Lemma
   (ensures (join x1 x2) `can_flow tr` public <==> x1 `can_flow tr` public \/ x2 `can_flow tr` public)
-  [SMTPat ((join x1 x2) `can_flow tr` public)] //Not sure about this
+  [SMTPat ((join x1 x2) `can_flow tr` public)]
 let join_flow_to_public_eq tr x1 x2 =
+  flow_to_public_eq tr x1;
+  flow_to_public_eq tr x2;
   reveal_opaque (`%is_corrupt) is_corrupt;
   reveal_opaque (`%can_flow) (can_flow);
   reveal_opaque (`%join) (join);
@@ -347,6 +349,7 @@ val state_pred_label_can_flow_public:
     )
   )
 let state_pred_label_can_flow_public tr p =
+  flow_to_public_eq tr (state_pred_label p);
   reveal_opaque (`%is_corrupt) is_corrupt;
   reveal_opaque (`%state_pred_label) (state_pred_label);
   FStar.Classical.forall_intro (FStar.Classical.move_requires (event_exists_fmap_trace_eq forget_label tr));


### PR DESCRIPTION
Fixes #77 .

Now `flow_to_public_eq` triggers when in the context appears `is_corrupt tr l`, instead of ``l `can_flow tr` public``. It works better in the examples, but in DY.Core.Label, when proving things about what happens when labels flows to public, we need to call this lemma by hand for some reason I have not figured out. If that's a problem, we can later change it to an `SMTPatOr`, I guess. I prefer the SMT patterns working well in the examples but less well in the DY* internals.