### PR TITLE
cleanup: correct small typos and small consistency tweaks

### DIFF
--- a/src/core/DY.Core.Attacker.Knowledge.fst
+++ b/src/core/DY.Core.Attacker.Knowledge.fst
@@ -20,7 +20,7 @@ open DY.Core.Label
 /// meaning that its label flows to public (by definition of publishability),
 /// which in turn will imply that some set of principals have been compromised (property of labels).
 
-/// Auxillary prediate for the attacker knowledge:
+/// Auxillary predicate for the attacker knowledge:
 /// given a trace `tr`,
 /// can the attacker compute `msg`
 /// by applying at most `step` cryptographic functions?

--- a/src/core/DY.Core.Label.fst
+++ b/src/core/DY.Core.Label.fst
@@ -230,7 +230,7 @@ let secret_is_bottom tr l =
   reveal_opaque (`%secret) secret;
   reveal_opaque (`%is_corrupt) is_corrupt
 
-/// `secret` is the maximum of the label lattice.
+/// `public` is the maximum of the label lattice.
 
 val public_is_top:
   tr:trace -> l:label ->

--- a/src/core/DY.Core.Trace.Invariant.fst
+++ b/src/core/DY.Core.Trace.Invariant.fst
@@ -198,8 +198,8 @@ val event_triggered_at_implies_pred:
   i:timestamp -> prin:principal -> tag:string -> content:bytes ->
   Lemma
   (requires
-    event_triggered_at tr i prin tag content /\
-    trace_invariant tr
+    trace_invariant tr /\
+    event_triggered_at tr i prin tag content
   )
   (ensures event_pred (prefix tr i) prin tag content)
   [SMTPat (event_triggered_at tr i prin tag content);

--- a/src/core/DY.Core.Trace.Invariant.fst
+++ b/src/core/DY.Core.Trace.Invariant.fst
@@ -143,8 +143,8 @@ val msg_sent_on_network_are_publishable:
   {|protocol_invariants|} -> tr:trace -> msg:bytes ->
   Lemma
   (requires
-    trace_invariant tr /\
-    msg_sent_on_network tr msg
+    msg_sent_on_network tr msg /\
+    trace_invariant tr
   )
   (ensures is_publishable tr msg)
 let msg_sent_on_network_are_publishable #invs tr msg =
@@ -161,8 +161,8 @@ val state_was_set_implies_pred:
   prin:principal -> sess_id:state_id -> content:bytes ->
   Lemma
   (requires
-    trace_invariant tr /\
-    state_was_set tr prin sess_id content
+    state_was_set tr prin sess_id content /\
+    trace_invariant tr
   )
   (ensures state_pred.pred tr prin sess_id content)
   [SMTPat (state_was_set tr prin sess_id content);
@@ -184,8 +184,8 @@ val state_is_knowable_by:
   prin:principal -> sess_id:state_id -> content:bytes ->
   Lemma
   (requires
-    trace_invariant tr /\
-    state_was_set tr prin sess_id content
+    state_was_set tr prin sess_id content /\
+    trace_invariant tr
   )
   (ensures is_knowable_by (principal_state_content_label prin sess_id content) tr content)
 let state_is_knowable_by #invs tr prin sess_id content =

--- a/src/core/DY.Core.Trace.Invariant.fst
+++ b/src/core/DY.Core.Trace.Invariant.fst
@@ -198,8 +198,8 @@ val event_triggered_at_implies_pred:
   i:timestamp -> prin:principal -> tag:string -> content:bytes ->
   Lemma
   (requires
-    trace_invariant tr /\
-    event_triggered_at tr i prin tag content
+    event_triggered_at tr i prin tag content /\
+    trace_invariant tr
   )
   (ensures event_pred (prefix tr i) prin tag content)
   [SMTPat (event_triggered_at tr i prin tag content);

--- a/src/lib/event/DY.Lib.Event.Typed.fst
+++ b/src/lib/event/DY.Lib.Event.Typed.fst
@@ -94,7 +94,9 @@ let has_event_pred #a #ev #invs epred =
 
 (*** Global event predicate builder ***)
 
-val mk_event_pred: {|crypto_invariants|} -> list (string & compiled_event_predicate) -> trace -> principal -> string -> bytes -> prop
+val mk_event_pred:
+  {|crypto_invariants|} -> list (string & compiled_event_predicate) ->
+  trace -> principal -> string -> bytes -> prop
 let mk_event_pred #cinvs tagged_local_preds =
   mk_global_fun split_event_pred_params (mk_dependent_tagged_local_funs tagged_local_preds)
 


### PR DESCRIPTION
Some small clean-ups. 
1. Corrected a couple of typos.
2. Changed an ordering of a conjunction in a requires to match the other lemmas in the same file. 
3. Changed some indentation to clarify the return type.