### PR TITLE
Cleanup: Renamed `trace_event` to `trace_entry`

### DIFF
--- a/differences_with_intrinsic.md
+++ b/differences_with_intrinsic.md
@@ -72,7 +72,7 @@ Instead, we write stateful protocol code in a lightweight state monad.
 ### Explicit trace
 
 The original DY\* use the witness mechanism to have an implicit and global trace that can be used by various predicates.
-The predicate usually depend on a timestamp that is used to refer to a particular event of the trace or a particular prefix of the trace.
+The predicate usually depend on a timestamp that is used to refer to a particular entry of the trace or a particular prefix of the trace.
 
 The witness mechanism is sound only when using F\*'s effect system,
 hence this is not an option when working in a lightweight monad.

--- a/examples/iso_dh/DY.Example.DH.Debug.Proof.fst
+++ b/examples/iso_dh/DY.Example.DH.Debug.Proof.fst
@@ -15,7 +15,7 @@ open DY.Example.DH.Debug
 /// duplicate the code from the debug function and
 /// call all the lemmas for the stateful code manually.
 
-#set-options "--fuel 0 --ifuel 0 --z3rlimit 20 --z3cliopt 'smt.qi.eager_threshold=100'"
+#set-options "--fuel 0 --ifuel 0 --z3rlimit 30 --z3cliopt 'smt.qi.eager_threshold=100'"
 val debug_proof:
   tr:trace ->
   Lemma

--- a/src/core/DY.Core.Label.Type.fst
+++ b/src/core/DY.Core.Label.Type.fst
@@ -14,7 +14,7 @@ open DY.Core.Trace.Type
 /// We therefore want labels to be predicates `trace -> prop`,
 /// however this doesn't work with F*'s positivity checker.
 /// (see https://fstar-lang.org/tutorial/book/part2/part2_inductive_type_families.html#strictly-positive-definitions )
-/// Indeed, we want the trace to contain labels (see `RandGen` event),
+/// Indeed, we want the trace to contain labels (see `RandGen` entry),
 /// and we want labels to be predicates on the trace, namely `trace -> prop` (see DY.Core.Label.Type).
 /// A type `t` cannot contain `t -> prop` because this could be used to derive False (using Cantor's diagonal argument).
 /// To circumvent that, labels are predicates on traces with no labels (i.e. whose label type is `unit`).
@@ -39,7 +39,7 @@ val is_monotonic:
   (trace_ unit -> prop) ->
   prop
 let is_monotonic is_corrupt =
-  forall tr ev. is_corrupt tr ==> is_corrupt (Snoc tr ev)
+  forall tr entry. is_corrupt tr ==> is_corrupt (Snoc tr entry)
 
 [@@erasable]
 noeq

--- a/src/core/DY.Core.Label.fst
+++ b/src/core/DY.Core.Label.fst
@@ -51,7 +51,7 @@ val label_is_corrupt_later:
   )
   (ensures l.is_corrupt tr2)
 let label_is_corrupt_later l tr1 tr2 =
-  grows_induction_principle l.is_corrupt (fun tr ev ->
+  grows_induction_principle l.is_corrupt (fun tr entry ->
     l.is_corrupt_later;
     reveal_opaque (`%is_monotonic) is_monotonic
   ) tr1 tr2
@@ -79,7 +79,7 @@ let mk_label l = {
     reveal_opaque (`%is_monotonic) is_monotonic;
     reveal_opaque (`%grows) (grows #unit);
     norm_spec [zeta; delta_only [`%prefix]] (prefix #unit);
-    assert(forall (tr:trace_ unit) ev. tr <$ (Snoc tr ev));
+    assert(forall (tr:trace_ unit) entry. tr <$ (Snoc tr entry));
     FStar.Classical.forall_intro_2 (FStar.Classical.move_requires_2 l.is_corrupt_later)
   );
 }
@@ -87,7 +87,7 @@ let mk_label l = {
 
 /// If the attacker knows a value with label `l`, then it must have done some corruptions in the trace.
 /// The corruption predicate express whether values with label `l` are still secure,
-/// with respect to corruption events in the trace.
+/// with respect to corruption entries in the trace.
 /// For example:
 /// - a public value can always be known to the attacker, so the label `public` is always corrupt.
 /// - a shared secret between Alice and Bob has the label `join (principal "Alice") (principal "Bob")`,
@@ -297,7 +297,7 @@ let join_flow_to_public_eq tr x1 x2 =
 
 /// Generic label for states:
 /// `state_pred_label p` is corrupt when
-/// there exists a corrupt `SetState` event satisfying the predicate `p`.
+/// there exists a corrupt `SetState` entry satisfying the predicate `p`.
 /// It can for example be used to depict any state of a principal
 /// (e.g. as done by `principal_label`)
 
@@ -352,8 +352,8 @@ let state_pred_label_can_flow_public tr p =
   flow_to_public_eq tr (state_pred_label p);
   reveal_opaque (`%is_corrupt) is_corrupt;
   reveal_opaque (`%state_pred_label) (state_pred_label);
-  FStar.Classical.forall_intro (FStar.Classical.move_requires (event_exists_fmap_trace_eq forget_label tr));
-  FStar.Classical.forall_intro_2 (FStar.Classical.move_requires_2 (event_at_fmap_trace_eq forget_label tr))
+  FStar.Classical.forall_intro (FStar.Classical.move_requires (entry_exists_fmap_trace_eq forget_label tr));
+  FStar.Classical.forall_intro_2 (FStar.Classical.move_requires_2 (entry_at_fmap_trace_eq forget_label tr))
 
 val principal_label_input:
   principal ->

--- a/src/core/DY.Core.Trace.Type.fst
+++ b/src/core/DY.Core.Trace.Type.fst
@@ -43,22 +43,22 @@ type state_id = { the_id: nat; }
 
 type timestamp = nat
 
-/// The type for events in the trace.
+/// The type for entries in the trace.
 
 noeq
-type trace_event_ (label_t:Type) =
+type trace_entry_ (label_t:Type) =
   // A message has been sent on the network.
-  | MsgSent: bytes -> trace_event_ label_t
+  | MsgSent: bytes -> trace_entry_ label_t
   // A random number has been generated, with some usage and label.
-  | RandGen: usg:usage -> label_t -> len:nat{len <> 0} -> trace_event_ label_t
+  | RandGen: usg:usage -> label_t -> len:nat{len <> 0} -> trace_entry_ label_t
   // A state of a principal has been corrupt.
-  | Corrupt: time:timestamp -> trace_event_ label_t
+  | Corrupt: time:timestamp -> trace_entry_ label_t
   // A principal stored some state.
-  | SetState: prin:principal -> sess_id:state_id -> content:bytes -> trace_event_ label_t
+  | SetState: prin:principal -> sess_id:state_id -> content:bytes -> trace_entry_ label_t
   // A custom and protocol-specific event has been triggered by a principal.
-  | Event: prin:principal -> tag:string -> content:bytes -> trace_event_ label_t
+  | Event: prin:principal -> tag:string -> content:bytes -> trace_entry_ label_t
 
-/// The trace is a list of trace events.
+/// The trace is a list of trace entries.
 /// Because the trace grows with time and the time is often represented going from left to right,
 /// the trace is actually a reversed list.
 /// To avoid confusions, we define a custom inductive to swap the arguments of the "cons" constructor.
@@ -66,4 +66,4 @@ type trace_event_ (label_t:Type) =
 noeq
 type trace_ (label_t:Type) =
   | Nil: trace_ label_t
-  | Snoc: trace_ label_t -> trace_event_ label_t -> trace_ label_t
+  | Snoc: trace_ label_t -> trace_entry_ label_t -> trace_ label_t

--- a/src/core/DY.Core.Trace.Type.fst
+++ b/src/core/DY.Core.Trace.Type.fst
@@ -6,7 +6,7 @@ open DY.Core.Bytes.Type
 /// It is separated from functions and predicates on trace (manipulation, invariants)
 /// in order to avoid dependency cycles.
 ///
-/// The trace is a log of every event that has happened during a protocol execution,
+/// The trace is a log of every action that has happened during a protocol execution,
 /// such as messages sent on the network, state storage or corruption by the attacker,
 /// as is standard is symbolic analysis tools to express security properties.
 ///

--- a/src/core/DY.Core.fst
+++ b/src/core/DY.Core.fst
@@ -51,7 +51,7 @@ module DY.Core
 /// we will not actually have them perform stateful, impure actions
 /// (such as sending messages to the actual network).
 /// Instead, every impure action performed by the protocol
-/// will be stored as an event in a trace (see DY.Core.Trace.Type.trace).
+/// will be stored as an entry in a trace (see DY.Core.Trace.Type.trace).
 /// The trace is a log of every event that has happened during a protocol execution.
 /// From this trace can be deduced many facts,
 /// such as the set of bytestrings that can be computed by the attacker
@@ -96,7 +96,7 @@ module DY.Core
 /// but that the attacker has to perform some corruption
 /// in order to compute a secret value.
 /// To express this kind of properties,
-/// the corruption will be represented as a corruption event in the trace.
+/// the corruption will be represented as a corruption entry in the trace.
 /// Therefore, many DY* predicates will depend on the trace to account for such corruptions.
 /// All predicates and relations in DY* will satisfy a key property
 /// being that they stay true when the trace is extended,

--- a/src/core/DY.Core.fst
+++ b/src/core/DY.Core.fst
@@ -52,7 +52,7 @@ module DY.Core
 /// (such as sending messages to the actual network).
 /// Instead, every impure action performed by the protocol
 /// will be stored as an entry in a trace (see DY.Core.Trace.Type.trace).
-/// The trace is a log of every event that has happened during a protocol execution.
+/// The trace is a log of every action that has happened during a protocol execution.
 /// From this trace can be deduced many facts,
 /// such as the set of bytestrings that can be computed by the attacker
 /// (see DY.Core.Attacker.Knowledge.attacker_knows).

--- a/src/lib/event/DY.Lib.Event.Typed.fst
+++ b/src/lib/event/DY.Lib.Event.Typed.fst
@@ -220,17 +220,17 @@ let event_triggered_grows #a #ev tr1 tr2 prin e =
   reveal_opaque (`%event_triggered_at) (event_triggered_at #a);
   ()
 
-val event_triggered_at_implies_trace_event_at:
+val event_triggered_at_implies_trace_entry_at:
   #a:Type -> {|ev:event a|} ->
   tr:trace -> i:timestamp -> prin:principal -> e:a  ->
   Lemma
   (requires event_triggered_at tr i prin e)
   (ensures
-    get_event_at tr i == Event prin ev.tag (serialize a e) /\
+    get_entry_at tr i == Event prin ev.tag (serialize a e) /\
     parse #bytes a (serialize a e) == Some e
   )
   [SMTPat (event_triggered_at tr i prin e)]
-let event_triggered_at_implies_trace_event_at #a #ev tr i prin e =
+let event_triggered_at_implies_trace_entry_at #a #ev tr i prin e =
   reveal_opaque (`%event_triggered_at) (event_triggered_at #a);
   ()
 

--- a/src/lib/utils/DY.Lib.Printing.fst
+++ b/src/lib/utils/DY.Lib.Printing.fst
@@ -185,12 +185,12 @@ noeq type trace_to_string_printers = {
 
 (*** Functions to Print the Trace ***)
 
-val trace_event_to_string: 
+val trace_entry_to_string: 
   trace_to_string_printers -> 
-  trace_event -> timestamp -> 
+  trace_entry -> timestamp -> 
   string
-let trace_event_to_string printers tr_event i =
-  match tr_event with
+let trace_entry_to_string printers tr_entry i =
+  match tr_entry with
   | MsgSent msg -> (
     let msg_str = option_to_string printers.message_to_string msg in
     Printf.sprintf "{\"TraceID\": %d, \"Type\": \"Message\", \"Content\": \"%s\"}\n"
@@ -213,7 +213,7 @@ let trace_event_to_string printers tr_event i =
       (i-1) prin tag content_str
   )
 
-/// Helper function for `trace_to_string` to avoid calling `length` for each trace event,
+/// Helper function for `trace_to_string` to avoid calling `length` for each trace entry,
 /// which would lead to quadratic complexity.
 
 val trace_to_string_helper:
@@ -223,8 +223,8 @@ val trace_to_string_helper:
 let rec trace_to_string_helper printers tr i =
   match tr with
   | Nil -> ""
-  | Snoc ptr ev -> (
-      trace_to_string_helper printers ptr (i-1) ^ trace_event_to_string printers ev i
+  | Snoc ptr entry -> (
+      trace_to_string_helper printers ptr (i-1) ^ trace_entry_to_string printers entry i
   )
 
 (*** Functions for Users ***)


### PR DESCRIPTION
Fixing https://github.com/REPROSEC/dolev-yao-star-extrinsic/issues/74 by renaming `trace_event` to `trace_entry` and related occurrences of `event` in functions and lemmas.
I hope, I didn't miss anything.