### PR TITLE
feat: define attacker knowledge as a Kleene fixpoint

### DIFF
--- a/src/core/DY.Core.Attacker.Knowledge.Kleene.fst
+++ b/src/core/DY.Core.Attacker.Knowledge.Kleene.fst
@@ -1,0 +1,149 @@
+module DY.Core.Attacker.Knowledge.Kleene
+
+#set-options "--fuel 1 --ifuel 0"
+
+/// This module formalizes Kleene's fixpoint theorem
+/// https://en.wikipedia.org/wiki/Kleene_fixed-point_theorem
+
+type set_t (a:Type) = a -> prop
+
+val is_subset:
+  #a:Type ->
+  set_t a -> set_t a ->
+  prop
+let is_subset #a set1 set2 =
+  forall x. set1 x ==> set2 x
+
+noeq
+type directed_chain_t (a:Type) = {
+  sets: nat -> set_t a;
+  sets_monotonic:
+    i:nat -> j:nat ->
+    Lemma
+    (requires i <= j)
+    (ensures is_subset (sets i) (sets j))
+  ;
+}
+
+val union_set:
+  #a:Type ->
+  (nat -> set_t a) ->
+  set_t a
+let union_set #a sets =
+  fun x ->
+    exists n. sets n x
+
+val map_sets:
+  #a:Type ->
+  (set_t a -> set_t a) ->
+  (nat -> set_t a) ->
+  (nat -> set_t a)
+let map_sets #a f sets =
+  fun n -> fun x ->
+    f (sets n) x
+
+noeq
+type f_properties (#a:Type) (f:set_t a -> set_t a) = {
+  is_scott_continuous:
+    chain:directed_chain_t a -> x:a ->
+    Lemma (f (union_set chain.sets) x <==> union_set (map_sets f chain.sets) x)
+  ;
+  // scott continuity implies monotonicity,
+  // but proving so requires extensionality on sets,
+  // so instead we ask the user to prove it manually
+  is_monotonic:
+    set1:set_t a -> set2:set_t a ->
+    Lemma
+    (requires is_subset set1 set2)
+    (ensures is_subset (f set1) (f set2))
+  ;
+}
+
+val mk_weakest_fixpoint_aux:
+  #a:Type ->
+  (set_t a -> set_t a) -> nat ->
+  set_t a
+let rec mk_weakest_fixpoint_aux #a f n =
+  fun x ->
+    if n = 0 then (
+      False
+    ) else (
+      f (mk_weakest_fixpoint_aux f (n-1)) x
+    )
+
+val mk_weakest_fixpoint:
+  #a:Type ->
+  (set_t a -> set_t a) ->
+  set_t a
+let mk_weakest_fixpoint #a f =
+  union_set (mk_weakest_fixpoint_aux f)
+
+val mk_weakest_fixpoint_aux_is_monotonic_consecutive:
+  #a:Type ->
+  f:(set_t a -> set_t a) -> f_properties f ->
+  i:nat ->
+  Lemma (is_subset (mk_weakest_fixpoint_aux f i) (mk_weakest_fixpoint_aux f (i+1)))
+let rec mk_weakest_fixpoint_aux_is_monotonic_consecutive #a f f_props i =
+  if i = 0 then ()
+  else (
+    mk_weakest_fixpoint_aux_is_monotonic_consecutive f f_props (i-1);
+    f_props.is_monotonic (mk_weakest_fixpoint_aux f (i-1)) (mk_weakest_fixpoint_aux f i)
+  )
+
+val mk_weakest_fixpoint_aux_is_monotonic:
+  #a:Type ->
+  f:(set_t a -> set_t a) -> f_properties f ->
+  i:nat -> j:nat ->
+  Lemma
+  (requires i <= j)
+  (ensures is_subset (mk_weakest_fixpoint_aux f i) (mk_weakest_fixpoint_aux f j))
+let rec mk_weakest_fixpoint_aux_is_monotonic #a f f_properties i j =
+  if i = j then ()
+  else (
+    mk_weakest_fixpoint_aux_is_monotonic f f_properties i (j-1);
+    mk_weakest_fixpoint_aux_is_monotonic_consecutive f f_properties (j-1)
+  )
+
+val mk_weakest_fixpoint_is_fixpoint:
+  #a:Type ->
+  f:(set_t a -> set_t a) ->
+  f_properties f ->
+  Lemma
+  (is_subset (f (mk_weakest_fixpoint f)) (mk_weakest_fixpoint f))
+let mk_weakest_fixpoint_is_fixpoint #a f f_props =
+  introduce forall x. f (mk_weakest_fixpoint f) x ==> mk_weakest_fixpoint f x
+  with introduce _ ==> _ with _. (
+    assert(f (mk_weakest_fixpoint f) x);
+    assert(f (union_set (mk_weakest_fixpoint_aux f)) x);
+    f_props.is_scott_continuous {
+      sets = mk_weakest_fixpoint_aux f;
+      sets_monotonic = mk_weakest_fixpoint_aux_is_monotonic f f_props;
+    } x;
+    assert(forall n. f (mk_weakest_fixpoint_aux f n) x ==> mk_weakest_fixpoint_aux f (n+1) x);
+    assert(mk_weakest_fixpoint f x)
+  )
+
+val mk_weakest_fixpoint_is_weakest_aux:
+  #a:Type ->
+  f:(set_t a -> set_t a) -> f_properties f ->
+  set:set_t a ->
+  n:nat ->
+  Lemma
+  (requires is_subset (f set) set)
+  (ensures is_subset (mk_weakest_fixpoint_aux f n) set)
+let rec mk_weakest_fixpoint_is_weakest_aux #a f f_props set n =
+  if n = 0 then ()
+  else (
+    mk_weakest_fixpoint_is_weakest_aux f f_props set (n-1);
+    f_props.is_monotonic (mk_weakest_fixpoint_aux f (n-1)) set
+  )
+
+val mk_weakest_fixpoint_is_weakest:
+  #a:Type ->
+  f:(set_t a -> set_t a) -> f_properties f ->
+  set:set_t a ->
+  Lemma
+  (requires is_subset (f set) set)
+  (ensures is_subset (mk_weakest_fixpoint f) set)
+let mk_weakest_fixpoint_is_weakest #a f f_props set =
+  FStar.Classical.forall_intro (FStar.Classical.move_requires (mk_weakest_fixpoint_is_weakest_aux f f_props set))

--- a/src/core/DY.Core.Attacker.Knowledge.Kleene.fst
+++ b/src/core/DY.Core.Attacker.Knowledge.Kleene.fst
@@ -14,6 +14,14 @@ val is_subset:
 let is_subset #a set1 set2 =
   forall x. set1 x ==> set2 x
 
+val is_equal:
+  #a:Type ->
+  set_t a -> set_t a ->
+  prop
+let is_equal #a set1 set2 =
+  is_subset set1 set2 /\
+  is_subset set2 set1
+
 noeq
 type directed_chain_t (a:Type) = {
   sets: nat -> set_t a;
@@ -108,19 +116,18 @@ val mk_weakest_fixpoint_is_fixpoint:
   #a:Type ->
   f:(set_t a -> set_t a) ->
   f_properties f ->
-  Lemma
-  (is_subset (f (mk_weakest_fixpoint f)) (mk_weakest_fixpoint f))
+  Lemma (
+    is_subset (f (mk_weakest_fixpoint f)) (mk_weakest_fixpoint f) /\
+    is_subset (mk_weakest_fixpoint f) (f (mk_weakest_fixpoint f))
+  )
 let mk_weakest_fixpoint_is_fixpoint #a f f_props =
-  introduce forall x. f (mk_weakest_fixpoint f) x ==> mk_weakest_fixpoint f x
-  with introduce _ ==> _ with _. (
-    assert(f (mk_weakest_fixpoint f) x);
-    assert(f (union_set (mk_weakest_fixpoint_aux f)) x);
+  introduce forall x. f (mk_weakest_fixpoint f) x <==> mk_weakest_fixpoint f x
+  with (
     f_props.is_scott_continuous {
       sets = mk_weakest_fixpoint_aux f;
       sets_monotonic = mk_weakest_fixpoint_aux_is_monotonic f f_props;
     } x;
-    assert(forall n. f (mk_weakest_fixpoint_aux f n) x ==> mk_weakest_fixpoint_aux f (n+1) x);
-    assert(mk_weakest_fixpoint f x)
+    assert(forall n. f (mk_weakest_fixpoint_aux f n) x <==> mk_weakest_fixpoint_aux f (n+1) x)
   )
 
 val mk_weakest_fixpoint_is_weakest_aux:

--- a/src/core/DY.Core.Attacker.Knowledge.fst
+++ b/src/core/DY.Core.Attacker.Knowledge.fst
@@ -1,5 +1,6 @@
 module DY.Core.Attacker.Knowledge
 
+open FStar.List.Tot { for_allP, for_allP_eq }
 open DY.Core.Bytes.Type
 open DY.Core.Bytes
 open DY.Core.Trace.Type
@@ -7,8 +8,9 @@ open DY.Core.Trace.Base
 open DY.Core.Trace.Invariant
 open DY.Core.Label.Type
 open DY.Core.Label
+open DY.Core.Attacker.Knowledge.Kleene
 
-#set-options "--fuel 1 --ifuel 0"
+#set-options "--fuel 0 --ifuel 0"
 
 /// This modules defines the knowledge of the attacker,
 /// and the attacker knowledge theorem
@@ -20,170 +22,223 @@ open DY.Core.Label
 /// meaning that its label flows to public (by definition of publishability),
 /// which in turn will imply that some set of principals have been compromised (property of labels).
 
-/// Auxillary predicate for the attacker knowledge:
-/// given a trace `tr`,
-/// can the attacker compute `msg`
-/// by applying at most `step` cryptographic functions?
+/// We define the attacker knowledge as the weakest predicate on bytes `A`
+/// that obeys the following rules:
+/// - if b was sent on the network, then A(b)
+/// - if b is a compromised state, then A(b)
+/// - if forall i. A(b_i) then A(f(b_1, ..., b_n))
+///   (for every cryptographic function `f`)
+/// We encode these rules in `attacker_rules` below.
+/// The attacker rules are parametrized by a (tentative) attacker knowledge predicate,
+/// and tells what additional bytestrings the attacker must also know
+/// by applying one of the rules.
 
-val attacker_knows_aux: nat -> trace -> bytes -> prop
-let rec attacker_knows_aux step tr msg =
-  // In zero steps, the attacker knows:
-  if step = 0 then (
-    // - messages sent on the network
-    (
-      msg_sent_on_network tr msg
-    ) \/
-    // - states that the attacker has corrupt
-    (
-      exists prin sess_id.
-        state_was_corrupt tr prin sess_id msg
-    ) \/
-    // - public literals
-    (
-      exists lit.
-        msg == literal_to_bytes lit
-    )
-  // The attacker can compute each cryptographic function in one step.
-  ) else (
-    // Use less steps (not super useful, but why not)
-    attacker_knows_aux (step-1) tr msg \/
-    // Concatenation
-    (
-      exists b1 b2.
-        msg == concat b1 b2 /\
-        attacker_knows_aux (step-1) tr b1 /\
-        attacker_knows_aux (step-1) tr b2
-    ) \/ (
-      exists i b2 buf.
-        Some (msg, b2) == split buf i /\
-        attacker_knows_aux (step-1) tr buf
-    ) \/ (
-      exists i b1 buf.
-        Some (b1, msg) == split buf i /\
-        attacker_knows_aux (step-1) tr buf
-    ) \/
-    // AEAD
-    (
-      exists key nonce buf ad.
-        msg == aead_enc key nonce buf ad /\
-        attacker_knows_aux (step-1) tr key /\
-        attacker_knows_aux (step-1) tr nonce /\
-        attacker_knows_aux (step-1) tr buf /\
-        attacker_knows_aux (step-1) tr ad
-    ) \/ (
-      exists key nonce buf ad.
-        Some msg == aead_dec key nonce buf ad /\
-        attacker_knows_aux (step-1) tr key /\
-        attacker_knows_aux (step-1) tr nonce /\
-        attacker_knows_aux (step-1) tr buf /\
-        attacker_knows_aux (step-1) tr ad
-    ) \/
-    // Public-key encryption
-    (
-      exists sk.
-        msg == pk sk /\
-        attacker_knows_aux (step-1) tr sk
-    ) \/ (
-      exists pk nonce buf.
-        msg == pke_enc pk nonce buf /\
-        attacker_knows_aux (step-1) tr pk /\
-        attacker_knows_aux (step-1) tr nonce /\
-        attacker_knows_aux (step-1) tr buf
-    ) \/ (
-      exists sk buf.
-        Some msg == pke_dec sk buf /\
-        attacker_knows_aux (step-1) tr sk /\
-        attacker_knows_aux (step-1) tr buf
-    ) \/
-    // Signature
-    (
-      exists sk.
-        msg == vk sk /\
-        attacker_knows_aux (step-1) tr sk
-    ) \/ (
-      exists sk nonce buf.
-        msg == sign sk nonce buf /\
-        attacker_knows_aux (step-1) tr sk /\
-        attacker_knows_aux (step-1) tr nonce /\
-        attacker_knows_aux (step-1) tr buf
-    ) \/
-    // Hash
-    (
-      exists buf.
-        msg == hash buf /\
-        attacker_knows_aux (step-1) tr buf
-    ) \/
-    // Diffie-Hellman
-    (
-      exists sk.
-        msg == dh_pk sk /\
-        attacker_knows_aux (step-1) tr sk
-    ) \/ (
-      exists sk pk.
-        msg == dh sk pk /\
-        attacker_knows_aux (step-1) tr sk /\
-        attacker_knows_aux (step-1) tr pk
-    ) \/
-    // KDF
-    (
-      exists salt ikm.
-        msg == kdf_extract salt ikm /\
-        attacker_knows_aux (step-1) tr salt /\
-        attacker_knows_aux (step-1) tr ikm
-    ) \/ (
-      exists prk info len.
-        msg == kdf_expand prk info len /\
-        attacker_knows_aux (step-1) tr prk /\
-        attacker_knows_aux (step-1) tr info
-    ) \/ (
-      exists prk info len1 len2.
-        len1 <= len2 /\
-        msg == kdf_expand prk info len1 /\
-        attacker_knows_aux (step-1) tr (kdf_expand prk info len2)
-    ) \/
-    // KEM
-    (
-      exists sk.
-        msg == kem_pk sk /\
-        attacker_knows_aux (step-1) tr sk
-    ) \/ (
-      exists pk nonce rhs.
-        (msg, rhs) == kem_encap pk nonce /\
-        attacker_knows_aux (step-1) tr pk /\
-        attacker_knows_aux (step-1) tr nonce
-    ) \/ (
-      exists pk nonce lhs.
-        (lhs, msg) == kem_encap pk nonce /\
-        attacker_knows_aux (step-1) tr pk /\
-        attacker_knows_aux (step-1) tr nonce
-    ) \/ (
-      exists sk encap.
-        Some msg == kem_decap sk encap /\
-        attacker_knows_aux (step-1) tr sk /\
-        attacker_knows_aux (step-1) tr encap
-    ) \/
-    // MAC
-    (
-      exists key buf.
-        msg == mac_compute key buf /\
-        attacker_knows_aux (step-1) tr key /\
-        attacker_knows_aux (step-1) tr buf
-    )
+val attacker_rules:
+  trace -> (bytes -> prop) -> bytes ->
+  prop
+let attacker_rules tr pre msg =
+  (
+    msg_sent_on_network tr msg
+  ) \/
+  // - states that the attacker has corrupt
+  (
+    exists prin sess_id.
+      state_was_corrupt tr prin sess_id msg
+  ) \/
+  // - public literals
+  (
+    exists lit.
+      msg == literal_to_bytes lit
+  ) \/
+  // Concatenation
+  (
+    exists b1 b2.
+      msg == concat b1 b2 /\
+      for_allP pre [b1; b2]
+  ) \/ (
+    exists i b2 buf.
+      Some (msg, b2) == split buf i /\
+      for_allP pre [buf]
+  ) \/ (
+    exists i b1 buf.
+      Some (b1, msg) == split buf i /\
+      for_allP pre [buf]
+  ) \/
+  // AEAD
+  (
+    exists key nonce buf ad.
+      msg == aead_enc key nonce buf ad /\
+      for_allP pre [key; nonce; buf; ad]
+  ) \/ (
+    exists key nonce buf ad.
+      Some msg == aead_dec key nonce buf ad /\
+      for_allP pre [key; nonce; buf; ad]
+  ) \/
+  // Public-key encryption
+  (
+    exists sk.
+      msg == pk sk /\
+      for_allP pre [sk]
+  ) \/ (
+    exists pk nonce buf.
+      msg == pke_enc pk nonce buf /\
+      for_allP pre [pk; nonce; buf]
+  ) \/ (
+    exists sk buf.
+      Some msg == pke_dec sk buf /\
+      for_allP pre [sk; buf]
+  ) \/
+  // Signature
+  (
+    exists sk.
+      msg == vk sk /\
+      for_allP pre [sk]
+  ) \/ (
+    exists sk nonce buf.
+      msg == sign sk nonce buf /\
+      for_allP pre [sk; nonce; buf]
+  ) \/
+  // Hash
+  (
+    exists buf.
+      msg == hash buf /\
+      for_allP pre [buf]
+  ) \/
+  // Diffie-Hellman
+  (
+    exists sk.
+      msg == dh_pk sk /\
+      for_allP pre [sk]
+  ) \/ (
+    exists sk pk.
+      msg == dh sk pk /\
+      for_allP pre [sk; pk]
+  ) \/
+  // KDF
+  (
+    exists salt ikm.
+      msg == kdf_extract salt ikm /\
+      for_allP pre [salt; ikm]
+  ) \/ (
+    exists prk info len.
+      msg == kdf_expand prk info len /\
+      for_allP pre [prk; info]
+  ) \/ (
+    exists prk info len1 len2.
+      len1 <= len2 /\
+      msg == kdf_expand prk info len1 /\
+      for_allP pre [kdf_expand prk info len2]
+  ) \/
+  // KEM
+  (
+    exists sk.
+      msg == kem_pk sk /\
+      for_allP pre [sk]
+  ) \/ (
+    exists pk nonce rhs.
+      (msg, rhs) == kem_encap pk nonce /\
+      for_allP pre [pk; nonce]
+  ) \/ (
+    exists pk nonce lhs.
+      (lhs, msg) == kem_encap pk nonce /\
+      for_allP pre [pk; nonce]
+  ) \/ (
+    exists sk encap.
+      Some msg == kem_decap sk encap /\
+      for_allP pre [sk; encap]
+  ) \/
+  // MAC
+  (
+    exists key buf.
+      msg == mac_compute key buf /\
+      for_allP pre [key; buf]
   )
 
-/// The predicate for attacker knowledge:
-/// given a trace `tr`,
-/// can the attacker compute a bytestring `msg`
-/// in any number of steps?
+/// We now define the attacker knowldege
+/// as the weakest predicate such that
+/// forall b. attacker_rules A b ==> A b
+/// (omitting the trace for simplicity).
 
 [@@ "opaque_to_smt"]
 val attacker_knows: trace -> bytes -> prop
-let attacker_knows tr msg =
-  exists step. attacker_knows_aux step tr msg
+let attacker_knows tr =
+  mk_weakest_fixpoint (attacker_rules tr)
 
-/// Lemma for the base case of the attacker knowledge theorem:
-/// bytestrings that the attacker obtained by corruption
-/// are publishable.
+/// Before proving that the attacker knowledge obeys the attacker rules
+/// (i.e. forall b. attacker_rules attacker_knows b ==> attacker_knows b)
+/// we need to prove that the tatacker rules is Scott-continuous.
+
+#push-options "--fuel 1 --ifuel 1"
+val scott_continuous_for_allP_lemma:
+  chain:directed_chain_t bytes ->
+  l:list bytes ->
+  Lemma
+  (requires for_allP (union_set chain.sets) l)
+  (ensures exists n. for_allP (chain.sets n) l)
+let rec scott_continuous_for_allP_lemma chain l =
+  match l with
+  | [] -> assert(for_allP (chain.sets 0) l)
+  | h::t -> (
+    scott_continuous_for_allP_lemma chain t;
+    eliminate exists n1 n2. chain.sets n1 h /\ for_allP (chain.sets n2) t
+    returns exists n. for_allP (chain.sets n) l
+    with _. (
+      let n = if n1 <= n2 then n2 else n1 in
+      chain.sets_monotonic n1 n;
+      chain.sets_monotonic n2 n;
+      for_allP_eq (chain.sets n2) t;
+      for_allP_eq (chain.sets n) t;
+      assert(for_allP (chain.sets n) l)
+    )
+  )
+#pop-options
+
+#push-options "--z3rlimit 25"
+val attacker_rules_properties: tr:trace -> f_properties (attacker_rules tr)
+let attacker_rules_properties tr = {
+  is_scott_continuous = (fun chain x ->
+    introduce forall (p:prop). p ==> (exists (n:nat). p) with (
+      introduce _ ==> _ with _. (
+        introduce exists (n:nat). p with 0 and ()
+      )
+    );
+    introduce forall l. for_allP (union_set chain.sets) l <==> (exists n. for_allP (chain.sets n) l) with (
+      FStar.Classical.move_requires (scott_continuous_for_allP_lemma chain) l;
+      introduce (exists n. for_allP (chain.sets n) l) ==> for_allP (union_set chain.sets) l with _. (
+        eliminate exists n. for_allP (chain.sets n) l
+        returns _
+        with _. (
+          for_allP_eq (chain.sets n) l;
+          for_allP_eq (union_set chain.sets) l
+        )
+      )
+    );
+    assert((attacker_rules tr (union_set chain.sets) x <==> (exists n. attacker_rules tr (chain.sets n) x)))
+  );
+  is_monotonic = (fun set1 set2 ->
+    introduce forall l. for_allP set1 l ==> for_allP set2 l with (
+      for_allP_eq set1 l;
+      for_allP_eq set2 l
+    )
+  );
+}
+#pop-options
+
+/// As advertised above,
+/// we can now prove that the attacker knowledge predicate
+/// obeys the attacker rules.
+
+val attacker_knows_obeys_attacker_rules:
+  tr:trace -> msg:bytes ->
+  Lemma
+  (requires attacker_rules tr (attacker_knows tr) msg)
+  (ensures attacker_knows tr msg)
+let attacker_knows_obeys_attacker_rules tr msg =
+  reveal_opaque (`%attacker_knows) (attacker_knows);
+  mk_weakest_fixpoint_is_fixpoint (attacker_rules tr) (attacker_rules_properties tr)
+
+/// We prove that the publishability predicate
+/// also obeys the attacker rules.
 
 val corrupted_state_is_publishable:
   {|protocol_invariants|} ->
@@ -198,49 +253,50 @@ let corrupted_state_is_publishable #invs tr prin sess_id content =
   state_is_knowable_by tr prin sess_id content;
   state_pred_label_can_flow_public tr (principal_state_content_label_input prin sess_id content)
 
-#push-options "--z3rlimit 25"
-val attacker_only_knows_publishable_values_aux:
+#push-options "--ifuel 1 --z3rlimit 25"
+val is_publishable_obeys_attacker_rules:
   {|protocol_invariants|} ->
-  step:nat -> tr:trace -> msg:bytes ->
+  tr:trace -> msg:bytes ->
   Lemma
   (requires
     trace_invariant tr /\
-    attacker_knows_aux step tr msg
+    attacker_rules tr (is_publishable tr) msg
   )
   (ensures is_publishable tr msg)
-let rec attacker_only_knows_publishable_values_aux #invs step tr msg =
-  if step = 0 then (
-    FStar.Classical.forall_intro   (FStar.Classical.move_requires   (msg_sent_on_network_are_publishable tr));
-    FStar.Classical.forall_intro   (FStar.Classical.move_requires   (msg_sent_on_network_are_publishable tr));
-    FStar.Classical.forall_intro_3 (FStar.Classical.move_requires_3 (corrupted_state_is_publishable tr));
-    FStar.Classical.forall_intro   (FStar.Classical.move_requires   (literal_to_bytes_is_publishable tr))
-  ) else (
-    FStar.Classical.forall_intro   (FStar.Classical.move_requires   (attacker_only_knows_publishable_values_aux (step-1) tr));
-    FStar.Classical.forall_intro_2 (FStar.Classical.move_requires_2 (concat_preserves_publishability tr));
-    FStar.Classical.forall_intro_2 (FStar.Classical.move_requires_2 (split_preserves_publishability tr));
-    FStar.Classical.forall_intro_4 (FStar.Classical.move_requires_4 (aead_enc_preserves_publishability tr));
-    FStar.Classical.forall_intro_4 (FStar.Classical.move_requires_4 (aead_dec_preserves_publishability tr));
-    FStar.Classical.forall_intro   (FStar.Classical.move_requires   (pk_preserves_publishability tr));
-    FStar.Classical.forall_intro_3 (FStar.Classical.move_requires_3 (pke_enc_preserves_publishability tr));
-    FStar.Classical.forall_intro_2 (FStar.Classical.move_requires_2 (pke_dec_preserves_publishability tr));
-    FStar.Classical.forall_intro   (FStar.Classical.move_requires   (vk_preserves_publishability tr));
-    FStar.Classical.forall_intro_3 (FStar.Classical.move_requires_3 (sign_preserves_publishability tr));
-    FStar.Classical.forall_intro   (FStar.Classical.move_requires   (hash_preserves_publishability tr));
-    FStar.Classical.forall_intro   (FStar.Classical.move_requires   (dh_pk_preserves_publishability tr));
-    FStar.Classical.forall_intro_2 (FStar.Classical.move_requires_2 (dh_preserves_publishability tr));
-    FStar.Classical.forall_intro_2 (FStar.Classical.move_requires_2 (kdf_extract_preserves_publishability tr));
-    FStar.Classical.forall_intro_3 (FStar.Classical.move_requires_3 (kdf_expand_preserves_publishability tr));
-    FStar.Classical.forall_intro_4 (FStar.Classical.move_requires_4 (kdf_expand_shorter_preserves_publishability tr));
-    FStar.Classical.forall_intro   (FStar.Classical.move_requires   (kem_pk_preserves_publishability tr));
-    FStar.Classical.forall_intro_2 (FStar.Classical.move_requires_2 (kem_encap_preserves_publishability tr));
-    FStar.Classical.forall_intro_2 (FStar.Classical.move_requires_2 (kem_decap_preserves_publishability tr));
-    FStar.Classical.forall_intro_2 (FStar.Classical.move_requires_2 (mac_compute_preserves_publishability tr));
-    ()
-  )
+let is_publishable_obeys_attacker_rules #invs tr msg =
+  introduce forall l. for_allP (is_publishable tr) l <==> norm [delta_only [`%for_allP]; iota; zeta] (for_allP (is_publishable tr) l) with (
+    norm_spec [delta_only [`%for_allP]; iota; zeta] (for_allP (is_publishable tr) l)
+  );
+  FStar.Classical.forall_intro   (FStar.Classical.move_requires   (msg_sent_on_network_are_publishable tr));
+  FStar.Classical.forall_intro_3 (FStar.Classical.move_requires_3 (corrupted_state_is_publishable tr));
+  FStar.Classical.forall_intro   (FStar.Classical.move_requires   (literal_to_bytes_is_publishable tr));
+  FStar.Classical.forall_intro_2 (FStar.Classical.move_requires_2 (concat_preserves_publishability tr));
+  FStar.Classical.forall_intro_2 (FStar.Classical.move_requires_2 (split_preserves_publishability tr));
+  FStar.Classical.forall_intro_4 (FStar.Classical.move_requires_4 (aead_enc_preserves_publishability tr));
+  FStar.Classical.forall_intro_4 (FStar.Classical.move_requires_4 (aead_dec_preserves_publishability tr));
+  FStar.Classical.forall_intro   (FStar.Classical.move_requires   (pk_preserves_publishability tr));
+  FStar.Classical.forall_intro_3 (FStar.Classical.move_requires_3 (pke_enc_preserves_publishability tr));
+  FStar.Classical.forall_intro_2 (FStar.Classical.move_requires_2 (pke_dec_preserves_publishability tr));
+  FStar.Classical.forall_intro   (FStar.Classical.move_requires   (vk_preserves_publishability tr));
+  FStar.Classical.forall_intro_3 (FStar.Classical.move_requires_3 (sign_preserves_publishability tr));
+  FStar.Classical.forall_intro   (FStar.Classical.move_requires   (hash_preserves_publishability tr));
+  FStar.Classical.forall_intro   (FStar.Classical.move_requires   (dh_pk_preserves_publishability tr));
+  FStar.Classical.forall_intro_2 (FStar.Classical.move_requires_2 (dh_preserves_publishability tr));
+  FStar.Classical.forall_intro_2 (FStar.Classical.move_requires_2 (kdf_extract_preserves_publishability tr));
+  FStar.Classical.forall_intro_3 (FStar.Classical.move_requires_3 (kdf_expand_preserves_publishability tr));
+  FStar.Classical.forall_intro_4 (FStar.Classical.move_requires_4 (kdf_expand_shorter_preserves_publishability tr));
+  FStar.Classical.forall_intro   (FStar.Classical.move_requires   (kem_pk_preserves_publishability tr));
+  FStar.Classical.forall_intro_2 (FStar.Classical.move_requires_2 (kem_encap_preserves_publishability tr));
+  FStar.Classical.forall_intro_2 (FStar.Classical.move_requires_2 (kem_decap_preserves_publishability tr));
+  FStar.Classical.forall_intro_2 (FStar.Classical.move_requires_2 (mac_compute_preserves_publishability tr));
+  ()
 #pop-options
 
 /// In a trace that satisfy the trace invariant,
 /// every bytestring known by the attacker is publishable.
+/// We prove this because the publishability predicate obeys the attacker rules,
+/// and the attacker knowledge predicate is the weakest predicate
+/// that obeys the attacker rules.
 
 val attacker_only_knows_publishable_values:
   {|protocol_invariants|} ->
@@ -253,8 +309,5 @@ val attacker_only_knows_publishable_values:
   (ensures is_publishable tr msg)
 let attacker_only_knows_publishable_values #invs tr msg =
   reveal_opaque (`%attacker_knows) (attacker_knows);
-  eliminate exists step. attacker_knows_aux step tr msg
-  returns is_publishable tr msg
-  with _. (
-    attacker_only_knows_publishable_values_aux step tr msg
-  )
+  FStar.Classical.forall_intro (FStar.Classical.move_requires (is_publishable_obeys_attacker_rules tr));
+  mk_weakest_fixpoint_is_weakest (attacker_rules tr) (attacker_rules_properties tr) (is_publishable tr)

--- a/src/core/DY.Core.Attacker.Knowledge.fst
+++ b/src/core/DY.Core.Attacker.Knowledge.fst
@@ -193,15 +193,10 @@ let rec scott_continuous_for_allP_lemma chain l =
   )
 #pop-options
 
-#push-options "--z3rlimit 25"
 val attacker_rules_properties: tr:trace -> f_properties (attacker_rules tr)
 let attacker_rules_properties tr = {
   is_scott_continuous = (fun chain x ->
-    introduce forall (p:prop). p ==> (exists (n:nat). p) with (
-      introduce _ ==> _ with _. (
-        introduce exists (n:nat). p with 0 and ()
-      )
-    );
+    introduce exists (n:nat). True with 0 and ();
     introduce forall l. for_allP (union_set chain.sets) l <==> (exists n. for_allP (chain.sets n) l) with (
       FStar.Classical.move_requires (scott_continuous_for_allP_lemma chain) l;
       introduce (exists n. for_allP (chain.sets n) l) ==> for_allP (union_set chain.sets) l with _. (
@@ -222,7 +217,6 @@ let attacker_rules_properties tr = {
     )
   );
 }
-#pop-options
 
 /// As advertised above,
 /// we can now prove that the attacker knowledge predicate

--- a/src/core/DY.Core.Attacker.Knowledge.fst
+++ b/src/core/DY.Core.Attacker.Knowledge.fst
@@ -166,7 +166,7 @@ let attacker_knows tr =
 
 /// Before proving that the attacker knowledge obeys the attacker rules
 /// (i.e. forall b. attacker_rules attacker_knows b ==> attacker_knows b)
-/// we need to prove that the tatacker rules is Scott-continuous.
+/// we need to prove that attacker_rules is Scott-continuous.
 
 #push-options "--fuel 1 --ifuel 1"
 val scott_continuous_for_allP_lemma:


### PR DESCRIPTION
While trying to explain why we define `attacker_knows` as we do, I realized we could argue that it is a Kleene fixpoint. This PR makes this more explicit.

Furthermore:
- We prove the attacker knowledge is the weakest predicate that obeys the attacker rules, this gives to a very nice proof of the attacker knowledge: because `is_publishable` also obeys the attacker rules, it must be stronger than `attacker_knows` (because it is the weakest such predicate).
- We prove that the attacker knowledge is preserved by computing cryptographic functions, these lemmas are currently missing. I think this additional proofs explain why the diff is positive. This paves the way to formally define the attacker API, which we didn't take the time to write properly yet.