### PR TITLE
chore: update F* and fix proofs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -46,11 +46,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1733419212,
-        "narHash": "sha256-LrUdHv2GMkvizcMR7PPQv86ODPPVY9GuFV4VCaeuGhs=",
+        "lastModified": 1736155139,
+        "narHash": "sha256-TPnXRclfOejPfLcLAg6QZ7cvw/GridzdvQB+DqiQiI8=",
         "owner": "FStarLang",
         "repo": "FStar",
-        "rev": "58ea6b0ed49984e4117b781deee7f6605f8269f0",
+        "rev": "01154db9f39d5943f7200703c541a960e9ff66c3",
         "type": "github"
       },
       "original": {

--- a/src/core/DY.Core.Trace.Manipulation.fst
+++ b/src/core/DY.Core.Trace.Manipulation.fst
@@ -556,7 +556,7 @@ val trigger_event: principal -> string -> bytes -> traceful unit
 let trigger_event prin tag content =
   add_entry (Event prin tag content)
 
-#push-options "--z3rlimit 25"
+#push-options "--z3rlimit 25 --ifuel 2"
 val trigger_event_event_triggered:
   prin:principal -> tag:string -> content:bytes -> tr:trace ->
   Lemma


### PR DESCRIPTION
DY* is currently not building with the latest version of F*, this PR fixes this problem.

I don't understand well how things broke though:
- #93 (the PR corresponding to our latest commit) builds with the locked version of F* but not with the latest version of F* (I made a separate commit to demonstrate this fact)
- #97 (the PR corresponding to our penultimate commit) builds with both the locked version of F* and the latest version of F*

And the fix is to increase ifuel (or add the line `let ((), tr_out) = trigger_event prin tag content tr in` to destruct the pair). Furthermore, the proof only fails when running `make`, it succeeds in interactive mode. Weird.