### PR TITLE
feat: pk_enc reverse msg ghost function for predicates

### DIFF
--- a/src/core/DY.Core.Bytes.fst
+++ b/src/core/DY.Core.Bytes.fst
@@ -1707,6 +1707,46 @@ let pk_dec_enc key nonce msg =
   normalize_term_spec pk_enc;
   normalize_term_spec pk
 
+/// Ghost reverse function for predicates
+
+val pk_enc_reverse_msg: enc_msg:bytes -> GTot (option bytes)
+let pk_enc_reverse_msg enc_msg =
+  match enc_msg with
+  | PkEnc pk nonce msg -> Some msg
+  | _ -> None
+
+/// Encryption lemma for the ghost reverse function
+
+val pk_enc_reverse_msg_enc_lemma:
+  pk_prin:bytes -> nonce:bytes ->
+  msg:bytes -> enc:bytes ->
+  Lemma
+  (requires
+    enc == pk_enc pk_prin nonce msg
+  )
+  (ensures
+    pk_enc_reverse_msg enc == Some msg
+  )
+let pk_enc_reverse_msg_enc_lemma pk_prin nonce msg enc =
+  normalize_term_spec pk_enc;
+  ()
+
+/// Decryption lemma for the ghost reverse function
+
+val pk_enc_reverse_msg_dec_lemma:
+  sk_prin:bytes ->
+  enc:bytes -> msg:bytes ->
+  Lemma
+  (requires
+    pk_dec sk_prin enc == Some msg
+  )
+  (ensures 
+    pk_enc_reverse_msg enc == Some msg
+  )
+let pk_enc_reverse_msg_dec_lemma sk_prin enc msg = 
+  normalize_term_spec pk_dec;
+  ()
+
 /// Lemma for attacker knowledge theorem.
 
 val pk_preserves_publishability:


### PR DESCRIPTION
The functions and corresponding lemmas are needed to prove the confidential and authenticated send and receive functions in #50. I think this function can also be useful for other use cases, so it should go into the core. If this is something we want to have in the core, we should probably also write such a function for the other crypto primitives.