### PR TITLE
Improve proof performance by making communication layer functions opaque and relying on lemmas

### DIFF
--- a/src/lib/communication/DY.Lib.Communication.Core.fst
+++ b/src/lib/communication/DY.Lib.Communication.Core.fst
@@ -58,12 +58,14 @@ instance event_communication_event: event communication_event = {
 
 (**** Confidential Send and Receive Functions ****)
 
+[@@ "opaque_to_smt"]
 val encrypt_message:
   #a:Type -> {| parseable_serializeable bytes a |} ->
   bytes -> bytes -> a -> bytes
 let encrypt_message #a pk_receiver nonce payload =
   pke_enc pk_receiver nonce (serialize a payload)
 
+[@@ "opaque_to_smt"]
 val send_confidential:
   #a:Type -> {| parseable_serializeable bytes a |} ->
   communication_keys_sess_ids ->
@@ -77,7 +79,7 @@ let send_confidential #a comm_keys_ids sender receiver payload =
   let* msg_id = send_msg msg_encrypted in
   return (Some msg_id)
 
-
+[@@ "opaque_to_smt"]
 val decrypt_message:
   #a:Type -> {| parseable_serializeable bytes a |} ->
   bytes -> bytes -> option a
@@ -85,6 +87,7 @@ let decrypt_message #a sk_receiver msg_encrypted =
   let? plaintext = pke_dec sk_receiver msg_encrypted in
   parse #bytes a plaintext
 
+[@@ "opaque_to_smt"]
 val receive_confidential:
   #a:Type -> {| parseable_serializeable bytes a |} ->
   communication_keys_sess_ids ->
@@ -101,7 +104,8 @@ let receive_confidential #a comm_keys_ids receiver msg_id =
 (**** Authenticated Send and Receive Functions ****)
 
 #push-options "--ifuel 1"
-val sign_message: 
+[@@ "opaque_to_smt"]
+val sign_message:
   #a:Type -> {| parseable_serializeable bytes a |} ->
   principal -> principal -> a -> option bytes -> bytes -> bytes -> bytes
 let sign_message #a sender receiver payload pk_receiver sk nonce =
@@ -117,6 +121,7 @@ let sign_message #a sender receiver payload pk_receiver sk nonce =
   serialize com_message_t signed_msg
 #pop-options
 
+[@@ "opaque_to_smt"]
 val send_authenticated:
   #a:Type -> {| parseable_serializeable bytes a |} ->
   communication_keys_sess_ids ->
@@ -132,6 +137,7 @@ let send_authenticated #a comm_keys_ids sender receiver payload =
   return (Some msg_id)
 
 #push-options "--ifuel 1 --fuel 0"
+//[@@ "opaque_to_smt"]
 val verify_message:
   #a:Type -> {| parseable_serializeable bytes a |} ->
   principal -> bytes -> option bytes -> bytes -> option (communication_message a)
@@ -166,6 +172,7 @@ let get_sender sign_msg_bytes =
   | Encrypted sender receiver payload_bytes pk_receiver -> Some sender
 #pop-options
 
+[@@ "opaque_to_smt"]
 val receive_authenticated:
   #a:Type -> {| parseable_serializeable bytes a |} ->
   communication_keys_sess_ids ->
@@ -182,6 +189,7 @@ let receive_authenticated #a comm_keys_ids receiver msg_id =
 
 (**** Confidential and Authenticates Send and Receive Functions ****)
 
+[@@ "opaque_to_smt"]
 val encrypt_and_sign_message:
   #a:Type -> {| parseable_serializeable bytes a |} ->
   principal -> principal -> a -> bytes -> bytes -> bytes -> bytes -> bytes
@@ -193,6 +201,7 @@ let encrypt_and_sign_message #a sender receiver payload pk_receiver sk_sender en
 // they can also be identified by the IP addresses or certificates they use.
 // Having the sender and receiver as plaintext allows us to reuse the functions
 // to create and parse confidential and authenticated messages.
+[@@ "opaque_to_smt"]
 val send_confidential_authenticated:
   #a:Type -> {| parseable_serializeable bytes a |} ->
   communication_keys_sess_ids ->
@@ -209,6 +218,7 @@ let send_confidential_authenticated #a comm_keys_ids sender receiver payload =
   let* msg_id = send_msg msg_encrypted_signed_bytes in
   return (Some msg_id)
 
+[@@ "opaque_to_smt"]
 val verify_and_decrypt_message:
   #a:Type -> {| parseable_serializeable bytes a |} ->
   principal -> bytes -> bytes -> bytes -> option (communication_message a)
@@ -217,6 +227,7 @@ let verify_and_decrypt_message #a #ps receiver sk_receiver vk_sender msg_encrypt
   let? payload:a = decrypt_message #a sk_receiver cm.payload.b in
   Some {sender=cm.sender; receiver=cm.receiver; payload}
 
+[@@ "opaque_to_smt"]
 val receive_confidential_authenticated:
   #a:Type -> {| parseable_serializeable bytes a |} ->
   communication_keys_sess_ids ->

--- a/src/lib/communication/DY.Lib.Communication.RequestResponse.fst
+++ b/src/lib/communication/DY.Lib.Communication.RequestResponse.fst
@@ -98,6 +98,7 @@ type comm_meta_data = {
 
 (*** API ***)
 
+[@@ "opaque_to_smt"]
 val send_request:
   #a:Type -> {| parseable_serializeable bytes a |} ->
   communication_keys_sess_ids ->
@@ -114,6 +115,7 @@ let send_request #a comm_keys_ids client server request =
   let req_meta_data = {key; server; sid; request=payload_bytes} in
   return (Some (msg_id, req_meta_data))
 
+[@@ "opaque_to_smt"]
 val receive_request:
   #a:Type -> {| parseable_serializeable bytes a |} ->
   communication_keys_sess_ids ->
@@ -130,12 +132,14 @@ let receive_request #a comm_keys_ids server msg_id =
   let req_meta_data = {key=req_msg.key; server; sid; request=req_msg.request} in
   return (Some (request, req_meta_data))
 
+[@@ "opaque_to_smt"]
 val mk_comm_layer_response_nonce: comm_meta_data -> usage -> traceful (option bytes)
 let mk_comm_layer_response_nonce req_meta_data usg =
   let* tr = get_trace in
   let* nonce = mk_rand usg (get_label #default_crypto_usages tr req_meta_data.key) 32 in
   return (Some nonce)
 
+[@@ "opaque_to_smt"]
 val mk_comm_layer_response_nonce_labeled: comm_meta_data -> usage -> label -> traceful (option bytes)
 let mk_comm_layer_response_nonce_labeled req_meta_data usg lab =
   let* tr = get_trace in
@@ -143,6 +147,7 @@ let mk_comm_layer_response_nonce_labeled req_meta_data usg lab =
   let* nonce = mk_rand usg lab_join 32 in
   return (Some nonce)
 
+[@@ "opaque_to_smt"]
 val compute_response_message:
   #a:Type -> {| parseable_serializeable bytes a |} ->
   principal -> bytes -> bytes -> a -> bytes
@@ -153,6 +158,7 @@ let compute_response_message #a server key nonce response =
   let ciphertext = aead_enc key nonce res_bytes ad_bytes in
   serialize com_message_t (ResponseMessage {nonce; ciphertext})
 
+[@@ "opaque_to_smt"]
 val send_response:
   #a:Type -> {| parseable_serializeable bytes a |} ->
   principal -> comm_meta_data -> a -> traceful (option timestamp)
@@ -168,6 +174,7 @@ let send_response #a server req_meta_data response =
   let* msg_id = send_msg resp_msg in
   return (Some msg_id)
 
+[@@ "opaque_to_smt"]
 val decode_response_message:
   #a:Type -> {| parseable_serializeable bytes a |} ->
   principal -> bytes -> bytes -> option a
@@ -181,6 +188,7 @@ let decode_response_message #a server key msg_bytes =
   let? resp = parse a resp_bytes in
   Some resp
 
+[@@ "opaque_to_smt"]
 val receive_response:
   #a:Type -> {| parseable_serializeable bytes a |} ->
   principal -> comm_meta_data -> timestamp ->


### PR DESCRIPTION
This PR has two main components:
- First, to make most of the communication layer opaque to the SMT solver, so that when we reason about the behaviour of the communication functions, we only get the information included in their specification lemmas, not the full details of how everything is computed.
- Second, adding SMT patterns to the communication layer core, as for the request response lemmas, so that they can be automatically triggered in the right circumstances.

I've also cleaned up end-of-line spaces as encountered, but this isn't a semantic change.

As of right now, all of the user-facing core functions are successfully opaque, as are most of the other core functions, but I haven't been able to make `verify_message` opaque without breaking proofs, even when revealing it. I think this is at least passable for now, since the users of the library shouldn't be aware of `verify_message` to begin with, but ideally we would be able to clean this up as well.

The request/response functions are also not yet opaque --- that will follow as a further part of this PR.