### PR TITLE
Splitting `_invariant` Lemmas

### DIFF
--- a/src/core/DY.Core.Trace.Base.fst
+++ b/src/core/DY.Core.Trace.Base.fst
@@ -254,6 +254,20 @@ val event_at_grows:
   [SMTPat (event_at tr1 i e); SMTPat (tr1 <$ tr2)]
 let event_at_grows #label_t tr1 tr2 i e = ()
 
+val last_entry_exists:
+  #label_t:Type ->
+  tr:trace_ label_t ->
+  Lemma
+    (requires Snoc? tr )
+    (ensures (
+       let Snoc _ last = tr in
+       event_exists tr last
+    ))
+    [SMTPat (Snoc? tr)]
+let last_entry_exists tr = 
+  let Snoc _ last = tr in
+  assert(event_at tr (DY.Core.Trace.Base.length tr - 1) last)
+
 /// Shorthand predicates.
 
 /// Has a message been sent on the network?

--- a/src/core/DY.Core.Trace.Manipulation.fst
+++ b/src/core/DY.Core.Trace.Manipulation.fst
@@ -541,7 +541,7 @@ val get_state_same_trace:
   (ensures (
     let (opt_content, tr_out) = get_state prin sess_id tr in
     tr == tr_out
-    ))
+  ))
   [SMTPat (get_state prin sess_id tr);]
 let get_state_same_trace prin sess_id tr =
   reveal_opaque (`%get_state) get_state

--- a/src/core/DY.Core.Trace.Manipulation.fst
+++ b/src/core/DY.Core.Trace.Manipulation.fst
@@ -211,7 +211,8 @@ val recv_msg_same_trace:
   Lemma
   (ensures (
     let (opt_msg, tr_out) = recv_msg i tr in
-    tr_out == tr))
+    tr_out == tr
+  ))
   [SMTPat (recv_msg i tr);]
 let recv_msg_same_trace i tr =
   reveal_opaque (`%recv_msg) recv_msg

--- a/src/core/DY.Core.Trace.Manipulation.fst
+++ b/src/core/DY.Core.Trace.Manipulation.fst
@@ -585,27 +585,6 @@ let get_state_state_was_set prin sess_id tr =
   reveal_opaque (`%get_state) get_state;
   get_state_aux_state_was_set prin sess_id tr
 
-/// When the trace invariant holds,
-/// retrieved states satisfy the state predicate.
-
-val get_state_state_invariant:
-  {|protocol_invariants|} ->
-  prin:principal -> sess_id:state_id -> tr:trace ->
-  Lemma
-  (requires
-    trace_invariant tr
-  )
-  (ensures (
-    let (opt_content, tr_out) = get_state prin sess_id tr in
-      match opt_content with
-      | None -> True
-      | Some content -> state_pred.pred tr prin sess_id content
-  ))
-  [SMTPat (get_state prin sess_id tr); SMTPat (trace_invariant tr)]
-let get_state_state_invariant #invs prin sess_id tr =
-  normalize_term_spec get_state;
-  get_state_aux_state_invariant prin sess_id tr
-
 (*** Event triggering ***)
 
 /// Trigger a protocol event.

--- a/src/core/DY.Core.Trace.Manipulation.fst
+++ b/src/core/DY.Core.Trace.Manipulation.fst
@@ -538,12 +538,10 @@ val get_state_state_was_set:
   Lemma
   (ensures (
     let (opt_content, tr_out) = get_state prin sess_id tr in
-    tr == tr_out /\ (
-      match opt_content with
-      | None -> True
-      | Some content -> 
-          state_was_set tr prin sess_id content
-    )
+    match opt_content with
+    | None -> True
+    | Some content ->
+        state_was_set tr prin sess_id content
   ))
   [SMTPat (get_state prin sess_id tr)]
 let get_state_state_was_set prin sess_id tr =

--- a/src/core/DY.Core.Trace.Manipulation.fst
+++ b/src/core/DY.Core.Trace.Manipulation.fst
@@ -501,41 +501,6 @@ let set_state_invariant #invs prin sess_id content tr =
   add_event_invariant (SetState prin sess_id content) tr;
   normalize_term_spec set_state
 
-val get_state_aux_state_invariant:
-  {|protocol_invariants|} ->
-  prin:principal -> sess_id:state_id -> tr:trace ->
-  Lemma
-  (requires
-    trace_invariant tr
-  )
-  (ensures (
-    match get_state_aux prin sess_id tr with
-    | None -> True
-    | Some content -> state_pred.pred tr prin sess_id content
-  ))
-let rec get_state_aux_state_invariant #invs prin sess_id tr =
-  reveal_opaque (`%grows) (grows #label);
-  norm_spec [zeta; delta_only [`%trace_invariant]] (trace_invariant);
-  norm_spec [zeta; delta_only [`%prefix]] (prefix #label);
-  match tr with
-  | Nil -> ()
-  | Snoc tr_init (SetState prin' sess_id' content) -> (
-    if prin = prin' && sess_id = sess_id' then (
-      state_pred.pred_later tr_init tr prin sess_id content
-    ) else (
-      get_state_aux_state_invariant prin sess_id tr_init;
-      match get_state_aux prin sess_id tr_init with
-      | None -> ()
-      | Some content -> state_pred.pred_later tr_init tr prin sess_id content
-    )
-  )
-  | Snoc tr_init _ ->
-    get_state_aux_state_invariant prin sess_id tr_init;
-    match get_state_aux prin sess_id tr_init with
-    | None -> ()
-    | Some content -> state_pred.pred_later tr_init tr prin sess_id content
-
-
 val get_state_same_trace:
   prin:principal -> sess_id:state_id -> tr:trace ->
   Lemma
@@ -555,7 +520,7 @@ val get_state_aux_state_was_set:
     match get_state_aux prin sess_id tr with
     | None -> True
     | Some content -> 
-          state_was_set tr prin sess_id content
+        state_was_set tr prin sess_id content
   ))
 let rec get_state_aux_state_was_set prin sess_id tr =
    match tr with
@@ -577,7 +542,7 @@ val get_state_state_was_set:
       match opt_content with
       | None -> True
       | Some content -> 
-             state_was_set tr prin sess_id content
+          state_was_set tr prin sess_id content
     )
   ))
   [SMTPat (get_state prin sess_id tr)]

--- a/src/lib/event/DY.Lib.Event.Typed.fst
+++ b/src/lib/event/DY.Lib.Event.Typed.fst
@@ -183,8 +183,7 @@ val event_triggered_at_on_trace:
     event_triggered_at tr i prin e
   )
   (ensures i < DY.Core.Trace.Base.length tr)
-  [SMTPat (event_triggered_at #a #ev tr i prin e);
-  ]
+  [SMTPat (event_triggered_at #a #ev tr i prin e)]
 let event_triggered_at_on_trace #a #ev  tr i prin e =
   reveal_opaque (`%event_triggered_at) (event_triggered_at #a)
 

--- a/src/lib/event/DY.Lib.Event.Typed.fst
+++ b/src/lib/event/DY.Lib.Event.Typed.fst
@@ -226,10 +226,10 @@ val event_triggered_at_implies_trace_event_at:
   tr:trace -> i:timestamp -> prin:principal -> e:a  ->
   Lemma
   (requires event_triggered_at tr i prin e)
-  (ensures (
+  (ensures
     get_event_at tr i == Event prin ev.tag (serialize a e) /\
     parse #bytes a (serialize a e) == Some e
-  ))
+  )
   [SMTPat (event_triggered_at tr i prin e)]
 let event_triggered_at_implies_trace_event_at #a #ev tr i prin e =
   reveal_opaque (`%event_triggered_at) (event_triggered_at #a);

--- a/src/lib/state/DY.Lib.State.Map.fst
+++ b/src/lib/state/DY.Lib.State.Map.fst
@@ -237,6 +237,21 @@ let add_key_value_invariant #invs #key_t #value_t #mt mpred prin sess_id key val
   reveal_opaque (`%add_key_value) (add_key_value #key_t #value_t)
 #pop-options
 
+val find_value_same_trace:
+  #key_t:eqtype -> #value_t:Type0 -> {|map_types key_t value_t|} ->
+  prin:principal -> sess_id:state_id ->
+  key:key_t ->
+  tr:trace ->
+  Lemma
+  (ensures (
+    let (opt_value, tr_out) = find_value #_ #value_t prin sess_id key tr in
+    tr_out == tr
+    ))
+  [SMTPat (find_value #key_t #value_t prin sess_id key tr);
+  ]
+let find_value_same_trace #key_t #value_t #mt prin sess_id key tr =
+  reveal_opaque (`%find_value) (find_value #key_t #value_t)
+
 val find_value_invariant:
   {|protocol_invariants|} ->
   #key_t:eqtype -> #value_t:Type0 -> {|map_types key_t value_t|} ->
@@ -251,13 +266,11 @@ val find_value_invariant:
   )
   (ensures (
     let (opt_value, tr_out) = find_value prin sess_id key tr in
-    tr_out == tr /\ (
       match opt_value with
       | None -> True
       | Some value -> (
         mpred.pred tr prin sess_id key value
       )
-    )
   ))
   [SMTPat (find_value #key_t #value_t prin sess_id key tr);
    SMTPat (has_map_session_invariant mpred);

--- a/src/lib/state/DY.Lib.State.Map.fst
+++ b/src/lib/state/DY.Lib.State.Map.fst
@@ -247,8 +247,7 @@ val find_value_same_trace:
     let (opt_value, tr_out) = find_value #_ #value_t prin sess_id key tr in
     tr_out == tr
     ))
-  [SMTPat (find_value #key_t #value_t prin sess_id key tr);
-  ]
+  [SMTPat (find_value #key_t #value_t prin sess_id key tr)]
 let find_value_same_trace #key_t #value_t #mt prin sess_id key tr =
   reveal_opaque (`%find_value) (find_value #key_t #value_t)
 

--- a/src/lib/state/DY.Lib.State.Map.fst
+++ b/src/lib/state/DY.Lib.State.Map.fst
@@ -246,7 +246,7 @@ val find_value_same_trace:
   (ensures (
     let (opt_value, tr_out) = find_value #_ #value_t prin sess_id key tr in
     tr_out == tr
-    ))
+  ))
   [SMTPat (find_value #key_t #value_t prin sess_id key tr)]
 let find_value_same_trace #key_t #value_t #mt prin sess_id key tr =
   reveal_opaque (`%find_value) (find_value #key_t #value_t)

--- a/src/lib/state/DY.Lib.State.PKI.fst
+++ b/src/lib/state/DY.Lib.State.PKI.fst
@@ -124,7 +124,7 @@ val get_public_key_same_trace:
   (ensures (
     let (opt_public_key, tr_out) = get_public_key prin sess_id pk_type who tr in
     tr_out == tr
-    ))
+  ))
   [SMTPat (get_public_key prin sess_id pk_type who tr);]
 let get_public_key_same_trace prin sess_id pk_type who tr =
   reveal_opaque (`%get_public_key) (get_public_key)

--- a/src/lib/state/DY.Lib.State.PKI.fst
+++ b/src/lib/state/DY.Lib.State.PKI.fst
@@ -117,6 +117,18 @@ val install_public_key_invariant:
 let install_public_key_invariant #invs prin sess_id pk_type who pk tr =
   reveal_opaque (`%install_public_key) (install_public_key)
 
+
+val get_public_key_same_trace:
+  prin:principal -> sess_id:state_id -> pk_type:long_term_key_type -> who:principal -> tr:trace ->
+  Lemma
+  (ensures (
+    let (opt_public_key, tr_out) = get_public_key prin sess_id pk_type who tr in
+    tr_out == tr
+    ))
+  [SMTPat (get_public_key prin sess_id pk_type who tr);]
+let get_public_key_same_trace prin sess_id pk_type who tr =
+  reveal_opaque (`%get_public_key) (get_public_key)
+
 val get_public_key_invariant:
   {|protocol_invariants|} ->
   prin:principal -> sess_id:state_id -> pk_type:long_term_key_type -> who:principal -> tr:trace ->
@@ -127,12 +139,10 @@ val get_public_key_invariant:
   )
   (ensures (
     let (opt_public_key, tr_out) = get_public_key prin sess_id pk_type who tr in
-    tr_out == tr /\ (
       match opt_public_key with
       | None -> True
       | Some public_key ->
         is_public_key_for tr public_key pk_type who
-    )
   ))
   [SMTPat (get_public_key prin sess_id pk_type who tr);
    SMTPat (has_pki_invariant);

--- a/src/lib/state/DY.Lib.State.PKI.fst
+++ b/src/lib/state/DY.Lib.State.PKI.fst
@@ -139,9 +139,9 @@ val get_public_key_invariant:
   )
   (ensures (
     let (opt_public_key, tr_out) = get_public_key prin sess_id pk_type who tr in
-      match opt_public_key with
-      | None -> True
-      | Some public_key ->
+    match opt_public_key with
+    | None -> True
+    | Some public_key ->
         is_public_key_for tr public_key pk_type who
   ))
   [SMTPat (get_public_key prin sess_id pk_type who tr);

--- a/src/lib/state/DY.Lib.State.PrivateKeys.fst
+++ b/src/lib/state/DY.Lib.State.PrivateKeys.fst
@@ -213,7 +213,7 @@ val compute_public_key_same_trace:
   (ensures (
     let (opt_private_key, tr_out) = compute_public_key prin sess_id pk_type tr in
     tr_out == tr
-    ))
+  ))
   [SMTPat (compute_public_key prin sess_id pk_type tr);]
 let compute_public_key_same_trace prin sess_id pk_type tr =
   reveal_opaque (`%compute_public_key) (compute_public_key)

--- a/src/lib/state/DY.Lib.State.PrivateKeys.fst
+++ b/src/lib/state/DY.Lib.State.PrivateKeys.fst
@@ -173,6 +173,18 @@ val generate_private_key_invariant:
 let generate_private_key_invariant #invs prin sess_id sk_type tr =
   reveal_opaque (`%generate_private_key) (generate_private_key)
 
+val get_private_key_same_trace:
+  prin:principal -> sess_id:state_id -> pk_type:long_term_key_type -> tr:trace ->
+  Lemma
+  (ensures (
+    let (opt_private_key, tr_out) = get_private_key prin sess_id pk_type tr in
+    tr_out == tr
+  ))
+  [SMTPat (get_private_key prin sess_id pk_type tr);]
+let get_private_key_same_trace prin sess_id pk_type tr =
+  reveal_opaque (`%get_private_key) (get_private_key)
+
+
 val get_private_key_invariant:
   {|protocol_invariants|} ->
   prin:principal -> sess_id:state_id -> pk_type:long_term_key_type -> tr:trace ->
@@ -183,18 +195,29 @@ val get_private_key_invariant:
   )
   (ensures (
     let (opt_private_key, tr_out) = get_private_key prin sess_id pk_type tr in
-    tr_out == tr /\ (
       match opt_private_key with
       | None -> True
       | Some private_key ->
         is_private_key_for tr private_key pk_type prin
-    )
   ))
   [SMTPat (get_private_key prin sess_id pk_type tr);
    SMTPat (has_private_keys_invariant);
    SMTPat (trace_invariant tr)]
 let get_private_key_invariant #invs prin sess_id pk_type tr =
   reveal_opaque (`%get_private_key) (get_private_key)
+
+
+val compute_public_key_same_trace:
+  prin:principal -> sess_id:state_id -> pk_type:long_term_key_type -> tr:trace ->
+  Lemma
+  (ensures (
+    let (opt_private_key, tr_out) = compute_public_key prin sess_id pk_type tr in
+    tr_out == tr
+    ))
+  [SMTPat (compute_public_key prin sess_id pk_type tr);]
+let compute_public_key_same_trace prin sess_id pk_type tr =
+  reveal_opaque (`%compute_public_key) (compute_public_key)
+
 
 val compute_public_key_invariant:
   {|protocol_invariants|} ->
@@ -206,12 +229,10 @@ val compute_public_key_invariant:
   )
   (ensures (
     let (opt_private_key, tr_out) = compute_public_key prin sess_id pk_type tr in
-    tr_out == tr /\ (
       match opt_private_key with
       | None -> True
       | Some private_key ->
         is_public_key_for tr private_key pk_type prin
-    )
   ))
   [SMTPat (compute_public_key prin sess_id pk_type tr);
    SMTPat (has_private_keys_invariant);

--- a/src/lib/state/DY.Lib.State.PrivateKeys.fst
+++ b/src/lib/state/DY.Lib.State.PrivateKeys.fst
@@ -195,9 +195,9 @@ val get_private_key_invariant:
   )
   (ensures (
     let (opt_private_key, tr_out) = get_private_key prin sess_id pk_type tr in
-      match opt_private_key with
-      | None -> True
-      | Some private_key ->
+    match opt_private_key with
+    | None -> True
+    | Some private_key ->
         is_private_key_for tr private_key pk_type prin
   ))
   [SMTPat (get_private_key prin sess_id pk_type tr);
@@ -229,9 +229,9 @@ val compute_public_key_invariant:
   )
   (ensures (
     let (opt_private_key, tr_out) = compute_public_key prin sess_id pk_type tr in
-      match opt_private_key with
-      | None -> True
-      | Some private_key ->
+    match opt_private_key with
+    | None -> True
+    | Some private_key ->
         is_public_key_for tr private_key pk_type prin
   ))
   [SMTPat (compute_public_key prin sess_id pk_type tr);

--- a/src/lib/state/DY.Lib.State.Tagged.fst
+++ b/src/lib/state/DY.Lib.State.Tagged.fst
@@ -319,13 +319,10 @@ val get_tagged_state_state_was_set:
   Lemma
   (ensures (
     let (opt_content, tr_out) = get_tagged_state tag prin sess_id tr in
-    tr == tr_out /\ (
-      match opt_content with
-      | None -> True
-      | Some content -> (
-         tagged_state_was_set tr tag prin sess_id content
-      )
-    )
+    match opt_content with
+    | None -> True
+    | Some content ->
+           tagged_state_was_set tr tag prin sess_id content
   ))
   [SMTPat (get_tagged_state tag prin sess_id tr)]
 let get_tagged_state_state_was_set tag prin sess_id tr =

--- a/src/lib/state/DY.Lib.State.Tagged.fst
+++ b/src/lib/state/DY.Lib.State.Tagged.fst
@@ -307,7 +307,7 @@ val get_tagged_state_same_trace:
   (ensures (
     let (opt_content, tr_out) = get_tagged_state tag prin sess_id tr in
     tr == tr_out 
-    ))
+  ))
   [SMTPat (get_tagged_state tag prin sess_id tr);]
 let get_tagged_state_same_trace tag prin sess_id tr =
   reveal_opaque (`%get_tagged_state) (get_tagged_state)
@@ -326,8 +326,7 @@ val get_tagged_state_state_was_set:
          tagged_state_was_set tr tag prin sess_id content
       )
     )
-  )
-  )
+  ))
   [SMTPat (get_tagged_state tag prin sess_id tr)]
 let get_tagged_state_state_was_set tag prin sess_id tr =
   reveal_opaque (`%get_tagged_state) (get_tagged_state);

--- a/src/lib/state/DY.Lib.State.Tagged.fst
+++ b/src/lib/state/DY.Lib.State.Tagged.fst
@@ -313,6 +313,32 @@ let get_tagged_state_same_trace tag prin sess_id tr =
   reveal_opaque (`%get_tagged_state) (get_tagged_state)
 
 
+val get_tagged_state_state_was_set:
+  tag:string -> 
+  prin:principal -> sess_id:state_id -> tr:trace ->
+  Lemma
+  (ensures (
+    let (opt_content, tr_out) = get_tagged_state tag prin sess_id tr in
+    tr == tr_out /\ (
+      match opt_content with
+      | None -> True
+      | Some content -> (
+         tagged_state_was_set tr tag prin sess_id content
+      )
+    )
+  )
+  )
+  [SMTPat (get_tagged_state tag prin sess_id tr)]
+let get_tagged_state_state_was_set tag prin sess_id tr =
+  reveal_opaque (`%get_tagged_state) (get_tagged_state);
+  reveal_opaque (`%tagged_state_was_set) (tagged_state_was_set);
+  match get_tagged_state tag prin sess_id tr with
+  | (None, _) -> ()
+  | (Some _, _) -> (
+    let (Some full_cont_bytes, _) = get_state prin sess_id tr in
+    serialize_parse_inv_lemma #bytes tagged_state full_cont_bytes    
+  )
+
 val get_tagged_state_invariant:
   {|protocol_invariants|} ->
   tag:string -> spred:local_bytes_state_predicate tag ->

--- a/src/lib/state/DY.Lib.State.Tagged.fst
+++ b/src/lib/state/DY.Lib.State.Tagged.fst
@@ -322,7 +322,7 @@ val get_tagged_state_state_was_set:
     match opt_content with
     | None -> True
     | Some content ->
-           tagged_state_was_set tr tag prin sess_id content
+        tagged_state_was_set tr tag prin sess_id content
   ))
   [SMTPat (get_tagged_state tag prin sess_id tr)]
 let get_tagged_state_state_was_set tag prin sess_id tr =

--- a/src/lib/state/DY.Lib.State.Tagged.fst
+++ b/src/lib/state/DY.Lib.State.Tagged.fst
@@ -335,36 +335,6 @@ let get_tagged_state_state_was_set tag prin sess_id tr =
     serialize_parse_inv_lemma #bytes tagged_state full_cont_bytes    
   )
 
-val get_tagged_state_invariant:
-  {|protocol_invariants|} ->
-  tag:string -> spred:local_bytes_state_predicate tag ->
-  prin:principal -> sess_id:state_id -> tr:trace ->
-  Lemma
-  (requires
-    trace_invariant tr /\
-    has_local_bytes_state_predicate (|tag, spred|)
-  )
-  (ensures (
-    let (opt_content, tr_out) = get_tagged_state tag prin sess_id tr in
-      match opt_content with
-      | None -> True
-      | Some content -> (
-        spred.pred tr prin sess_id content
-    )
-  ))
-  [SMTPat (get_tagged_state tag prin sess_id tr);
-   SMTPat (trace_invariant tr);
-   SMTPat (has_local_bytes_state_predicate (|tag, spred|))]
-let get_tagged_state_invariant #invs tag spred prin sess_id tr =
-  reveal_opaque (`%has_local_bytes_state_predicate) (has_local_bytes_state_predicate);
-  reveal_opaque (`%get_tagged_state) (get_tagged_state);
-  let (opt_content, tr_out) = get_tagged_state tag prin sess_id tr in
-  match opt_content with
-  | None -> ()
-  | Some content ->
-    let (Some full_content_bytes, tr) = get_state prin sess_id tr in
-    local_eq_global_lemma split_local_bytes_state_predicate_params state_pred.pred tag spred (tr, prin, sess_id, full_content_bytes) tag (tr, prin, sess_id, content)
-
 (*** Theorem ***)
 
 val tagged_state_was_set_implies_pred:

--- a/src/lib/state/DY.Lib.State.Typed.fst
+++ b/src/lib/state/DY.Lib.State.Typed.fst
@@ -217,7 +217,7 @@ val get_state_same_trace:
   (ensures (
     let (opt_content, tr_out) = get_state #a prin sess_id tr in
     tr == tr_out
-    ))
+  ))
   [SMTPat (get_state #a #ls prin sess_id tr);]
 let get_state_same_trace #a #ls prin sess_id tr =
   reveal_opaque (`%get_state) (get_state #a #ls)

--- a/src/lib/state/DY.Lib.State.Typed.fst
+++ b/src/lib/state/DY.Lib.State.Typed.fst
@@ -173,6 +173,20 @@ let get_state #a #ls prin sess_id =
   | None -> return None
   | Some content -> return (Some content)
 
+
+val set_state_state_was_set:
+  #a:Type -> {|ls:local_state a|} ->
+  prin:principal -> sess_id:state_id -> content:a -> tr:trace ->
+  Lemma
+  (ensures (
+    let ((), tr_out) = set_state prin sess_id content tr in
+    state_was_set tr_out prin sess_id content
+  ))
+  [SMTPat (set_state #a #ls prin sess_id content tr);]
+let set_state_state_was_set #a #ls  prin sess_id content tr =
+  reveal_opaque (`%set_state) (set_state #a);
+  reveal_opaque (`%state_was_set) (state_was_set #a #ls)
+
 val set_state_invariant:
   #a:Type -> {|local_state a|} ->
   {|protocol_invariants|} ->
@@ -186,16 +200,28 @@ val set_state_invariant:
   )
   (ensures (
     let ((), tr_out) = set_state prin sess_id content tr in
-    trace_invariant tr_out /\
-    state_was_set tr_out prin sess_id content
+    trace_invariant tr_out
   ))
   [SMTPat (set_state prin sess_id content tr);
    SMTPat (trace_invariant tr);
    SMTPat (has_local_state_predicate spred)]
 let set_state_invariant #a #ls #invs spred prin sess_id content tr =
   reveal_opaque (`%set_state) (set_state #a);
-  reveal_opaque (`%state_was_set) (state_was_set #a);
   parse_serialize_inv_lemma #bytes a content
+
+
+val get_state_same_trace:
+  #a:Type -> {|ls:local_state a|} ->
+  prin:principal -> sess_id:state_id -> tr:trace ->
+  Lemma
+  (ensures (
+    let (opt_content, tr_out) = get_state #a prin sess_id tr in
+    tr == tr_out
+    ))
+  [SMTPat (get_state #a #ls prin sess_id tr);]
+let get_state_same_trace #a #ls prin sess_id tr =
+  reveal_opaque (`%get_state) (get_state #a #ls)
+
 
 val get_state_invariant:
   #a:Type -> {|local_state a|} ->
@@ -209,12 +235,10 @@ val get_state_invariant:
   )
   (ensures (
     let (opt_content, tr_out) = get_state prin sess_id tr in
-    tr == tr_out /\ (
       match opt_content with
       | None -> True
       | Some content -> (
         spred.pred tr prin sess_id content
-      )
     )
   ))
   [SMTPat (get_state #a prin sess_id tr);

--- a/src/lib/state/DY.Lib.State.Typed.fst
+++ b/src/lib/state/DY.Lib.State.Typed.fst
@@ -243,30 +243,6 @@ let get_state_state_was_set #a #ls prin sess_id tr =
   | (Some _, _) ->
       let (Some cont, _) = get_tagged_state ls.tag prin sess_id tr in
       serialize_parse_inv_lemma a cont
-  
-val get_state_invariant:
-  #a:Type -> {|local_state a|} ->
-  {|protocol_invariants|} ->
-  spred:local_state_predicate a ->
-  prin:principal -> sess_id:state_id -> tr:trace ->
-  Lemma
-  (requires
-    trace_invariant tr /\
-    has_local_state_predicate spred
-  )
-  (ensures (
-    let (opt_content, tr_out) = get_state prin sess_id tr in
-      match opt_content with
-      | None -> True
-      | Some content -> (
-        spred.pred tr prin sess_id content
-    )
-  ))
-  [SMTPat (get_state #a prin sess_id tr);
-   SMTPat (trace_invariant tr);
-   SMTPat (has_local_state_predicate spred)]
-let get_state_invariant #a #ls #invs spred prin sess_id tr =
-  reveal_opaque (`%get_state) (get_state #a)
 
 val state_was_set_implies_pred:
   #a:Type -> {|local_state a|} ->

--- a/src/lib/state/DY.Lib.State.Typed.fst
+++ b/src/lib/state/DY.Lib.State.Typed.fst
@@ -229,10 +229,10 @@ val get_state_state_was_set:
   Lemma
   (ensures (
     let (opt_content, tr_out) = get_state #a #ls prin sess_id tr in
-      match opt_content with
-      | None -> True
-      | Some content -> 
-             state_was_set tr prin sess_id content
+    match opt_content with
+    | None -> True
+    | Some content -> 
+        state_was_set tr prin sess_id content
   ))
   [SMTPat (get_state #a #ls prin sess_id tr)]
 let get_state_state_was_set #a #ls prin sess_id tr =

--- a/src/lib/state/DY.Lib.State.Typed.fst
+++ b/src/lib/state/DY.Lib.State.Typed.fst
@@ -223,6 +223,27 @@ let get_state_same_trace #a #ls prin sess_id tr =
   reveal_opaque (`%get_state) (get_state #a #ls)
 
 
+val get_state_state_was_set:
+  #a:Type -> {|ls:local_state a|} ->
+  prin:principal -> sess_id:state_id -> tr:trace ->
+  Lemma
+  (ensures (
+    let (opt_content, tr_out) = get_state #a #ls prin sess_id tr in
+      match opt_content with
+      | None -> True
+      | Some content -> 
+             state_was_set tr prin sess_id content
+  ))
+  [SMTPat (get_state #a #ls prin sess_id tr)]
+let get_state_state_was_set #a #ls prin sess_id tr =
+  reveal_opaque (`%get_state) (get_state #a #ls);
+  reveal_opaque (`%state_was_set) (state_was_set #a #ls);
+  match get_state #a #ls prin sess_id tr with
+  | (None, _) -> ()
+  | (Some _, _) ->
+      let (Some cont, _) = get_tagged_state ls.tag prin sess_id tr in
+      serialize_parse_inv_lemma a cont
+  
 val get_state_invariant:
   #a:Type -> {|local_state a|} ->
   {|protocol_invariants|} ->


### PR DESCRIPTION
Fixing https://github.com/REPROSEC/dolev-yao-star-extrinsic/issues/80.

I also added "get_state => state_was_set" Lemmas (core, tagged, typed), which are often useful.
(For this, I needed the `last_entry_exists` Lemma in `Trace.Base`)