### PR TITLE
Adjust request/confidential message postconditions

### DIFF
--- a/src/lib/communication/DY.Lib.Communication.Core.Invariants.fst
+++ b/src/lib/communication/DY.Lib.Communication.Core.Invariants.fst
@@ -128,10 +128,10 @@ let default_comm_higher_layer_event_preds (a:Type) {| parseable_serializeable by
 }
 
 #push-options "--ifuel 1 --fuel 0"
-let event_predicate_communication_layer 
+let event_predicate_communication_layer
   {|cinvs:crypto_invariants|}
   (#a:Type) {| parseable_serializeable bytes a |}
-  (higher_layer_preds:comm_higher_layer_event_preds a) : 
+  (higher_layer_preds:comm_higher_layer_event_preds a) :
   event_predicate communication_event =
   fun tr prin e ->
     (match e with
@@ -186,7 +186,7 @@ let event_predicate_communication_layer
     )
 #pop-options
 
-val event_predicate_communication_layer_and_tag: 
+val event_predicate_communication_layer_and_tag:
   {|cinvs:crypto_invariants|} ->
   #a:Type -> {| parseable_serializeable bytes a |} ->
   comm_higher_layer_event_preds a ->

--- a/src/lib/communication/DY.Lib.Communication.Core.Invariants.fst
+++ b/src/lib/communication/DY.Lib.Communication.Core.Invariants.fst
@@ -143,11 +143,8 @@ let event_predicate_communication_layer
       )
     )
     | CommConfReceiveMsg receiver payload -> (
-      exists sender.
-        (
-          event_triggered tr sender (CommConfSendMsg sender receiver payload) \/
-          is_publishable tr payload
-        )
+      (exists sender. event_triggered tr sender (CommConfSendMsg sender receiver payload)) \/
+      is_publishable tr payload
     )
     | CommAuthSendMsg sender payload -> (
       (match parse a payload with

--- a/src/lib/communication/DY.Lib.Communication.Core.Lemmas.fst
+++ b/src/lib/communication/DY.Lib.Communication.Core.Lemmas.fst
@@ -133,7 +133,8 @@ val receive_confidential_proof:
     | (None, tr_out) -> trace_invariant tr_out
     | (Some payload, tr_out) ->
       trace_invariant tr_out /\
-      event_triggered tr_out receiver (CommConfReceiveMsg receiver (serialize a payload))
+      event_triggered tr_out receiver (CommConfReceiveMsg receiver (serialize a payload)) /\
+      is_well_formed a (is_knowable_by (principal_label receiver) tr) payload
   ))
 let receive_confidential_proof #invs #a tr higher_layer_preds comm_keys_ids receiver msg_id =
   match receive_confidential #a comm_keys_ids receiver msg_id tr with

--- a/src/lib/communication/DY.Lib.Communication.Core.Lemmas.fst
+++ b/src/lib/communication/DY.Lib.Communication.Core.Lemmas.fst
@@ -131,24 +131,9 @@ val receive_confidential_proof:
   (ensures (
     match receive_confidential #a comm_keys_ids receiver msg_id tr with
     | (None, tr_out) -> trace_invariant tr_out
-    | (Some payload, tr_out) -> ( 
+    | (Some payload, tr_out) ->
       trace_invariant tr_out /\
-      (
-        (exists sender.
-          is_well_formed a (is_knowable_by (comm_label sender receiver) tr) payload /\
-          // We explicitly do not use `event_triggered tr receiver
-          // (CommConfReceiveMsg receiver (serialize a payload))` as a
-          // post-condition here. The reason for the following form of the
-          // post-condition is that it allows us on the higher layer to assert a
-          // statement `b` contained in the `higher_layer_preds` that depends on
-          // some field `field1` of the payload in the following way: `b
-          // payload.field1 \/ is_publishable tr payload.field1`.
-          event_triggered tr sender (CommConfSendMsg sender receiver (serialize a payload))
-        ) \/ (
-          is_well_formed a (is_publishable tr) payload
-        )
-      )
-    )
+      event_triggered tr_out receiver (CommConfReceiveMsg receiver (serialize a payload))
   ))
 let receive_confidential_proof #invs #a tr higher_layer_preds comm_keys_ids receiver msg_id =
   match receive_confidential #a comm_keys_ids receiver msg_id tr with

--- a/src/lib/communication/DY.Lib.Communication.Core.Lemmas.fst
+++ b/src/lib/communication/DY.Lib.Communication.Core.Lemmas.fst
@@ -123,7 +123,7 @@ val receive_confidential_proof:
   receiver:principal -> msg_id:timestamp ->
   Lemma
   (requires
-    trace_invariant tr /\ 
+    trace_invariant tr /\
     has_private_keys_invariant /\
     has_communication_layer_crypto_predicates /\
     has_communication_layer_event_predicates higher_layer_preds

--- a/src/lib/communication/DY.Lib.Communication.Core.Properties.fst
+++ b/src/lib/communication/DY.Lib.Communication.Core.Properties.fst
@@ -18,6 +18,53 @@ open DY.Lib.Communication.Core.Lemmas
 /// This module contains security properties that can be proven from the
 /// communication layer guarantees.
 
+(*** Confidential Messages Properties ***)
+
+val conf_message_secrecy:
+  {|protocol_invariants|} ->
+  #a:Type -> {| parseable_serializeable bytes a |} ->
+  tr:trace -> i:timestamp ->
+  higher_layer_preds:comm_higher_layer_event_preds a ->
+  receiver:principal ->
+  payload:bytes ->
+  Lemma
+  (requires
+    trace_invariant tr /\
+    has_communication_layer_event_predicates higher_layer_preds /\
+    event_triggered_at tr i receiver (CommConfReceiveMsg receiver payload)
+  )
+  (ensures
+    is_knowable_by (principal_label receiver) (prefix tr i) payload /\
+    (exists sender.
+      Some? (parse a payload) /\
+      higher_layer_preds.send_conf (prefix tr i) sender receiver (Some?.v (parse a payload))
+    ) \/
+    is_publishable (prefix tr i) payload
+  )
+let conf_message_secrecy #invs #a tr i higher_layer_preds receiver payload =
+  let send_event sender = CommConfSendMsg sender receiver payload in
+  let tr_i = prefix tr i in
+  eliminate (exists sender. event_triggered tr_i sender (send_event sender)) \/
+            is_publishable tr_i payload
+  returns
+    is_knowable_by (principal_label receiver) tr_i payload /\
+    (exists sender.
+      Some? (parse a payload) /\
+      higher_layer_preds.send_conf tr_i sender receiver (Some?.v (parse a payload))
+    ) \/
+    is_publishable tr_i payload
+  with _. eliminate exists sender. event_triggered tr_i sender (send_event sender)
+    returns _
+    with _. (
+      let j = find_event_triggered_at_timestamp tr sender (send_event sender) in
+      find_event_triggered_at_timestamp_later tr_i tr sender (send_event sender);
+
+      serialize_parse_inv_lemma a payload;
+      higher_layer_preds.send_conf_later (prefix tr j) tr_i sender receiver (Some?.v (parse a payload))
+    )
+  and _. ()
+
+
 (*** Authenticated Messages Properties ***)
 
 val sender_authentication:

--- a/src/lib/communication/DY.Lib.Communication.RequestResponse.Invariants.fst
+++ b/src/lib/communication/DY.Lib.Communication.RequestResponse.Invariants.fst
@@ -70,10 +70,7 @@ let state_predicates_communication_layer {|crypto_invariants|}: local_state_pred
       let server = prin in
       is_knowable_by (principal_label server) tr key /\
       is_knowable_by (get_label tr key) tr request /\
-      (
-        key `has_usage tr` (AeadKey comm_layer_aead_tag empty) \/
-        is_publishable tr key
-      )
+      key `has_usage tr` (AeadKey comm_layer_aead_tag empty)
     )
     | ClientReceiveResponse {server; response; key} -> (
       let client = prin in
@@ -157,9 +154,13 @@ let event_predicate_communication_layer_reqres
       | Some request -> higher_layer_resreq_preds.send_request tr client server request (get_label tr key))
     )
     | CommServerReceiveRequest server request key -> (
-      is_knowable_by (principal_label server) tr request /\
-      (exists client. event_triggered tr client (CommClientSendRequest client server request key) \/
-        is_publishable tr request)
+      is_knowable_by (principal_label server) tr key /\
+      is_knowable_by (get_label tr key) tr request /\
+      key `has_usage tr` (AeadKey comm_layer_aead_tag empty) /\
+      (
+        (exists client. event_triggered tr client (CommClientSendRequest client server request key)) \/
+        is_publishable tr key
+      )
     )
     | CommServerSendResponse server request response -> (
       (match parse a response with

--- a/src/lib/communication/DY.Lib.Communication.RequestResponse.Lemmas.fst
+++ b/src/lib/communication/DY.Lib.Communication.RequestResponse.Lemmas.fst
@@ -125,7 +125,7 @@ val receive_request_proof:
       is_well_formed a (is_knowable_by (get_response_label tr req_meta_data) tr) payload
     )
   ))
-  [SMTPat (trace_invariant tr); 
+  [SMTPat (trace_invariant tr);
   SMTPat (apply_com_layer_lemmas higher_layer_preds);
   SMTPat (receive_request #a comm_keys_ids server msg_id tr)]
 let receive_request_proof #invs #a tr comm_keys_ids higher_layer_preds server msg_id =
@@ -142,7 +142,7 @@ let receive_request_proof #invs #a tr comm_keys_ids higher_layer_preds server ms
     let ((), tr') = trigger_event server (CommServerReceiveRequest server req_msg.request req_msg.key) tr' in
     let (sid', tr') = new_session_id server tr' in
     let ((), tr') = set_state server sid' (ServerReceiveRequest {request=req_msg.request; key=req_msg.key} <: communication_states) tr' in
-    assert(tr' == tr_out);    
+    assert(tr' == tr_out);
     assert(trace_invariant tr_out);
     ()
   )

--- a/src/lib/communication/DY.Lib.Communication.RequestResponse.Lemmas.fst
+++ b/src/lib/communication/DY.Lib.Communication.RequestResponse.Lemmas.fst
@@ -141,18 +141,6 @@ let receive_request_proof #invs #a tr comm_keys_ids higher_layer_preds server ms
     conf_message_secrecy tr' i request_response_event_preconditions server req_msg_bytes;
 
     // Properties that can be proved uniformly in both the honest and corrupt case
-    assert(is_well_formed com_message_t (is_knowable_by (principal_label server) tr') req_msg_t);
-    assert(is_knowable_by (principal_label server) tr' req_msg.request); // needed for ServerReceiveRequest
-    assert(is_knowable_by (principal_label server) tr' req_msg.key); // needed for ServerReceiveRequest
-
-    // Properties that require separate proof in the honest and corrupt case
-    eliminate (exists client. event_triggered tr' client (req_send_event client)) \/
-              is_publishable tr' (serialize com_message_t req_msg_t)
-    returns (exists client. event_triggered tr' client (req_send_event client)) \/
-            (is_publishable tr' req_msg.request /\ is_publishable tr' req_msg.key)
-    with _. ()
-    and _. assert(is_well_formed com_message_t (is_publishable tr') req_msg_t);
-
     eliminate (exists client. event_triggered tr' client (req_send_event client)) \/
               (is_publishable tr' req_msg.request /\ is_publishable tr' req_msg.key)
     returns (

--- a/src/lib/communication/DY.Lib.Communication.RequestResponse.fst
+++ b/src/lib/communication/DY.Lib.Communication.RequestResponse.fst
@@ -120,13 +120,13 @@ val receive_request:
   principal -> timestamp ->
   traceful (option (a & comm_meta_data))
 let receive_request #a comm_keys_ids server msg_id =
-  let*? req_msg_t:com_message_t = receive_confidential #com_message_t comm_keys_ids server msg_id in  
+  let*? req_msg_t:com_message_t = receive_confidential #com_message_t comm_keys_ids server msg_id in
   guard_tr (RequestMessage? req_msg_t);*?
   let RequestMessage req_msg = req_msg_t in
+  let*? request = return (parse a req_msg.request) in
   trigger_event server (CommServerReceiveRequest server req_msg.request req_msg.key);*
   let* sid = new_session_id server in
   set_state server sid (ServerReceiveRequest {request=req_msg.request; key=req_msg.key} <: communication_states);*
-  let*? request = return (parse a req_msg.request) in
   let req_meta_data = {key=req_msg.key; server; sid; request=req_msg.request} in
   return (Some (request, req_meta_data))
 

--- a/src/lib/comparse/DY.Lib.Comparse.DYUtils.fst
+++ b/src/lib/comparse/DY.Lib.Comparse.DYUtils.fst
@@ -1,0 +1,23 @@
+module DY.Lib.Comparse.DYUtils
+
+open Comparse
+open DY.Core
+
+open DY.Lib.Comparse.Glue
+open DY.Lib.Comparse.Parsers
+
+/// This module provides some utility functions for working more simply
+/// with parseable bytes (e.g., lifting predicates from abstract types to
+/// their serialized bytes counterparts).
+
+#set-options "--fuel 0 --ifuel 0"
+
+unfold
+val parse_and_pred:
+  #a:Type -> {| parseable_serializeable bytes a |} ->
+  (p:a -> Type0) -> (bytes -> Type0)
+let parse_and_pred #a p = (fun b ->
+  match parse a b with
+  | None -> False
+  | Some x -> p x
+  )


### PR DESCRIPTION
The primary role of this PR is to change confidential messages (and the requests that they are built on), so that the receiver of a confidential message/request gets a simpler, more obvious guarantee --- that a request/confidential message has indeed been received.

The lemma `conf_message_secrecy` in DY.Lib.Communication.Core.Properties.fst allows us to dig into the event predicates, and extract the most relevant information. This may be further improveable, for instance by strengthening the predicate for `CommConfReceiveMsg` (e.g., to say that the payload parses successfully). See for comparison the predicate for request received events, which contains many of the desired guarantees already, only needing to refer to the send event for guarantees that depend on the higher layer send predicate or on secrecy of the key.

The current form, however, does seem to be enough for the examples (separate PR to appear for the examples --- I'll cross-reference once that's made).

A few more minor changes:
- Limit the scope of some quantifiers `exists sender. ...` where possible.
- Remove redundant `is_publishable` from ``b `has_usage tr` u \/ is_publishable tr b``.