### PR TITLE
cleanup: reduce boilerplate to merge local predicates

### DIFF
--- a/examples/iso_dh/DY.Example.DH.Protocol.Stateful.Proof.fst
+++ b/examples/iso_dh/DY.Example.DH.Protocol.Stateful.Proof.fst
@@ -90,13 +90,13 @@ let dh_event_pred: event_predicate dh_event =
 let all_sessions = [
   pki_tag_and_invariant;
   private_keys_tag_and_invariant;
-  (|local_state_dh_session.tag, local_state_predicate_to_local_bytes_state_predicate dh_session_pred|);
+  mk_local_state_tag_and_pred dh_session_pred;
 ]
 
 /// List of all local event predicates.
 
 let all_events = [
-  (dh_event_instance.tag, compile_event_pred dh_event_pred)
+  mk_event_tag_and_pred dh_event_pred;
 ]
 
 /// Create the global trace invariants.
@@ -113,39 +113,8 @@ instance dh_protocol_invs: protocol_invariants = {
 
 /// Lemmas that the global state predicate contains all the local ones
 
-// Below, the `has_..._predicate` are called with the implicit argument `#dh_protocol_invs`.
-// This argument could be omitted as it can be instantiated automatically by F*'s typeclass resolution algorithm.
-// However we instantiate it explicitly here so that the meaning of `has_..._predicate` is easier to understand.
-
-val all_sessions_has_all_sessions: unit -> Lemma (norm [delta_only [`%all_sessions; `%for_allP]; iota; zeta] (for_allP (has_local_bytes_state_predicate #dh_protocol_invs) all_sessions))
-let all_sessions_has_all_sessions () =
-  assert_norm(List.Tot.no_repeats_p (List.Tot.map dfst (all_sessions)));
-  mk_state_pred_correct #dh_protocol_invs all_sessions;
-  norm_spec [delta_only [`%all_sessions; `%for_allP]; iota; zeta] (for_allP (has_local_bytes_state_predicate #dh_protocol_invs) all_sessions)
-
-val full_dh_session_pred_has_pki_invariant: squash (has_pki_invariant #dh_protocol_invs)
-let full_dh_session_pred_has_pki_invariant = all_sessions_has_all_sessions ()
-
-val full_dh_session_pred_has_private_keys_invariant: squash (has_private_keys_invariant #dh_protocol_invs)
-let full_dh_session_pred_has_private_keys_invariant = all_sessions_has_all_sessions ()
-
-// As an example, below `#dh_protocol_invs` is omitted and instantiated using F*'s typeclass resolution algorithm
-val full_dh_session_pred_has_dh_invariant: squash (has_local_state_predicate dh_session_pred)
-let full_dh_session_pred_has_dh_invariant = all_sessions_has_all_sessions ()
-
-/// Lemmas that the global event predicate contains all the local ones
-
-val all_events_has_all_events: unit -> Lemma (norm [delta_only [`%all_events; `%for_allP]; iota; zeta] (for_allP (has_compiled_event_pred #dh_protocol_invs) all_events))
-let all_events_has_all_events () =
-  assert_norm(List.Tot.no_repeats_p (List.Tot.map fst (all_events)));
-  mk_event_pred_correct #dh_protocol_invs all_events;
-  norm_spec [delta_only [`%all_events; `%for_allP]; iota; zeta] (for_allP (has_compiled_event_pred #dh_protocol_invs) all_events);
-  let dumb_lemma (x:prop) (y:prop): Lemma (requires x /\ x == y) (ensures y) = () in
-  dumb_lemma (for_allP (has_compiled_event_pred #dh_protocol_invs) all_events) (norm [delta_only [`%all_events; `%for_allP]; iota; zeta] (for_allP (has_compiled_event_pred #dh_protocol_invs) all_events))
-
-// As an example, below `#dh_protocol_invs` is omitted and instantiated using F*'s typeclass resolution algorithm
-val full_dh_event_pred_has_dh_invariant: squash (has_event_pred dh_event_pred)
-let full_dh_event_pred_has_dh_invariant = all_events_has_all_events ()
+let _ = do_boilerplate mk_state_pred_correct all_sessions
+let _ = do_boilerplate mk_event_pred_correct all_events
 
 (*** Proofs ****)
 

--- a/examples/iso_dh/DY.Example.DH.Protocol.Stateful.Proof.fst
+++ b/examples/iso_dh/DY.Example.DH.Protocol.Stateful.Proof.fst
@@ -113,8 +113,8 @@ instance dh_protocol_invs: protocol_invariants = {
 
 /// Lemmas that the global state predicate contains all the local ones
 
-let _ = do_boilerplate mk_state_pred_correct all_sessions
-let _ = do_boilerplate mk_event_pred_correct all_events
+let _ = do_split_boilerplate mk_state_pred_correct all_sessions
+let _ = do_split_boilerplate mk_event_pred_correct all_events
 
 (*** Proofs ****)
 

--- a/examples/nsl_pk/DY.Example.NSL.Protocol.Stateful.Proof.fst
+++ b/examples/nsl_pk/DY.Example.NSL.Protocol.Stateful.Proof.fst
@@ -105,8 +105,8 @@ instance protocol_invariants_nsl: protocol_invariants = {
 
 /// Lemmas that the global state predicate contains all the local ones
 
-let _ = do_boilerplate mk_state_pred_correct all_sessions
-let _ = do_boilerplate mk_event_pred_correct all_events
+let _ = do_split_boilerplate mk_state_pred_correct all_sessions
+let _ = do_split_boilerplate mk_event_pred_correct all_events
 
 (*** Proofs ***)
 

--- a/examples/nsl_pk/DY.Example.NSL.Protocol.Stateful.Proof.fst
+++ b/examples/nsl_pk/DY.Example.NSL.Protocol.Stateful.Proof.fst
@@ -82,13 +82,13 @@ let event_predicate_nsl: event_predicate nsl_event =
 let all_sessions = [
   pki_tag_and_invariant;
   private_keys_tag_and_invariant;
-  (|local_state_nsl_session.tag, local_state_predicate_to_local_bytes_state_predicate state_predicate_nsl|);
+  mk_local_state_tag_and_pred state_predicate_nsl;
 ]
 
 /// List of all local event predicates.
 
 let all_events = [
-  (event_nsl_event.tag, compile_event_pred event_predicate_nsl)
+  mk_event_tag_and_pred event_predicate_nsl;
 ]
 
 /// Create the global trace invariants.
@@ -105,39 +105,8 @@ instance protocol_invariants_nsl: protocol_invariants = {
 
 /// Lemmas that the global state predicate contains all the local ones
 
-// Below, the `has_..._predicate` are called with the implicit argument `#protocol_invariants_nsl`.
-// This argument could be omitted as it can be instantiated automatically by F*'s typeclass resolution algorithm.
-// However we instantiate it explicitly here so that the meaning of `has_..._predicate` is easier to understand.
-
-val all_sessions_has_all_sessions: unit -> Lemma (norm [delta_only [`%all_sessions; `%for_allP]; iota; zeta] (for_allP (has_local_bytes_state_predicate #protocol_invariants_nsl) all_sessions))
-let all_sessions_has_all_sessions () =
-  assert_norm(List.Tot.no_repeats_p (List.Tot.map dfst (all_sessions)));
-  mk_state_pred_correct #protocol_invariants_nsl all_sessions;
-  norm_spec [delta_only [`%all_sessions; `%for_allP]; iota; zeta] (for_allP (has_local_bytes_state_predicate #protocol_invariants_nsl) all_sessions)
-
-val protocol_invariants_nsl_has_pki_invariant: squash (has_pki_invariant #protocol_invariants_nsl)
-let protocol_invariants_nsl_has_pki_invariant = all_sessions_has_all_sessions ()
-
-val protocol_invariants_nsl_has_private_keys_invariant: squash (has_private_keys_invariant #protocol_invariants_nsl)
-let protocol_invariants_nsl_has_private_keys_invariant = all_sessions_has_all_sessions ()
-
-// As an example, below `#protocol_invariants_nsl` is omitted and instantiated using F*'s typeclass resolution algorithm
-val protocol_invariants_nsl_has_nsl_session_invariant: squash (has_local_state_predicate state_predicate_nsl)
-let protocol_invariants_nsl_has_nsl_session_invariant = all_sessions_has_all_sessions ()
-
-/// Lemmas that the global event predicate contains all the local ones
-
-val all_events_has_all_events: unit -> Lemma (norm [delta_only [`%all_events; `%for_allP]; iota; zeta] (for_allP (has_compiled_event_pred #protocol_invariants_nsl) all_events))
-let all_events_has_all_events () =
-  assert_norm(List.Tot.no_repeats_p (List.Tot.map fst (all_events)));
-  mk_event_pred_correct #protocol_invariants_nsl all_events;
-  norm_spec [delta_only [`%all_events; `%for_allP]; iota; zeta] (for_allP (has_compiled_event_pred #protocol_invariants_nsl) all_events);
-  let dumb_lemma (x:prop) (y:prop): Lemma (requires x /\ x == y) (ensures y) = () in
-  dumb_lemma (for_allP (has_compiled_event_pred #protocol_invariants_nsl) all_events) (norm [delta_only [`%all_events; `%for_allP]; iota; zeta] (for_allP (has_compiled_event_pred #protocol_invariants_nsl) all_events))
-
-// As an example, below `#protocol_invariants_nsl` is omitted and instantiated using F*'s typeclass resolution algorithm
-val protocol_invariants_nsl_has_nsl_event_invariant: squash (has_event_pred event_predicate_nsl)
-let protocol_invariants_nsl_has_nsl_event_invariant = all_events_has_all_events ()
+let _ = do_boilerplate mk_state_pred_correct all_sessions
+let _ = do_boilerplate mk_event_pred_correct all_events
 
 (*** Proofs ***)
 

--- a/src/lib/event/DY.Lib.Event.Typed.fst
+++ b/src/lib/event/DY.Lib.Event.Typed.fst
@@ -80,17 +80,25 @@ let compile_event_pred #a #ev epred tr prin content_bytes =
   | None -> False
   | Some(content) -> epred tr prin content
 
+val mk_event_tag_and_pred:
+  #a:Type0 -> {|event a|} ->
+  event_predicate a ->
+  string & compiled_event_predicate
+let mk_event_tag_and_pred #a #ev_a epred =
+  (ev_a.tag, compile_event_pred epred)
+
 [@@ "opaque_to_smt"]
 val has_compiled_event_pred:
   {|protocol_invariants|} -> (string & compiled_event_predicate) -> prop
 let has_compiled_event_pred #invs (tag, epred) =
   has_local_fun split_event_pred_params event_pred (|tag, epred|)
 
+unfold
 val has_event_pred:
   #a:Type0 -> {|event a|} ->
   {|protocol_invariants|} -> event_predicate a -> prop
 let has_event_pred #a #ev #invs epred =
-  has_compiled_event_pred (ev.tag, compile_event_pred epred)
+  has_compiled_event_pred (mk_event_tag_and_pred epred)
 
 (*** Global event predicate builder ***)
 

--- a/src/lib/state/DY.Lib.State.Map.fst
+++ b/src/lib/state/DY.Lib.State.Map.fst
@@ -122,11 +122,19 @@ let map_session_invariant #cinvs #key_t #value_t #mt mpred = {
   );
 }
 
+val mk_map_state_tag_and_pred:
+  #key_t:eqtype -> #value_t:Type0 -> {|map_types key_t value_t|} ->
+  {|crypto_invariants|} -> map_predicate key_t value_t ->
+  dtuple2 string local_bytes_state_predicate
+let mk_map_state_tag_and_pred #key_t #value_t #mt #cinvs mpred =
+  mk_local_state_tag_and_pred (map_session_invariant mpred)
+
+unfold
 val has_map_session_invariant:
   #key_t:eqtype -> #value_t:Type0 -> {|map_types key_t value_t|} ->
   {|protocol_invariants|} -> map_predicate key_t value_t -> prop
 let has_map_session_invariant #key_t #value_t #mt #invs mpred =
-  has_local_state_predicate (map_session_invariant mpred)
+  has_local_bytes_state_predicate (mk_map_state_tag_and_pred mpred)
 
 (*** Map API ***)
 

--- a/src/lib/state/DY.Lib.State.PKI.fst
+++ b/src/lib/state/DY.Lib.State.PKI.fst
@@ -56,12 +56,13 @@ let pki_pred #cinvs = {
   pred_knowable = (fun tr prin sess_id key value -> ());
 }
 
+val pki_tag_and_invariant: {|crypto_invariants|} -> dtuple2 string local_bytes_state_predicate
+let pki_tag_and_invariant #ci = mk_map_state_tag_and_pred pki_pred
+
+unfold
 val has_pki_invariant: {|protocol_invariants|} -> prop
 let has_pki_invariant #invs =
-  has_map_session_invariant pki_pred
-
-val pki_tag_and_invariant: {|crypto_invariants|} -> dtuple2 string local_bytes_state_predicate
-let pki_tag_and_invariant #ci = (|map_types_pki.tag, local_state_predicate_to_local_bytes_state_predicate (map_session_invariant pki_pred)|)
+  has_local_bytes_state_predicate pki_tag_and_invariant
 
 (*** PKI API ***)
 

--- a/src/lib/state/DY.Lib.State.PrivateKeys.fst
+++ b/src/lib/state/DY.Lib.State.PrivateKeys.fst
@@ -102,12 +102,13 @@ let private_keys_pred #cinvs = {
 }
 #pop-options
 
+val private_keys_tag_and_invariant: {|crypto_invariants|} -> dtuple2 string local_bytes_state_predicate
+let private_keys_tag_and_invariant #ci = mk_map_state_tag_and_pred private_keys_pred
+
+unfold
 val has_private_keys_invariant: {|protocol_invariants|} -> prop
 let has_private_keys_invariant #invs =
-  has_map_session_invariant private_keys_pred
-
-val private_keys_tag_and_invariant: {|crypto_invariants|} -> dtuple2 string local_bytes_state_predicate
-let private_keys_tag_and_invariant #ci = (|map_types_private_keys.tag, local_state_predicate_to_local_bytes_state_predicate (map_session_invariant private_keys_pred)|)
+  has_local_bytes_state_predicate private_keys_tag_and_invariant
 
 (*** Private Keys API ***)
 

--- a/src/lib/state/DY.Lib.State.Typed.fst
+++ b/src/lib/state/DY.Lib.State.Typed.fst
@@ -141,12 +141,20 @@ let local_state_predicate_to_local_bytes_state_predicate #cinvs #a #ps_a tspred 
     );
   }
 
+val mk_local_state_tag_and_pred:
+  #a:Type -> {|local_state a|} ->
+  {|crypto_invariants|} -> local_state_predicate a ->
+  dtuple2 string local_bytes_state_predicate
+let mk_local_state_tag_and_pred #a #ls_a #cinvs spred =
+  (|ls_a.tag, (local_state_predicate_to_local_bytes_state_predicate spred)|)
+
+unfold
 val has_local_state_predicate:
   #a:Type -> {|local_state a|} ->
   {|protocol_invariants|} -> local_state_predicate a ->
   prop
 let has_local_state_predicate #a #ls #invs spred =
-  has_local_bytes_state_predicate (|ls.tag, (local_state_predicate_to_local_bytes_state_predicate spred)|)
+  has_local_bytes_state_predicate (mk_local_state_tag_and_pred spred)
 
 [@@ "opaque_to_smt"]
 val state_was_set:


### PR DESCRIPTION
Fixes #37.

This uses an approach similar to #40 with `unfold`s, but is less aggressive in the unfolding hence I am confident this scales well (contrary to #40 whose unfolded SMT patterns could grow big).

The reason we have a lot of boilerplate in the examples is that although we prove `has_local_bytes_state_predicate pki_tag_and_invariant` (post-condition of `mk_state_pred_correct`), the SMT patterns are on `has_pki_invariant`, which although equivalent is not the same term, hence are different with respect to SMT patterns.

To solve this problem, the idea is that `has_..._state_predicate` now unfolds to `has_local_bytes_state_predicate tag_and_pred`, where `tag_and_pred` is specific to the state we are currently dealing with. It's nice for two reasons:
- `tag_and_pred` is not unfolded, hence its expression can be big, that's no problem
- the `mk_state_pred_correct` lemma post-condition is about `has_local_bytes_state_predicate`, which is what the (unfolded) SMT pattern are about

The other type of boilerplate we have is that we always normalize the `for_allP` in the post-condition of `mk_state_pred_correct` to transform it into `... /\ ... /\ ...`, and we also normalize the `no_repeats_p` in its pre-condition.
This PR introduces the `do_boilerplate` function which does some F* wizardry to do that for us.