### PR TITLE
cleanup: re-center labels around `is_corrupt`

### DIFF
--- a/src/core/DY.Core.Attacker.Knowledge.fst
+++ b/src/core/DY.Core.Attacker.Knowledge.fst
@@ -196,7 +196,7 @@ val corrupted_state_is_publishable:
   (ensures is_publishable tr content)
 let corrupted_state_is_publishable #invs tr prin sess_id content =
   state_is_knowable_by tr prin sess_id content;
-  state_pred_label_can_flow_public tr (principal_state_content_label_input prin sess_id content)
+  is_corrupt_state_pred_label tr (principal_state_content_label_input prin sess_id content)
 
 #push-options "--z3rlimit 25"
 val attacker_only_knows_publishable_values_aux:

--- a/src/core/DY.Core.Label.Derived.fst
+++ b/src/core/DY.Core.Label.Derived.fst
@@ -97,12 +97,7 @@ val join_associative:
   Lemma
   (((l1 `join` l2) `join` l3) == (l1 `join` (l2 `join` l3)))
 let join_associative l1 l2 l3 =
-  intro_label_equal ((l1 `join` l2) `join` l3) (l1 `join` (l2 `join` l3)) (fun tr ->
-    join_flows_to_left tr (l1 `join` l2) l3;
-    join_eq tr l1 (l2 `join` l3) ((l1 `join` l2) `join` l3);
-    join_flows_to_right tr l1 (l2 `join` l3);
-    join_eq tr (l1 `join` l2) l3 (l1 `join` (l2 `join` l3))
-  )
+  intro_label_equal ((l1 `join` l2) `join` l3) (l1 `join` (l2 `join` l3)) (fun tr -> ())
 
 val join_commutes:
   l1:label -> l2:label ->
@@ -146,12 +141,7 @@ val meet_associative:
   Lemma
   (((l1 `meet` l2) `meet` l3) == (l1 `meet` (l2 `meet` l3)))
 let meet_associative l1 l2 l3 =
-  intro_label_equal ((l1 `meet` l2) `meet` l3) (l1 `meet` (l2 `meet` l3)) (fun tr ->
-    left_flows_to_meet tr (l1 `meet` l2) l3;
-    meet_eq tr ((l1 `meet` l2) `meet` l3) l1 (l2 `meet` l3);
-    right_flows_to_meet tr l1 (l2 `meet` l3);
-    meet_eq tr (l1 `meet` (l2 `meet` l3)) (l1 `meet` l2) l3
-  )
+  intro_label_equal ((l1 `meet` l2) `meet` l3) (l1 `meet` (l2 `meet` l3)) (fun tr -> ())
 
 val meet_commutes:
   tr:trace ->

--- a/src/core/DY.Core.Label.fst
+++ b/src/core/DY.Core.Label.fst
@@ -123,67 +123,31 @@ let can_flow tr l1 l2 =
   forall tr_extended. tr <$ tr_extended ==>
     (is_corrupt tr_extended l2 ==> is_corrupt tr_extended l1)
 
-/// Extensionality theorems for labels
+val intro_can_flow:
+  tr:trace -> l1:label -> l2:label -> (
+    tr_extended:trace ->
+    Lemma
+    (requires tr <$ tr_extended /\ is_corrupt tr_extended l2)
+    (ensures is_corrupt tr_extended l1)
+  ) ->
+  Lemma (l1 `can_flow tr` l2)
+let intro_can_flow tr l1 l2 pf =
+  reveal_opaque (`%can_flow) (l1 `can_flow tr` l2);
+  FStar.Classical.forall_intro (FStar.Classical.move_requires pf)
 
-val intro_label_equal:
-  l1:label -> l2:label ->
-  (tr:trace -> Lemma (l1 `can_flow tr` l2 /\ l2 `can_flow tr` l1)) ->
-  Lemma (l1 == l2)
-let intro_label_equal l1 l2 pf =
-  let open DY.Core.Label.Unknown in
-  reveal_opaque (`%can_flow) can_flow;
-  reveal_opaque (`%is_corrupt) is_corrupt;
-  introduce forall tr. l1.is_corrupt tr == l2.is_corrupt tr with (
-    pf (fmap_trace (replace_label unknown_label) tr);
-    // These two lines prove surjectivity of `trace_forget_labels`
-    // by showing that fmap_trace (forget_label public) is a right-inverse
-    // (we could replace `unknown_label` with anything)
-    fmap_trace_compose (replace_label unknown_label) forget_label forget_label tr;
-    fmap_trace_identity forget_label tr;
-    FStar.PropositionalExtensionality.apply (l1.is_corrupt tr) (l2.is_corrupt tr)
-  );
-  assert(l1.is_corrupt `FStar.FunctionalExtensionality.feq` l2.is_corrupt);
-  assert(l1.is_corrupt == l2.is_corrupt);
-  assert(l1.is_corrupt_later == l2.is_corrupt_later);
-  ()
-
-
-/// Functions to create labels.
-/// They are useful so that the label type can remain abstract to the user.
-
-[@@"opaque_to_smt"]
-val secret: label
-let secret = mk_label {
-  is_corrupt = (fun tr -> False);
-  is_corrupt_later = (fun tr1 tr2 -> ());
-}
-
-[@@"opaque_to_smt"]
-val public: label
-let public = mk_label {
-  is_corrupt = (fun tr -> True);
-  is_corrupt_later = (fun tr1 tr2 -> ());
-}
-
-[@@"opaque_to_smt"]
-val meet: label -> label -> label
-let meet l1 l2 = mk_label {
-  is_corrupt = (fun tr -> l1.is_corrupt tr /\ l2.is_corrupt tr);
-  is_corrupt_later = (fun tr1 tr2 ->
-    label_is_corrupt_later l1 tr1 tr2;
-    label_is_corrupt_later l2 tr1 tr2
-  );
-}
-
-[@@"opaque_to_smt"]
-val join: label -> label -> label
-let join l1 l2 = mk_label {
-  is_corrupt = (fun tr -> l1.is_corrupt tr \/ l2.is_corrupt tr);
-  is_corrupt_later = (fun tr1 tr2 ->
-    FStar.Classical.move_requires_3 label_is_corrupt_later l1 tr1 tr2;
-    FStar.Classical.move_requires_3 label_is_corrupt_later l2 tr1 tr2
-  );
-}
+val elim_can_flow:
+  tr:trace -> l1:label -> l2:label ->
+  Lemma
+  (requires
+    l1 `can_flow tr` l2 /\
+    is_corrupt tr l2
+  )
+  (ensures is_corrupt tr l1)
+  [SMTPat (l1 `can_flow tr` l2);
+   SMTPat (is_corrupt tr l2);
+  ]
+let elim_can_flow tr l1 l2 =
+  reveal_opaque (`%can_flow) (l1 `can_flow tr` l2)
 
 /// `can_flow tr` is reflexive.
 
@@ -218,7 +182,48 @@ val can_flow_later:
 let can_flow_later tr1 tr2 l1 l2 =
   reveal_opaque (`%can_flow) (can_flow)
 
-/// `secret` is the minimum of the label lattice.
+/// Extensionality theorems for labels
+
+val intro_label_equal:
+  l1:label -> l2:label ->
+  (tr:trace -> Lemma (is_corrupt tr l1 <==> is_corrupt tr l2)) ->
+  Lemma (l1 == l2)
+let intro_label_equal l1 l2 pf =
+  let open DY.Core.Label.Unknown in
+  reveal_opaque (`%can_flow) can_flow;
+  reveal_opaque (`%is_corrupt) is_corrupt;
+  introduce forall tr. l1.is_corrupt tr == l2.is_corrupt tr with (
+    pf (fmap_trace (replace_label unknown_label) tr);
+    // These two lines prove surjectivity of `trace_forget_labels`
+    // by showing that fmap_trace (forget_label public) is a right-inverse
+    // (we could replace `unknown_label` with anything)
+    fmap_trace_compose (replace_label unknown_label) forget_label forget_label tr;
+    fmap_trace_identity forget_label tr;
+    FStar.PropositionalExtensionality.apply (l1.is_corrupt tr) (l2.is_corrupt tr)
+  );
+  assert(l1.is_corrupt `FStar.FunctionalExtensionality.feq` l2.is_corrupt);
+  assert(l1.is_corrupt == l2.is_corrupt);
+  assert(l1.is_corrupt_later == l2.is_corrupt_later);
+  ()
+
+
+/// Secret label, the minimum of the label lattice.
+
+[@@"opaque_to_smt"]
+val secret: label
+let secret = mk_label {
+  is_corrupt = (fun tr -> False);
+  is_corrupt_later = (fun tr1 tr2 -> ());
+}
+
+val is_corrupt_secret:
+  tr:trace ->
+  Lemma
+  (ensures ~(is_corrupt tr secret))
+  [SMTPat (is_corrupt tr secret)]
+let is_corrupt_secret tr =
+  reveal_opaque (`%secret) secret;
+  reveal_opaque (`%is_corrupt) is_corrupt
 
 val secret_is_bottom:
   tr:trace -> l:label ->
@@ -226,11 +231,26 @@ val secret_is_bottom:
   (ensures l `can_flow tr` secret)
   [SMTPat (l `can_flow tr` secret)]
 let secret_is_bottom tr l =
-  reveal_opaque (`%can_flow) can_flow;
-  reveal_opaque (`%secret) secret;
-  reveal_opaque (`%is_corrupt) is_corrupt
+  intro_can_flow tr l secret
+    (fun tr' -> is_corrupt_secret tr')
 
-/// `public` is the maximum of the label lattice.
+/// Public label, the maximum of the label lattice.
+
+[@@"opaque_to_smt"]
+val public: label
+let public = mk_label {
+  is_corrupt = (fun tr -> True);
+  is_corrupt_later = (fun tr1 tr2 -> ());
+}
+
+val is_corrupt_public:
+  tr:trace ->
+  Lemma
+  (ensures is_corrupt tr public)
+  [SMTPat (is_corrupt tr public)]
+let is_corrupt_public tr =
+  reveal_opaque (`%public) public;
+  reveal_opaque (`%is_corrupt) is_corrupt
 
 val public_is_top:
   tr:trace -> l:label ->
@@ -238,11 +258,41 @@ val public_is_top:
   (ensures public `can_flow tr` l)
   [SMTPat (public `can_flow tr` l)]
 let public_is_top tr l =
-  reveal_opaque (`%can_flow) can_flow;
-  reveal_opaque (`%public) public;
-  reveal_opaque (`%is_corrupt) is_corrupt
+  intro_can_flow tr public l
+    (fun tr' -> is_corrupt_public tr')
 
-/// `meet` satisfy the lower bound property.
+/// A label flows to `public` iff. it is corrupt.
+
+val flow_to_public_eq:
+  tr:trace -> l:label ->
+  Lemma
+  (ensures l `can_flow tr` public <==> is_corrupt tr l)
+  [SMTPat (l `can_flow tr` public)]
+let flow_to_public_eq tr prin =
+  reveal_opaque (`%is_corrupt) (is_corrupt);
+  reveal_opaque (`%can_flow) (can_flow);
+  reveal_opaque (`%public) (public)
+
+/// Meet label, the lower bound of the label lattice.
+
+[@@"opaque_to_smt"]
+val meet: label -> label -> label
+let meet l1 l2 = mk_label {
+  is_corrupt = (fun tr -> l1.is_corrupt tr /\ l2.is_corrupt tr);
+  is_corrupt_later = (fun tr1 tr2 ->
+    label_is_corrupt_later l1 tr1 tr2;
+    label_is_corrupt_later l2 tr1 tr2
+  );
+}
+
+val is_corrupt_meet:
+  tr:trace -> l1:label -> l2:label ->
+  Lemma
+  (ensures is_corrupt tr (meet l1 l2) <==> is_corrupt tr l1 /\ is_corrupt tr l2)
+  [SMTPat (is_corrupt tr (meet l1 l2))]
+let is_corrupt_meet tr l1 l2 =
+  reveal_opaque (`%is_corrupt) (is_corrupt);
+  reveal_opaque (`%meet) (meet)
 
 val meet_eq:
   tr:trace -> x:label -> y1:label -> y2:label ->
@@ -254,7 +304,26 @@ let meet_eq tr x y1 y2 =
   reveal_opaque (`%can_flow) (can_flow);
   reveal_opaque (`%meet) (meet)
 
-/// `join` satisfy the upper bound property.
+/// Join label, the upper bound of the label lattice.
+
+[@@"opaque_to_smt"]
+val join: label -> label -> label
+let join l1 l2 = mk_label {
+  is_corrupt = (fun tr -> l1.is_corrupt tr \/ l2.is_corrupt tr);
+  is_corrupt_later = (fun tr1 tr2 ->
+    FStar.Classical.move_requires_3 label_is_corrupt_later l1 tr1 tr2;
+    FStar.Classical.move_requires_3 label_is_corrupt_later l2 tr1 tr2
+  );
+}
+
+val is_corrupt_join:
+  tr:trace -> x1:label -> x2:label ->
+  Lemma
+  (ensures is_corrupt tr (join x1 x2) <==> is_corrupt tr x1 \/ is_corrupt tr x2)
+  [SMTPat (is_corrupt tr (join x1 x2))]
+let is_corrupt_join tr x1 x2 =
+  reveal_opaque (`%is_corrupt) is_corrupt;
+  reveal_opaque (`%join) (join)
 
 val join_eq:
   tr:trace -> x1:label -> x2:label -> y:label ->
@@ -265,35 +334,6 @@ let join_eq tr x1 x2 y =
   reveal_opaque (`%is_corrupt) (is_corrupt);
   reveal_opaque (`%can_flow) (can_flow);
   reveal_opaque (`%join) (join)
-
-/// A label flows to `public` iff. it is corrupt.
-
-val flow_to_public_eq:
-  tr:trace -> l:label ->
-  Lemma
-  (ensures l `can_flow tr` public <==> is_corrupt tr l)
-  [SMTPat (is_corrupt tr l)]
-let flow_to_public_eq tr prin =
-  reveal_opaque (`%is_corrupt) (is_corrupt);
-  reveal_opaque (`%can_flow) (can_flow);
-  reveal_opaque (`%public) (public)
-
-/// A `join` flows to `public` iff. one of its operands flows to `public`.
-/// This is a property specific to labels,
-/// that is not implied by the standard lattice properties.
-
-val join_flow_to_public_eq:
-  tr:trace -> x1:label -> x2:label ->
-  Lemma
-  (ensures (join x1 x2) `can_flow tr` public <==> x1 `can_flow tr` public \/ x2 `can_flow tr` public)
-  [SMTPat ((join x1 x2) `can_flow tr` public)]
-let join_flow_to_public_eq tr x1 x2 =
-  flow_to_public_eq tr x1;
-  flow_to_public_eq tr x2;
-  reveal_opaque (`%is_corrupt) is_corrupt;
-  reveal_opaque (`%can_flow) (can_flow);
-  reveal_opaque (`%join) (join);
-  reveal_opaque (`%public) (public)
 
 /// Generic label for states:
 /// `state_pred_label p` is corrupt when
@@ -337,19 +377,18 @@ let state_pred_label_can_flow_state_pred_label tr p1 p2 =
   reveal_opaque (`%can_flow) (can_flow);
   reveal_opaque (`%state_pred_label) (state_pred_label)
 
-val state_pred_label_can_flow_public:
+val is_corrupt_state_pred_label:
   tr:trace ->
   p:state_pred_label_input ->
   Lemma (
-    (state_pred_label p) `can_flow tr` public
+    is_corrupt tr (state_pred_label p)
     <==> (
       exists prin sess_id content.
         state_was_corrupt tr prin sess_id content /\
         p prin sess_id content
     )
   )
-let state_pred_label_can_flow_public tr p =
-  flow_to_public_eq tr (state_pred_label p);
+let is_corrupt_state_pred_label tr p =
   reveal_opaque (`%is_corrupt) is_corrupt;
   reveal_opaque (`%state_pred_label) (state_pred_label);
   FStar.Classical.forall_intro (FStar.Classical.move_requires (entry_exists_fmap_trace_eq forget_label tr));

--- a/src/core/DY.Core.Trace.Manipulation.fst
+++ b/src/core/DY.Core.Trace.Manipulation.fst
@@ -547,7 +547,7 @@ val trigger_event: principal -> string -> bytes -> traceful unit
 let trigger_event prin tag content =
   add_entry (Event prin tag content)
 
-#push-options "--z3rlimit 30"
+#push-options "--z3rlimit 25 --ifuel 2"
 val trigger_event_event_triggered:
   prin:principal -> tag:string -> content:bytes -> tr:trace ->
   Lemma

--- a/src/lib/state/DY.Lib.State.Tagged.fst
+++ b/src/lib/state/DY.Lib.State.Tagged.fst
@@ -68,20 +68,20 @@ let tagged_state_pred_label_input_allow_inversion p1 p2 =
   allow_inversion (option tagged_state);
   allow_inversion (tagged_state)
 
-val tagged_state_pred_label_can_flow_public:
+val is_corrupt_tagged_state_pred_label:
   tr:trace ->
   p:tagged_state_pred_label_input ->
   Lemma (
-    tagged_state_pred_label p `can_flow tr` public
+    is_corrupt tr (tagged_state_pred_label p)
     <==> (
       exists prin tag sid content.
         tagged_state_was_corrupt tr prin tag sid content /\
         p prin tag sid content
     )
   )
-let tagged_state_pred_label_can_flow_public tr p =
+let is_corrupt_tagged_state_pred_label tr p =
   FStar.Classical.forall_intro (FStar.Classical.move_requires (serialize_parse_inv_lemma #bytes tagged_state));
-  state_pred_label_can_flow_public tr (compile_tagged_state_pred_label_input p)
+  is_corrupt_state_pred_label tr (compile_tagged_state_pred_label_input p)
 
 val principal_tag_state_content_label_input:
   principal -> string -> state_id -> bytes ->

--- a/src/lib/state/DY.Lib.State.Typed.fst
+++ b/src/lib/state/DY.Lib.State.Typed.fst
@@ -65,7 +65,7 @@ val typed_state_pred_label_input_allow_inversion:
 let typed_state_pred_label_input_allow_inversion #a #ps_a p1 p2 =
   allow_inversion (option a)
 
-val typed_state_pred_label_can_flow_public:
+val is_corrupt_typed_state_pred_label:
   #a:Type0 -> {|parseable_serializeable bytes a|} ->
   tr:trace ->
   p:typed_state_pred_label_input a ->
@@ -78,9 +78,9 @@ val typed_state_pred_label_can_flow_public:
     )
   )
   [SMTPat (typed_state_pred_label p `can_flow tr` public)]
-let typed_state_pred_label_can_flow_public #a #ps tr p =
+let is_corrupt_typed_state_pred_label #a #ps tr p =
   FStar.Classical.forall_intro (FStar.Classical.move_requires (serialize_parse_inv_lemma #bytes a));
-  tagged_state_pred_label_can_flow_public tr (compile_typed_state_pred_label_input p)
+  is_corrupt_tagged_state_pred_label tr (compile_typed_state_pred_label_input p)
 
 val principal_typed_state_content_label_input:
   #a:Type0 -> {|parseable_serializeable bytes a|} ->


### PR DESCRIPTION
This PR does a few cleanups on labels, following some insights I got while working on new labels for TreeKEM:

- various reordering of definitions
- add lemmas on `can_flow` (intro and elim lemmas)
- add lemmas stating when a label is corrupt
- change the lemmas about ``l `can_flow tr` public`` to be on `is_corrupt tr l` (this is an artifact from when there was no separate `is_corrupt` function)
- change the hypothesis of `intro_label_equal` to be on `is_corrupt` rather than `can_flow`