### PR TITLE
cleanup: update F*, use F*'s `for_allP`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -10,11 +10,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1736420028,
-        "narHash": "sha256-AdRcHI1fdS+nHd1KhkyVkGOmMsmYtp+AXHcJqnjeyl4=",
+        "lastModified": 1748215731,
+        "narHash": "sha256-msAys4omyJm5tdxdeyfx/BQTh68rF4SwUzqGZ91CUos=",
         "owner": "TWal",
         "repo": "comparse",
-        "rev": "bedffbc4239353f825070e5b392a8c91e933bc0a",
+        "rev": "411b0219ce4d360d60c4f72ebd855fc13f785772",
         "type": "github"
       },
       "original": {
@@ -46,11 +46,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1736396396,
-        "narHash": "sha256-jiE6ra1CkiELsce5c2lSSIetnph07dVrT7IS3sz0zh4=",
+        "lastModified": 1748199801,
+        "narHash": "sha256-clP79o0NsSjoNi59GxHxfN8lfc+5BPQyWnriYceyoHg=",
         "owner": "FStarLang",
         "repo": "FStar",
-        "rev": "c72e8b799b4da09cda5b901c7ff1746511853db8",
+        "rev": "ff868e03ee0d16303c514ae396706ba283b328a3",
         "type": "github"
       },
       "original": {
@@ -61,11 +61,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1693158576,
-        "narHash": "sha256-aRTTXkYvhXosGx535iAFUaoFboUrZSYb1Ooih/auGp0=",
+        "lastModified": 1743588408,
+        "narHash": "sha256-WRZyK13yucGjwNBMOGjU8ljRJ8FYFv8MBru/bXqZUn0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a999c1cc0c9eb2095729d5aa03e0d8f7ed256780",
+        "rev": "88efe689298b1863db0310c0a22b3ebb4d04fbc3",
         "type": "github"
       },
       "original": {

--- a/src/lib/comparse/DY.Lib.Comparse.Parsers.fst
+++ b/src/lib/comparse/DY.Lib.Comparse.Parsers.fst
@@ -1,5 +1,6 @@
 module DY.Lib.Comparse.Parsers
 
+open FStar.List.Tot { for_allP, for_allP_eq }
 open DY.Core
 open Comparse
 

--- a/src/lib/crypto/DY.Lib.Crypto.AEAD.Split.fst
+++ b/src/lib/crypto/DY.Lib.Crypto.AEAD.Split.fst
@@ -1,6 +1,6 @@
 module DY.Lib.Crypto.AEAD.Split
 
-open Comparse // for_allP, for_allP_eq
+open FStar.List.Tot { for_allP, for_allP_eq }
 open DY.Core
 open DY.Lib.Crypto.SplitPredicate
 

--- a/src/lib/crypto/DY.Lib.Crypto.KdfExpand.Split.fst
+++ b/src/lib/crypto/DY.Lib.Crypto.KdfExpand.Split.fst
@@ -1,6 +1,6 @@
 module DY.Lib.Crypto.KdfExpand.Split
 
-open Comparse // for_allP, for_allP_eq
+open FStar.List.Tot { for_allP, for_allP_eq }
 open DY.Core
 open DY.Lib.SplitFunction
 

--- a/src/lib/crypto/DY.Lib.Crypto.MAC.Split.fst
+++ b/src/lib/crypto/DY.Lib.Crypto.MAC.Split.fst
@@ -1,6 +1,6 @@
 module DY.Lib.Crypto.MAC.Split
 
-open Comparse // for_allP, for_allP_eq
+open FStar.List.Tot { for_allP, for_allP_eq }
 open DY.Core
 open DY.Lib.Crypto.SplitPredicate
 

--- a/src/lib/crypto/DY.Lib.Crypto.PKE.Split.fst
+++ b/src/lib/crypto/DY.Lib.Crypto.PKE.Split.fst
@@ -1,6 +1,6 @@
 module DY.Lib.Crypto.PKE.Split
 
-open Comparse // for_allP, for_allP_eq
+open FStar.List.Tot { for_allP, for_allP_eq }
 open DY.Core
 open DY.Lib.Crypto.SplitPredicate
 

--- a/src/lib/crypto/DY.Lib.Crypto.Signature.Split.fst
+++ b/src/lib/crypto/DY.Lib.Crypto.Signature.Split.fst
@@ -1,6 +1,6 @@
 module DY.Lib.Crypto.Signature.Split
 
-open Comparse // for_allP, for_allP_eq
+open FStar.List.Tot { for_allP, for_allP_eq }
 open DY.Core
 open DY.Lib.Crypto.SplitPredicate
 

--- a/src/lib/event/DY.Lib.Event.Typed.fst
+++ b/src/lib/event/DY.Lib.Event.Typed.fst
@@ -1,5 +1,6 @@
 module DY.Lib.Event.Typed
 
+open FStar.List.Tot { for_allP, for_allP_eq }
 open Comparse
 open DY.Core
 open DY.Lib.SplitFunction

--- a/src/lib/hpke/DY.Lib.HPKE.Split.fst
+++ b/src/lib/hpke/DY.Lib.HPKE.Split.fst
@@ -1,6 +1,6 @@
 module DY.Lib.HPKE.Split
 
-open Comparse // for_allP, for_allP_eq
+open FStar.List.Tot { for_allP, for_allP_eq }
 open DY.Core
 open DY.Lib.Crypto.SplitPredicate
 open DY.Lib.HPKE.Lemmas

--- a/src/lib/state/DY.Lib.State.Map.fst
+++ b/src/lib/state/DY.Lib.State.Map.fst
@@ -1,5 +1,6 @@
 module DY.Lib.State.Map
 
+open FStar.List.Tot { for_allP, for_allP_eq }
 open Comparse
 open DY.Core
 open DY.Lib.Comparse.Glue

--- a/src/lib/state/DY.Lib.State.Tagged.fst
+++ b/src/lib/state/DY.Lib.State.Tagged.fst
@@ -1,5 +1,6 @@
 module DY.Lib.State.Tagged
 
+open FStar.List.Tot { for_allP, for_allP_eq }
 open Comparse
 open DY.Core
 open DY.Lib.SplitFunction

--- a/src/lib/utils/DY.Lib.SplitFunction.fst
+++ b/src/lib/utils/DY.Lib.SplitFunction.fst
@@ -1,7 +1,6 @@
 module DY.Lib.SplitFunction
 
 open FStar.List.Tot
-open Comparse //for_allP, for_allP_eq
 
 #set-options "--fuel 1 --ifuel 1"
 


### PR DESCRIPTION
Solves a long-standing itch, that is, to have to import Comparse when we only need `for_allP`. It was recently introduced in F*'s standard library (FStarLang/FStar#3853), therefore I removed it from Comparse and updated DY* here.