### PR TITLE
cleanup: add missing val statements to maintain style

### DIFF
--- a/src/core/DY.Core.Trace.Base.fst
+++ b/src/core/DY.Core.Trace.Base.fst
@@ -837,7 +837,7 @@ let rec trace_search_last tr p =
 /// but treats two RandGen entries with the same non-label content as equivalent.
 val trace_entry_equiv:
   #label_t:Type ->
-  e1:trace_entry_ label_t -> e2:trace_entry_ label_t ->
+  trace_entry_ label_t -> trace_entry_ label_t ->
   bool
 let trace_entry_equiv e1 e2 =
   (fmap_trace_entry forget_label e1) = (fmap_trace_entry forget_label e2)

--- a/src/core/DY.Core.Trace.Base.fst
+++ b/src/core/DY.Core.Trace.Base.fst
@@ -218,8 +218,7 @@ let prefix_grows #label_t tr i =
 val grows_nil :
   #label_t:Type ->
   tr:trace_ label_t ->
-  Lemma
-  (ensures Nil <$ tr)
+  Lemma (Nil <$ tr)
   [SMTPat (Nil <$ tr)]
 let grows_nil #label_t tr =
   reveal_opaque (`%grows) (grows #label_t)
@@ -227,8 +226,7 @@ let grows_nil #label_t tr =
 val grows_snoc :
   #label_t:Type ->
   tr:trace_ label_t -> e:trace_entry_ label_t ->
-  Lemma
-  (ensures tr <$ (Snoc tr e))
+  Lemma (tr <$ (Snoc tr e))
   [SMTPat (tr <$ (Snoc tr e))]
 let grows_snoc #label_t tr e =
   reveal_opaque (`%grows) (grows #label_t);
@@ -283,8 +281,7 @@ let rec prefix_prefix_eq #label_t tr1 tr2 i =
 val prefix_full_eq :
   #label_t:Type ->
   tr:trace_ label_t ->
-  Lemma
-  (ensures (prefix tr (trace_length tr) == tr))
+  Lemma (prefix tr (trace_length tr) == tr)
   [SMTPat (prefix tr (trace_length tr))]
 let prefix_full_eq #label_t tr =
   reveal_opaque (`%prefix) (prefix #label_t)

--- a/src/core/DY.Core.Trace.Base.fst
+++ b/src/core/DY.Core.Trace.Base.fst
@@ -287,8 +287,7 @@ val prefix_full_eq :
   (ensures (prefix tr (trace_length tr) == tr))
   [SMTPat (prefix tr (trace_length tr))]
 let prefix_full_eq #label_t tr =
-    reveal_opaque (`%prefix) (prefix #label_t);
-    reveal_opaque (`%prefix) (prefix #label_t)
+  reveal_opaque (`%prefix) (prefix #label_t)
 
 /// Two traces with the same length, where one is a prefix of the other, must be the same
 


### PR DESCRIPTION
Small cleanup to add some missing val declarations in DY.Core.Trace.Base to maintain codebase style.