### PR TITLE
State update constraints

### DIFF
--- a/examples/iso_dh/DY.Example.DH.Protocol.Stateful.Proof.fst
+++ b/examples/iso_dh/DY.Example.DH.Protocol.Stateful.Proof.fst
@@ -98,14 +98,6 @@ let all_sessions = [
   mk_local_state_tag_and_preds dh_session_preds;
 ]
 
-(*
-let all_session_updates = [
-  pki_tag_and_state_update_pred;
-  private_keys_tag_and_state_update_pred;
-  mk_local_state_tag_and_update_pred dh_session_update_pred;
-]
-*)
-
 /// List of all local event predicates.
 
 let all_events = [
@@ -116,8 +108,6 @@ let all_events = [
 
 let dh_trace_invs: trace_invariants = {
   state_preds = mk_state_preds all_sessions;
-//  state_pred = mk_state_pred all_sessions;
-//  state_update_pred = mk_state_update_pred all_session_updates;
   event_pred = mk_event_pred all_events;
 }
 
@@ -129,7 +119,6 @@ instance dh_protocol_invs: protocol_invariants = {
 /// Lemmas that the global state predicate contains all the local ones
 
 let _ = do_split_boilerplate mk_state_preds_correct all_sessions
-//let _ = do_split_boilerplate mk_state_update_pred_correct all_session_updates
 let _ = do_split_boilerplate mk_event_pred_correct all_events
 
 (*** Proofs ****)

--- a/examples/iso_dh/DY.Example.DH.Protocol.Stateful.Proof.fst
+++ b/examples/iso_dh/DY.Example.DH.Protocol.Stateful.Proof.fst
@@ -60,10 +60,10 @@ let dh_session_pred: local_state_predicate dh_session = {
   pred_knowable = (fun tr prin sess_id st -> ());
 }
 
-/// The (local) state update predicate is trivial for this protocol:
-
-let dh_session_update_pred: local_state_update_predicate dh_session =
-  default_local_state_update_pred dh_session
+let dh_session_preds: local_state_predicates dh_session = {
+  default_local_state_preds dh_session with
+  local_state_pred = dh_session_pred
+}
 
 /// The (local) event predicate.
 
@@ -93,16 +93,18 @@ let dh_event_pred: event_predicate dh_event =
 /// List of all local state predicates.
 
 let all_sessions = [
-  pki_tag_and_invariant;
-  private_keys_tag_and_invariant;
-  mk_local_state_tag_and_pred dh_session_pred;
+  pki_tag_and_preds;
+  private_keys_tag_and_preds;
+  mk_local_state_tag_and_preds dh_session_preds;
 ]
 
+(*
 let all_session_updates = [
   pki_tag_and_state_update_pred;
   private_keys_tag_and_state_update_pred;
   mk_local_state_tag_and_update_pred dh_session_update_pred;
 ]
+*)
 
 /// List of all local event predicates.
 
@@ -113,8 +115,9 @@ let all_events = [
 /// Create the global trace invariants.
 
 let dh_trace_invs: trace_invariants = {
-  state_pred = mk_state_pred all_sessions;
-  state_update_pred = mk_state_update_pred all_session_updates;
+  state_preds = mk_state_preds all_sessions;
+//  state_pred = mk_state_pred all_sessions;
+//  state_update_pred = mk_state_update_pred all_session_updates;
   event_pred = mk_event_pred all_events;
 }
 
@@ -125,8 +128,8 @@ instance dh_protocol_invs: protocol_invariants = {
 
 /// Lemmas that the global state predicate contains all the local ones
 
-let _ = do_split_boilerplate mk_state_pred_correct all_sessions
-let _ = do_split_boilerplate mk_state_update_pred_correct all_session_updates
+let _ = do_split_boilerplate mk_state_preds_correct all_sessions
+//let _ = do_split_boilerplate mk_state_update_pred_correct all_session_updates
 let _ = do_split_boilerplate mk_event_pred_correct all_events
 
 (*** Proofs ****)

--- a/examples/nsl_pk/DY.Example.NSL.Protocol.Stateful.Proof.fst
+++ b/examples/nsl_pk/DY.Example.NSL.Protocol.Stateful.Proof.fst
@@ -47,6 +47,11 @@ let state_predicate_nsl: local_state_predicate nsl_session = {
   pred_knowable = (fun tr prin sess_id st -> ());
 }
 
+/// The (local) state update predicate is trivial for this protocol:
+
+let update_predicate_nsl: local_state_update_predicate nsl_session =
+  default_local_state_update_pred nsl_session
+
 /// The (local) event predicate.
 
 let event_predicate_nsl: event_predicate nsl_event =
@@ -85,6 +90,12 @@ let all_sessions = [
   mk_local_state_tag_and_pred state_predicate_nsl;
 ]
 
+let all_session_updates = [
+  pki_tag_and_state_update_pred;
+  private_keys_tag_and_state_update_pred;
+  mk_local_state_tag_and_update_pred update_predicate_nsl;
+]
+
 /// List of all local event predicates.
 
 let all_events = [
@@ -95,6 +106,7 @@ let all_events = [
 
 let trace_invariants_nsl: trace_invariants = {
   state_pred = mk_state_pred all_sessions;
+  state_update_pred = mk_state_update_pred all_session_updates;
   event_pred = mk_event_pred all_events;
 }
 
@@ -106,6 +118,7 @@ instance protocol_invariants_nsl: protocol_invariants = {
 /// Lemmas that the global state predicate contains all the local ones
 
 let _ = do_split_boilerplate mk_state_pred_correct all_sessions
+let _ = do_split_boilerplate mk_state_update_pred_correct all_session_updates
 let _ = do_split_boilerplate mk_event_pred_correct all_events
 
 (*** Proofs ***)

--- a/examples/nsl_pk/DY.Example.NSL.Protocol.Stateful.Proof.fst
+++ b/examples/nsl_pk/DY.Example.NSL.Protocol.Stateful.Proof.fst
@@ -47,10 +47,10 @@ let state_predicate_nsl: local_state_predicate nsl_session = {
   pred_knowable = (fun tr prin sess_id st -> ());
 }
 
-/// The (local) state update predicate is trivial for this protocol:
-
-let update_predicate_nsl: local_state_update_predicate nsl_session =
-  default_local_state_update_pred nsl_session
+let state_predicates_nsl: local_state_predicates nsl_session = {
+  default_local_state_preds nsl_session with
+  local_state_pred = state_predicate_nsl
+}
 
 /// The (local) event predicate.
 
@@ -85,16 +85,18 @@ let event_predicate_nsl: event_predicate nsl_event =
 /// List of all local state predicates.
 
 let all_sessions = [
-  pki_tag_and_invariant;
-  private_keys_tag_and_invariant;
-  mk_local_state_tag_and_pred state_predicate_nsl;
+  pki_tag_and_preds;
+  private_keys_tag_and_preds;
+  mk_local_state_tag_and_preds state_predicates_nsl;
 ]
 
+(*
 let all_session_updates = [
   pki_tag_and_state_update_pred;
   private_keys_tag_and_state_update_pred;
   mk_local_state_tag_and_update_pred update_predicate_nsl;
 ]
+*)
 
 /// List of all local event predicates.
 
@@ -105,8 +107,8 @@ let all_events = [
 /// Create the global trace invariants.
 
 let trace_invariants_nsl: trace_invariants = {
-  state_pred = mk_state_pred all_sessions;
-  state_update_pred = mk_state_update_pred all_session_updates;
+  state_preds = mk_state_preds all_sessions;
+//  state_update_pred = mk_state_update_pred all_session_updates;
   event_pred = mk_event_pred all_events;
 }
 
@@ -117,8 +119,8 @@ instance protocol_invariants_nsl: protocol_invariants = {
 
 /// Lemmas that the global state predicate contains all the local ones
 
-let _ = do_split_boilerplate mk_state_pred_correct all_sessions
-let _ = do_split_boilerplate mk_state_update_pred_correct all_session_updates
+let _ = do_split_boilerplate mk_state_preds_correct all_sessions
+//let _ = do_split_boilerplate mk_state_update_pred_correct all_session_updates
 let _ = do_split_boilerplate mk_event_pred_correct all_events
 
 (*** Proofs ***)

--- a/examples/nsl_pk/DY.Example.NSL.Protocol.Stateful.Proof.fst
+++ b/examples/nsl_pk/DY.Example.NSL.Protocol.Stateful.Proof.fst
@@ -90,14 +90,6 @@ let all_sessions = [
   mk_local_state_tag_and_preds state_predicates_nsl;
 ]
 
-(*
-let all_session_updates = [
-  pki_tag_and_state_update_pred;
-  private_keys_tag_and_state_update_pred;
-  mk_local_state_tag_and_update_pred update_predicate_nsl;
-]
-*)
-
 /// List of all local event predicates.
 
 let all_events = [
@@ -108,7 +100,6 @@ let all_events = [
 
 let trace_invariants_nsl: trace_invariants = {
   state_preds = mk_state_preds all_sessions;
-//  state_update_pred = mk_state_update_pred all_session_updates;
   event_pred = mk_event_pred all_events;
 }
 
@@ -120,7 +111,6 @@ instance protocol_invariants_nsl: protocol_invariants = {
 /// Lemmas that the global state predicate contains all the local ones
 
 let _ = do_split_boilerplate mk_state_preds_correct all_sessions
-//let _ = do_split_boilerplate mk_state_update_pred_correct all_session_updates
 let _ = do_split_boilerplate mk_event_pred_correct all_events
 
 (*** Proofs ***)

--- a/src/core/DY.Core.Trace.Base.fst
+++ b/src/core/DY.Core.Trace.Base.fst
@@ -435,6 +435,13 @@ val state_was_set:
 let state_was_set #label_t tr prin sess_id content =
   entry_exists tr (SetState prin sess_id content)
 
+val state_was_set_at:
+  #label_t:Type ->
+  trace_ label_t -> timestamp -> principal -> state_id -> bytes ->
+  prop
+let state_was_set_at #label_t tr ts prin sess_id content =
+  entry_at tr ts (SetState prin sess_id content)
+
 /// A state being set at some time stays on the trace as the trace grows.
 
 val state_was_set_grows:

--- a/src/core/DY.Core.Trace.Base.fst
+++ b/src/core/DY.Core.Trace.Base.fst
@@ -949,8 +949,8 @@ let is_most_recent_state_for_state_was_set prin sess_id content tr =
 val is_most_recent_state_for_get_most_recent_state_for_ghost:
   prin:principal -> sess_id:state_id -> st_opt:option bytes -> tr:trace ->
   Lemma
-  (requires is_most_recent_state_for prin sess_id st_opt tr)
-  (ensures get_most_recent_state_for_ghost tr prin sess_id == st_opt)
+  (is_most_recent_state_for prin sess_id st_opt tr <==>
+  get_most_recent_state_for_ghost tr prin sess_id == st_opt)
   [SMTPat (get_most_recent_state_for_ghost tr prin sess_id);
    SMTPat (is_most_recent_state_for prin sess_id st_opt tr);
   ]

--- a/src/core/DY.Core.Trace.Invariant.fst
+++ b/src/core/DY.Core.Trace.Invariant.fst
@@ -295,6 +295,10 @@ val state_was_set_twice_implies_update_pred:
   (ensures
     state_update_pred.update_pred tr prin sess_id content1 content2
   )
+  [SMTPat (state_was_set_at tr ts1 prin sess_id content1);
+   SMTPat (state_was_set_at tr ts2 prin sess_id content2);
+   SMTPat (trace_invariant tr);
+  ]
 let rec state_was_set_twice_implies_update_pred tr ts1 ts2 prin sess_id content1 content2 =
   let is_state_for prin sess_id e =
     match e with

--- a/src/core/DY.Core.Trace.Invariant.fst
+++ b/src/core/DY.Core.Trace.Invariant.fst
@@ -72,7 +72,10 @@ type state_update_predicate {|crypto_invariants|} = {
     prin:principal -> sess_id:state_id ->
     b1:bytes -> b2:bytes ->
     Lemma
-    (requires update_pred tr1 prin sess_id b1 b2)
+    (requires
+      update_pred tr1 prin sess_id b1 b2 /\
+      tr1 <$ tr2
+    )
     (ensures update_pred tr2 prin sess_id b1 b2)
   ;
   // Do we want transitivity?

--- a/src/core/DY.Core.Trace.Invariant.fst
+++ b/src/core/DY.Core.Trace.Invariant.fst
@@ -52,11 +52,57 @@ type state_predicate {|crypto_invariants|} = {
   ;
 }
 
+/// The state update predicate can be used to constrain how a principal's state is allowed
+/// to evolve over time, for instance, requiring that some fields of the state are constant
+/// once set, or that a counter is monotonically increasing.
+/// To update a state (i.e., write to a principal, state_id pair that already had a state
+/// entry on the current trace), the state predicate needs to hold for the new state, but
+/// also the update predicate must hold, relating the old and new states (at the trace/time
+/// where the update is taking place).
+
+noeq
+type state_update_predicate {|crypto_invariants|} = {
+  update_pred: trace -> principal -> state_id -> bytes -> bytes -> prop;
+  // TODO Should this hold? It seems quite natural that if an update
+  // from A to B was allowed, it remains allowed. This works because we
+  // talk about both the start and end of the update, rather than saying
+  // "it is allowed to update from [current value] to B".
+  update_pred_later:
+    tr1:trace -> tr2:trace ->
+    prin:principal -> sess_id:state_id ->
+    b1:bytes -> b2:bytes ->
+    Lemma
+    (requires update_pred tr1 prin sess_id b1 b2)
+    (ensures update_pred tr2 prin sess_id b1 b2)
+  ;
+  // Do we want transitivity?
+  update_pred_trans:
+    tr:trace ->
+    prin:principal -> sess_id:state_id ->
+    b1:bytes -> b2:bytes -> b3:bytes ->
+    Lemma
+    (requires
+      update_pred tr prin sess_id b1 b2 /\
+      update_pred tr prin sess_id b2 b3
+    )
+    (ensures update_pred tr prin sess_id b1 b3)
+  ;
+  // Reflexivity too?
+}
+
+// Transitivity:
+// - Pred transitive for any given trace?
+//   - Would also need a later pred saying that the update pred is stable.
+//   - Do these two hold? Probably easier to use than a single mixed transitivity pred.
+// - Pred transitive as in later pred above?
+//
+
 /// The parameters of the trace invariant.
 
 noeq
 type trace_invariants {|crypto_invariants|} = {
   state_pred: state_predicate;
+  state_update_pred: state_update_predicate;
   event_pred: trace -> principal -> string -> bytes -> prop;
 }
 
@@ -76,6 +122,7 @@ class protocol_invariants = {
 // hence we simulate inheritance like this.
 
 let state_pred {|invs:protocol_invariants|} = invs.trace_invs.state_pred
+let state_update_pred {|invs:protocol_invariants|} = invs.trace_invs.state_update_pred
 let event_pred {|invs:protocol_invariants|} = invs.trace_invs.event_pred
 
 (*** Trace invariant definition ***)
@@ -90,7 +137,21 @@ let trace_entry_invariant #invs tr entry =
     is_publishable tr msg
   | SetState prin sess_id content -> (
     // Stored states satisfy the custom state predicate
-    invs.trace_invs.state_pred.pred tr prin sess_id content
+    invs.trace_invs.state_pred.pred tr prin sess_id content /\
+    (
+      let is_state_for prin sess_id e =
+        match e with
+        | SetState prin' sess_id' content -> prin = prin' && sess_id = sess_id'
+        | _ -> false
+      in
+      let ts_old_opt = trace_search_last tr (is_state_for prin sess_id) in
+      match ts_old_opt with
+      | None -> True
+      | Some ts_old -> (
+        let SetState _ _ content_old = get_entry_at tr ts_old in
+        invs.trace_invs.state_update_pred.update_pred tr prin sess_id content_old content
+      )
+    )
   )
   | Event prin tag content -> (
     // Triggered protocol events satisfy the custom event predicate
@@ -212,6 +273,44 @@ val state_is_knowable_by:
   (ensures is_knowable_by (principal_state_content_label prin sess_id content) tr content)
 let state_is_knowable_by #invs tr prin sess_id content =
   state_pred.pred_knowable tr prin sess_id content
+
+/// If a state was known to be set at two different times, its value at those times
+/// must be related by the update predicate.
+
+val state_was_set_twice_implies_update_pred:
+  {|protocol_invariants|} -> tr:trace ->
+  ts1:timestamp -> ts2:timestamp ->
+  prin:principal -> sess_id:state_id ->
+  content1:bytes -> content2:bytes ->
+  Lemma
+  (requires
+    state_was_set_at tr ts1 prin sess_id content1 /\
+    state_was_set_at tr ts2 prin sess_id content2 /\
+    ts1 < ts2 /\
+    trace_invariant tr
+  )
+  (ensures
+    state_update_pred.update_pred tr prin sess_id content1 content2
+  )
+let rec state_was_set_twice_implies_update_pred tr ts1 ts2 prin sess_id content1 content2 =
+  let is_state_for prin sess_id e =
+    match e with
+    | SetState prin' sess_id' content -> prin = prin' && sess_id = sess_id'
+    | _ -> false
+  in
+  let Some ts' = trace_search_last (prefix tr ts2) (is_state_for prin sess_id) in
+  let SetState _ _ content' = get_entry_at tr ts' in
+
+  entry_at_implies_trace_entry_invariant tr ts2 (SetState prin sess_id content2);
+  state_update_pred.update_pred_later (prefix tr ts2) tr prin sess_id content' content2;
+
+  if ts1 < ts'
+  then (
+    state_was_set_twice_implies_update_pred tr ts1 ts' prin sess_id content1 content';
+    state_update_pred.update_pred_trans tr prin sess_id content1 content' content2;
+    ()
+  )
+  else ()
 
 /// Triggered protocol events satisfy the event predicate.
 

--- a/src/core/DY.Core.Trace.Invariant.fst
+++ b/src/core/DY.Core.Trace.Invariant.fst
@@ -93,13 +93,6 @@ type state_update_predicate {|crypto_invariants|} = {
   // Reflexivity too?
 }
 
-// Transitivity:
-// - Pred transitive for any given trace?
-//   - Would also need a later pred saying that the update pred is stable.
-//   - Do these two hold? Probably easier to use than a single mixed transitivity pred.
-// - Pred transitive as in later pred above?
-//
-
 /// The parameters of the trace invariant.
 
 noeq

--- a/src/core/DY.Core.Trace.Invariant.fst
+++ b/src/core/DY.Core.Trace.Invariant.fst
@@ -63,10 +63,6 @@ type state_predicate {|crypto_invariants|} = {
 noeq
 type state_update_predicate {|crypto_invariants|} = {
   update_pred: trace -> principal -> state_id -> bytes -> bytes -> prop;
-  // TODO Should this hold? It seems quite natural that if an update
-  // from A to B was allowed, it remains allowed. This works because we
-  // talk about both the start and end of the update, rather than saying
-  // "it is allowed to update from [current value] to B".
   update_pred_later:
     tr1:trace -> tr2:trace ->
     prin:principal -> sess_id:state_id ->
@@ -78,7 +74,7 @@ type state_update_predicate {|crypto_invariants|} = {
     )
     (ensures update_pred tr2 prin sess_id b1 b2)
   ;
-  // Do we want transitivity?
+  // TODO: We may want to relax this in the future.
   update_pred_trans:
     tr:trace ->
     prin:principal -> sess_id:state_id ->
@@ -90,15 +86,19 @@ type state_update_predicate {|crypto_invariants|} = {
     )
     (ensures update_pred tr prin sess_id b1 b3)
   ;
-  // Reflexivity too?
+}
+
+noeq
+type state_predicates {|crypto_invariants|} = {
+  state_pred: state_predicate;
+  state_update_pred: state_update_predicate;
 }
 
 /// The parameters of the trace invariant.
 
 noeq
 type trace_invariants {|crypto_invariants|} = {
-  state_pred: state_predicate;
-  state_update_pred: state_update_predicate;
+  state_preds: state_predicates;
   event_pred: trace -> principal -> string -> bytes -> prop;
 }
 
@@ -117,9 +117,36 @@ class protocol_invariants = {
 // `trace_invariants` cannot be a typeclass that is inherited by `protocol_invariants`,
 // hence we simulate inheritance like this.
 
-let state_pred {|invs:protocol_invariants|} = invs.trace_invs.state_pred
-let state_update_pred {|invs:protocol_invariants|} = invs.trace_invs.state_update_pred
+let state_pred {|invs:protocol_invariants|} = invs.trace_invs.state_preds.state_pred
+let state_update_pred {|invs:protocol_invariants|} = invs.trace_invs.state_preds.state_update_pred
 let event_pred {|invs:protocol_invariants|} = invs.trace_invs.event_pred
+
+/// Default state predicates, allowing all state updates, but no state sets.
+/// In practice, this means that no states can be set with the default predicates,
+/// ensuring that state is not inadvertently used, but also makes it easy to supply
+/// only the state predicate (without the update predicate) in situations where we do
+/// not need to constrain updates.
+
+val default_state_predicate: {|crypto_invariants|} -> state_predicate
+let default_state_predicate #cinvs = {
+  pred = (fun tr prin sess_id b -> False);
+  pred_later = (fun tr1 tr2 prin sess_id b -> ());
+  pred_knowable = (fun tr prin sess_id b -> ());
+}
+
+val default_state_update_predicate: {|crypto_invariants|} -> state_update_predicate
+let default_state_update_predicate #cinvs = {
+  update_pred = (fun tr prin sess_id b1 b2 -> True);
+  update_pred_later = (fun tr1 tr2 prin sess_id b1 b2 -> ());
+  update_pred_trans = (fun tr prin sess_id b1 b2 b3 -> ());
+}
+
+val default_state_predicates: {|crypto_invariants|} -> state_predicates
+let default_state_predicates #cinvs = {
+  state_pred = default_state_predicate;
+  state_update_pred = default_state_update_predicate;
+}
+
 
 (*** Trace invariant definition ***)
 
@@ -133,12 +160,12 @@ let trace_entry_invariant #invs tr entry =
     is_publishable tr msg
   | SetState prin sess_id content -> (
     // Stored states satisfy the custom state predicate
-    invs.trace_invs.state_pred.pred tr prin sess_id content /\
+    state_pred.pred tr prin sess_id content /\
     (
       match get_most_recent_state_for_ghost tr prin sess_id with
       | None -> True
       | Some old_content ->
-        invs.trace_invs.state_update_pred.update_pred tr prin sess_id old_content content
+        state_update_pred.update_pred tr prin sess_id old_content content
     )
   )
   | Event prin tag content -> (
@@ -241,10 +268,10 @@ val state_was_set_implies_pred:
   ]
 let state_was_set_implies_pred #invs tr prin sess_id content =
   eliminate exists i. entry_at tr i (SetState prin sess_id content)
-  returns invs.trace_invs.state_pred.pred tr prin sess_id content
+  returns state_pred.pred tr prin sess_id content
   with _. (
     entry_at_implies_trace_entry_invariant tr i (SetState prin sess_id content);
-    invs.trace_invs.state_pred.pred_later (prefix tr i) tr prin sess_id content
+    state_pred.pred_later (prefix tr i) tr prin sess_id content
   )
 
 /// States stored are knowable by the corresponding principal and state identifier.

--- a/src/core/DY.Core.Trace.Manipulation.fst
+++ b/src/core/DY.Core.Trace.Manipulation.fst
@@ -497,6 +497,11 @@ val set_state_invariant:
   Lemma
   (requires
     state_pred.pred tr prin sess_id content /\
+    (
+      let content_old_opt = get_state_aux prin sess_id tr in
+      Some? content_old_opt ==>
+      state_update_pred.update_pred tr prin sess_id (Some?.v content_old_opt) content
+    ) /\
     trace_invariant tr
   )
   (ensures (

--- a/src/core/DY.Core.Trace.Manipulation.fst
+++ b/src/core/DY.Core.Trace.Manipulation.fst
@@ -460,6 +460,25 @@ val new_session_id_same_trace:
 let new_session_id_same_trace prin tr =
   normalize_term_spec new_session_id
 
+val new_session_id_is_most_recent_state_for:
+  prin:principal -> tr:trace ->
+  Lemma
+  (ensures (
+    let (sess_id, tr_out) = new_session_id prin tr in
+    is_most_recent_state_for prin sess_id None tr
+  ))
+  [SMTPat (new_session_id prin tr)]
+let new_session_id_is_most_recent_state_for prin tr =
+  reveal_opaque (`%new_session_id) (new_session_id);
+  reveal_opaque (`%is_most_recent_state_for) (is_most_recent_state_for);
+  let (sess_id, tr_out) = new_session_id prin tr in
+  match get_most_recent_state_for_ghost tr prin sess_id with
+  | None -> ()
+  | Some content -> (
+    assert(is_most_recent_state_for prin sess_id (Some content) tr);
+    compute_new_session_id_correct prin tr sess_id content
+  )
+
 #push-options "--ifuel 2"
 val set_state_is_most_recent_state_for:
   prin:principal -> sess_id:state_id ->

--- a/src/lib/communication/DY.Lib.Communication.Core.Lemmas.fst
+++ b/src/lib/communication/DY.Lib.Communication.Core.Lemmas.fst
@@ -49,7 +49,9 @@ val initialize_communication_proof:
   (requires
     trace_invariant tr /\
     has_private_keys_invariant /\
-    has_pki_invariant
+    has_private_keys_state_update_invariant /\
+    has_pki_invariant /\
+    has_pki_state_update_invariant
   )
   (ensures (
     let (_, tr_out) = initialize_communication sender receiver tr in

--- a/src/lib/communication/DY.Lib.Communication.Core.Lemmas.fst
+++ b/src/lib/communication/DY.Lib.Communication.Core.Lemmas.fst
@@ -50,10 +50,6 @@ val initialize_communication_proof:
     trace_invariant tr /\
     has_private_keys_preds /\
     has_pki_preds
-//    has_private_keys_invariant /\
-//    has_private_keys_state_update_invariant /\
-//    has_pki_invariant /\
-//    has_pki_state_update_invariant
   )
   (ensures (
     let (_, tr_out) = initialize_communication sender receiver tr in
@@ -101,7 +97,6 @@ val send_confidential_proof:
   (requires (
     trace_invariant tr /\
     has_pki_preds /\
-//    has_pki_invariant /\
     has_communication_layer_crypto_predicates /\
     has_communication_layer_event_predicates higher_layer_preds /\
     higher_layer_preds.send_conf tr sender receiver payload /\
@@ -183,7 +178,6 @@ val receive_confidential_proof:
   (requires
     trace_invariant tr /\
     has_private_keys_preds /\
-//    has_private_keys_invariant /\
     has_communication_layer_crypto_predicates /\
     has_communication_layer_event_predicates higher_layer_preds
   )
@@ -274,7 +268,6 @@ val send_authenticated_proof:
   Lemma
   (requires
     trace_invariant tr /\
-//    has_private_keys_invariant /\
     has_private_keys_preds /\
     has_communication_layer_crypto_predicates /\
     has_communication_layer_event_predicates higher_layer_preds /\
@@ -390,7 +383,6 @@ val receive_authenticated_proof:
   (requires
     trace_invariant tr /\
     has_pki_preds /\
-//    has_pki_invariant /\
     has_communication_layer_crypto_predicates /\
     has_communication_layer_event_predicates higher_layer_preds
   )
@@ -468,8 +460,6 @@ val send_confidential_authenticated_proof:
     trace_invariant tr /\
     has_private_keys_preds /\
     has_pki_preds /\
-//    has_private_keys_invariant /\
-//    has_pki_invariant /\
     has_communication_layer_crypto_predicates /\
     has_communication_layer_event_predicates higher_layer_preds /\
     higher_layer_preds.send_conf tr sender receiver payload /\
@@ -583,8 +573,6 @@ val receive_confidential_authenticated_proof:
     trace_invariant tr /\
     has_private_keys_preds /\
     has_pki_preds /\
-//    has_private_keys_invariant /\
-//    has_pki_invariant /\
     has_communication_layer_crypto_predicates /\
     has_communication_layer_event_predicates higher_layer_preds
   )

--- a/src/lib/communication/DY.Lib.Communication.Core.Lemmas.fst
+++ b/src/lib/communication/DY.Lib.Communication.Core.Lemmas.fst
@@ -48,10 +48,12 @@ val initialize_communication_proof:
   Lemma
   (requires
     trace_invariant tr /\
-    has_private_keys_invariant /\
-    has_private_keys_state_update_invariant /\
-    has_pki_invariant /\
-    has_pki_state_update_invariant
+    has_private_keys_preds /\
+    has_pki_preds
+//    has_private_keys_invariant /\
+//    has_private_keys_state_update_invariant /\
+//    has_pki_invariant /\
+//    has_pki_state_update_invariant
   )
   (ensures (
     let (_, tr_out) = initialize_communication sender receiver tr in
@@ -98,7 +100,8 @@ val send_confidential_proof:
   Lemma
   (requires (
     trace_invariant tr /\
-    has_pki_invariant /\
+    has_pki_preds /\
+//    has_pki_invariant /\
     has_communication_layer_crypto_predicates /\
     has_communication_layer_event_predicates higher_layer_preds /\
     higher_layer_preds.send_conf tr sender receiver payload /\
@@ -179,7 +182,8 @@ val receive_confidential_proof:
   Lemma
   (requires
     trace_invariant tr /\
-    has_private_keys_invariant /\
+    has_private_keys_preds /\
+//    has_private_keys_invariant /\
     has_communication_layer_crypto_predicates /\
     has_communication_layer_event_predicates higher_layer_preds
   )
@@ -270,7 +274,8 @@ val send_authenticated_proof:
   Lemma
   (requires
     trace_invariant tr /\
-    has_private_keys_invariant /\
+//    has_private_keys_invariant /\
+    has_private_keys_preds /\
     has_communication_layer_crypto_predicates /\
     has_communication_layer_event_predicates higher_layer_preds /\
     higher_layer_preds.send_auth tr sender payload /\
@@ -384,7 +389,8 @@ val receive_authenticated_proof:
   Lemma
   (requires
     trace_invariant tr /\
-    has_pki_invariant /\
+    has_pki_preds /\
+//    has_pki_invariant /\
     has_communication_layer_crypto_predicates /\
     has_communication_layer_event_predicates higher_layer_preds
   )
@@ -460,8 +466,10 @@ val send_confidential_authenticated_proof:
   Lemma
   (requires
     trace_invariant tr /\
-    has_private_keys_invariant /\
-    has_pki_invariant /\
+    has_private_keys_preds /\
+    has_pki_preds /\
+//    has_private_keys_invariant /\
+//    has_pki_invariant /\
     has_communication_layer_crypto_predicates /\
     has_communication_layer_event_predicates higher_layer_preds /\
     higher_layer_preds.send_conf tr sender receiver payload /\
@@ -573,8 +581,10 @@ val receive_confidential_authenticated_proof:
   Lemma
   (requires
     trace_invariant tr /\
-    has_private_keys_invariant /\
-    has_pki_invariant /\
+    has_private_keys_preds /\
+    has_pki_preds /\
+//    has_private_keys_invariant /\
+//    has_pki_invariant /\
     has_communication_layer_crypto_predicates /\
     has_communication_layer_event_predicates higher_layer_preds
   )

--- a/src/lib/communication/DY.Lib.Communication.Data.fst
+++ b/src/lib/communication/DY.Lib.Communication.Data.fst
@@ -28,12 +28,12 @@ instance parseable_serializeable_bytes_com_send_byte: parseable_serializeable by
 /// Data structure to return data from communication layer functions
 type communication_message (a:Type) = {
   sender:principal;
-  receiver:principal;  
+  receiver:principal;
   payload:a;
 }
 
 [@@with_bytes bytes]
-type signature_input = 
+type signature_input =
   | Plain: sender:principal -> receiver:principal -> payload:bytes -> signature_input
   | Encrypted: sender:principal -> receiver:principal -> payload:bytes -> pk:bytes -> signature_input
 

--- a/src/lib/communication/DY.Lib.Communication.RequestResponse.Invariants.fst
+++ b/src/lib/communication/DY.Lib.Communication.RequestResponse.Invariants.fst
@@ -90,12 +90,18 @@ val state_predicates_communication_layer_and_tag:
 let state_predicates_communication_layer_and_tag #cinvs =
   mk_local_state_tag_and_pred state_predicates_communication_layer
 
+val state_update_predicates_communication_layer_and_tag:
+  {|crypto_invariants|} ->
+  dtuple2 string local_bytes_state_update_predicate
+let state_update_predicates_communication_layer_and_tag #cinvs =
+  mk_local_state_tag_and_update_pred (default_local_state_update_pred communication_states)
+
 val has_communication_layer_state_predicates:
   {|protocol_invariants|} ->
   prop
 let has_communication_layer_state_predicates #invs =
-  has_local_state_predicate state_predicates_communication_layer
-
+  has_local_state_predicate state_predicates_communication_layer /\
+  has_local_state_update_predicate (default_local_state_update_pred communication_states)
 
 (*** Event Predicates ***)
 

--- a/src/lib/communication/DY.Lib.Communication.RequestResponse.Invariants.fst
+++ b/src/lib/communication/DY.Lib.Communication.RequestResponse.Invariants.fst
@@ -98,13 +98,6 @@ val state_predicates_communication_layer_and_tag:
 let state_predicates_communication_layer_and_tag #cinvs =
   mk_local_state_tag_and_preds state_predicates_communication_layer
 
-(*
-val state_update_predicates_communication_layer_and_tag:
-  {|crypto_invariants|} ->
-  dtuple2 string local_bytes_state_update_predicate
-let state_update_predicates_communication_layer_and_tag #cinvs =
-  mk_local_state_tag_and_update_pred (default_local_state_update_pred communication_states)
-*)
 
 unfold
 val has_communication_layer_state_predicates:
@@ -112,8 +105,6 @@ val has_communication_layer_state_predicates:
   prop
 let has_communication_layer_state_predicates #invs =
   has_local_state_predicates state_predicates_communication_layer
-//  has_local_state_predicate state_predicates_communication_layer /\
-//  has_local_state_update_predicate (default_local_state_update_pred communication_states)
 
 (*** Event Predicates ***)
 

--- a/src/lib/communication/DY.Lib.Communication.RequestResponse.Invariants.fst
+++ b/src/lib/communication/DY.Lib.Communication.RequestResponse.Invariants.fst
@@ -58,7 +58,7 @@ let has_communication_layer_reqres_crypto_predicates #cinvs =
 (*** State Predicates ***)
 
 #push-options "--ifuel 2 --z3rlimit 25"
-let state_predicates_communication_layer {|crypto_invariants|}: local_state_predicate communication_states = {
+let state_predicate_communication_layer {|crypto_invariants|}: local_state_predicate communication_states = {
   pred = (fun tr prin sess_id st ->
     match st with
     | ClientSendRequest {server; request; key} -> (
@@ -84,24 +84,36 @@ let state_predicates_communication_layer {|crypto_invariants|}: local_state_pred
 }
 #pop-options
 
+val state_predicates_communication_layer:
+  {|crypto_invariants|} ->
+  local_state_predicates communication_states
+let state_predicates_communication_layer #cinvs = {
+  default_local_state_preds communication_states with
+  local_state_pred = state_predicate_communication_layer
+}
+
 val state_predicates_communication_layer_and_tag:
   {|crypto_invariants|} ->
-  dtuple2 string local_bytes_state_predicate
+  dtuple2 string local_bytes_state_predicates
 let state_predicates_communication_layer_and_tag #cinvs =
-  mk_local_state_tag_and_pred state_predicates_communication_layer
+  mk_local_state_tag_and_preds state_predicates_communication_layer
 
+(*
 val state_update_predicates_communication_layer_and_tag:
   {|crypto_invariants|} ->
   dtuple2 string local_bytes_state_update_predicate
 let state_update_predicates_communication_layer_and_tag #cinvs =
   mk_local_state_tag_and_update_pred (default_local_state_update_pred communication_states)
+*)
 
+unfold
 val has_communication_layer_state_predicates:
   {|protocol_invariants|} ->
   prop
 let has_communication_layer_state_predicates #invs =
-  has_local_state_predicate state_predicates_communication_layer /\
-  has_local_state_update_predicate (default_local_state_update_pred communication_states)
+  has_local_state_predicates state_predicates_communication_layer
+//  has_local_state_predicate state_predicates_communication_layer /\
+//  has_local_state_update_predicate (default_local_state_update_pred communication_states)
 
 (*** Event Predicates ***)
 

--- a/src/lib/communication/DY.Lib.Communication.RequestResponse.Lemmas.fst
+++ b/src/lib/communication/DY.Lib.Communication.RequestResponse.Lemmas.fst
@@ -70,6 +70,7 @@ val send_request_proof:
   (requires
     trace_invariant tr /\
     has_pki_invariant /\
+    has_pki_state_update_invariant /\
     has_communication_layer_crypto_predicates /\
     has_communication_layer_reqres_event_predicates request_response_event_preconditions higher_layer_preds /\
     has_communication_layer_state_predicates /\

--- a/src/lib/communication/DY.Lib.Communication.RequestResponse.Lemmas.fst
+++ b/src/lib/communication/DY.Lib.Communication.RequestResponse.Lemmas.fst
@@ -69,8 +69,9 @@ val send_request_proof:
   Lemma
   (requires
     trace_invariant tr /\
-    has_pki_invariant /\
-    has_pki_state_update_invariant /\
+    has_pki_preds /\
+//    has_pki_invariant /\
+//    has_pki_state_update_invariant /\
     has_communication_layer_crypto_predicates /\
     has_communication_layer_reqres_event_predicates request_response_event_preconditions higher_layer_preds /\
     has_communication_layer_state_predicates /\
@@ -128,8 +129,10 @@ val receive_request_proof:
   Lemma
   (requires
     trace_invariant tr /\
-    has_private_keys_invariant /\
-    has_pki_invariant /\
+    has_private_keys_preds /\
+    has_pki_preds /\
+//    has_private_keys_invariant /\
+//    has_pki_invariant /\
     has_communication_layer_reqres_crypto_predicates /\
     has_communication_layer_reqres_event_predicates request_response_event_preconditions higher_layer_preds /\
     has_communication_layer_state_predicates

--- a/src/lib/communication/DY.Lib.Communication.RequestResponse.Lemmas.fst
+++ b/src/lib/communication/DY.Lib.Communication.RequestResponse.Lemmas.fst
@@ -70,8 +70,6 @@ val send_request_proof:
   (requires
     trace_invariant tr /\
     has_pki_preds /\
-//    has_pki_invariant /\
-//    has_pki_state_update_invariant /\
     has_communication_layer_crypto_predicates /\
     has_communication_layer_reqres_event_predicates request_response_event_preconditions higher_layer_preds /\
     has_communication_layer_state_predicates /\
@@ -131,8 +129,6 @@ val receive_request_proof:
     trace_invariant tr /\
     has_private_keys_preds /\
     has_pki_preds /\
-//    has_private_keys_invariant /\
-//    has_pki_invariant /\
     has_communication_layer_reqres_crypto_predicates /\
     has_communication_layer_reqres_event_predicates request_response_event_preconditions higher_layer_preds /\
     has_communication_layer_state_predicates

--- a/src/lib/state/DY.Lib.State.Map.fst
+++ b/src/lib/state/DY.Lib.State.Map.fst
@@ -140,37 +140,6 @@ val mk_map_state_tag_and_preds:
 let mk_map_state_tag_and_preds #key_t #value_t #mt #cinvs mpred =
   mk_local_state_tag_and_preds (map_state_preds mpred)
 
-(*
-unfold
-val has_map_session_invariant:
-  #key_t:eqtype -> #value_t:Type0 -> {|map_types key_t value_t|} ->
-  {|protocol_invariants|} -> map_predicate key_t value_t -> prop
-let has_map_session_invariant #key_t #value_t #mt #invs mpred =
-  has_local_bytes_state_predicate (mk_map_state_tag_and_pred mpred)
-
-val map_state_update_invariant:
-  {|crypto_invariants|} ->
-  #key_t:eqtype -> #value_t:Type0 -> {|map_types key_t value_t|} ->
-   map_predicate key_t value_t ->
-  local_state_update_predicate (map key_t value_t)
-let map_state_update_invariant #cinvs #key_t #value_t #mt mpred =
-  default_local_state_update_pred (map key_t value_t)
-
-val mk_map_state_tag_and_update_pred:
-  #key_t:eqtype -> #value_t:Type0 -> {|map_types key_t value_t|} ->
-  {|crypto_invariants|} -> map_predicate key_t value_t ->
-  dtuple2 string local_bytes_state_update_predicate
-let mk_map_state_tag_and_update_pred #key_t #value_t #mt #cinvs mpred =
-  mk_local_state_tag_and_update_pred (map_state_update_invariant mpred)
-
-unfold
-val has_map_state_update_invariant:
-  #key_t:eqtype -> #value_t:Type0 -> {|map_types key_t value_t|} ->
-  {|protocol_invariants|} -> map_predicate key_t value_t -> prop
-let has_map_state_update_invariant #key_t #value_t #mt #invs mpred =
-  has_local_bytes_state_update_predicate (mk_map_state_tag_and_update_pred mpred)
-*)
-
 unfold
 val has_map_state_preds:
   #key_t:eqtype -> #value_t:Type0 -> {|map_types key_t value_t|} ->
@@ -248,16 +217,12 @@ val initialize_map_invariant:
   (requires
     trace_invariant tr /\
     has_map_state_preds mpred
-//    has_map_session_invariant mpred /\
-//    has_map_state_update_invariant mpred
   )
   (ensures (
     let (_, tr_out) = initialize_map key_t value_t prin tr in
     trace_invariant tr_out
   ))
   [SMTPat (initialize_map key_t value_t prin tr);
-//   SMTPat (has_map_session_invariant mpred);
-//   SMTPat (has_map_state_update_invariant mpred);
    SMTPat (has_map_state_preds mpred);
    SMTPat (trace_invariant tr)
   ]
@@ -278,8 +243,6 @@ val add_key_value_invariant:
     mpred.pred tr prin sess_id key value /\
     trace_invariant tr /\
     has_map_state_preds mpred
-//    has_map_session_invariant mpred /\
-//    has_map_state_update_invariant mpred
   )
   (ensures (
     let (_, tr_out) = add_key_value prin sess_id key value tr in
@@ -287,8 +250,6 @@ val add_key_value_invariant:
   ))
   [SMTPat (add_key_value prin sess_id key value tr);
    SMTPat (has_map_state_preds mpred);
-//   SMTPat (has_map_session_invariant mpred);
-//   SMTPat (has_map_state_update_invariant mpred);
    SMTPat (trace_invariant tr)
   ]
 let add_key_value_invariant #invs #key_t #value_t #mt mpred prin sess_id key value tr =
@@ -320,7 +281,6 @@ val find_value_invariant:
   (requires
     trace_invariant tr /\
     has_map_state_preds mpred
-//    has_map_session_invariant mpred
   )
   (ensures (
     let (opt_value, tr_out) = find_value prin sess_id key tr in
@@ -331,7 +291,6 @@ val find_value_invariant:
       )
   ))
   [SMTPat (find_value #key_t #value_t prin sess_id key tr);
-//   SMTPat (has_map_session_invariant mpred);
    SMTPat (has_map_state_preds mpred);
    SMTPat (trace_invariant tr);
   ]

--- a/src/lib/state/DY.Lib.State.Map.fst
+++ b/src/lib/state/DY.Lib.State.Map.fst
@@ -123,13 +123,24 @@ let map_session_invariant #cinvs #key_t #value_t #mt mpred = {
   );
 }
 
-val mk_map_state_tag_and_pred:
+val map_state_preds:
+  {|crypto_invariants|} ->
+  #key_t:eqtype -> #value_t:Type0 -> {|map_types key_t value_t|} ->
+  mpred:map_predicate key_t value_t ->
+  local_state_predicates (map key_t value_t)
+let map_state_preds #cinvs #key_t #value_t #map_t mpred = {
+  default_local_state_preds (map key_t value_t) with
+  local_state_pred = map_session_invariant mpred;
+}
+
+val mk_map_state_tag_and_preds:
   #key_t:eqtype -> #value_t:Type0 -> {|map_types key_t value_t|} ->
   {|crypto_invariants|} -> map_predicate key_t value_t ->
-  dtuple2 string local_bytes_state_predicate
-let mk_map_state_tag_and_pred #key_t #value_t #mt #cinvs mpred =
-  mk_local_state_tag_and_pred (map_session_invariant mpred)
+  dtuple2 string local_bytes_state_predicates
+let mk_map_state_tag_and_preds #key_t #value_t #mt #cinvs mpred =
+  mk_local_state_tag_and_preds (map_state_preds mpred)
 
+(*
 unfold
 val has_map_session_invariant:
   #key_t:eqtype -> #value_t:Type0 -> {|map_types key_t value_t|} ->
@@ -158,6 +169,14 @@ val has_map_state_update_invariant:
   {|protocol_invariants|} -> map_predicate key_t value_t -> prop
 let has_map_state_update_invariant #key_t #value_t #mt #invs mpred =
   has_local_bytes_state_update_predicate (mk_map_state_tag_and_update_pred mpred)
+*)
+
+unfold
+val has_map_state_preds:
+  #key_t:eqtype -> #value_t:Type0 -> {|map_types key_t value_t|} ->
+  {|protocol_invariants|} -> map_predicate key_t value_t -> prop
+let has_map_state_preds #key_t #value_t #map_t #invs mpred =
+  has_local_bytes_state_predicates (mk_map_state_tag_and_preds mpred)
 
 (*** Map API ***)
 
@@ -228,16 +247,18 @@ val initialize_map_invariant:
   Lemma
   (requires
     trace_invariant tr /\
-    has_map_session_invariant mpred /\
-    has_map_state_update_invariant mpred
+    has_map_state_preds mpred
+//    has_map_session_invariant mpred /\
+//    has_map_state_update_invariant mpred
   )
   (ensures (
     let (_, tr_out) = initialize_map key_t value_t prin tr in
     trace_invariant tr_out
   ))
   [SMTPat (initialize_map key_t value_t prin tr);
-   SMTPat (has_map_session_invariant mpred);
-   SMTPat (has_map_state_update_invariant mpred);
+//   SMTPat (has_map_session_invariant mpred);
+//   SMTPat (has_map_state_update_invariant mpred);
+   SMTPat (has_map_state_preds mpred);
    SMTPat (trace_invariant tr)
   ]
 let initialize_map_invariant #invs #key_t #value_t #mt mpred prin tr =
@@ -256,16 +277,18 @@ val add_key_value_invariant:
   (requires
     mpred.pred tr prin sess_id key value /\
     trace_invariant tr /\
-    has_map_session_invariant mpred /\
-    has_map_state_update_invariant mpred
+    has_map_state_preds mpred
+//    has_map_session_invariant mpred /\
+//    has_map_state_update_invariant mpred
   )
   (ensures (
     let (_, tr_out) = add_key_value prin sess_id key value tr in
     trace_invariant tr_out
   ))
   [SMTPat (add_key_value prin sess_id key value tr);
-   SMTPat (has_map_session_invariant mpred);
-   SMTPat (has_map_state_update_invariant mpred);
+   SMTPat (has_map_state_preds mpred);
+//   SMTPat (has_map_session_invariant mpred);
+//   SMTPat (has_map_state_update_invariant mpred);
    SMTPat (trace_invariant tr)
   ]
 let add_key_value_invariant #invs #key_t #value_t #mt mpred prin sess_id key value tr =
@@ -296,7 +319,8 @@ val find_value_invariant:
   Lemma
   (requires
     trace_invariant tr /\
-    has_map_session_invariant mpred
+    has_map_state_preds mpred
+//    has_map_session_invariant mpred
   )
   (ensures (
     let (opt_value, tr_out) = find_value prin sess_id key tr in
@@ -307,7 +331,8 @@ val find_value_invariant:
       )
   ))
   [SMTPat (find_value #key_t #value_t prin sess_id key tr);
-   SMTPat (has_map_session_invariant mpred);
+//   SMTPat (has_map_session_invariant mpred);
+   SMTPat (has_map_state_preds mpred);
    SMTPat (trace_invariant tr);
   ]
 let find_value_invariant #invs #key_t #value_t #mt mpred prin sess_id key tr =

--- a/src/lib/state/DY.Lib.State.PKI.fst
+++ b/src/lib/state/DY.Lib.State.PKI.fst
@@ -64,6 +64,14 @@ val has_pki_invariant: {|protocol_invariants|} -> prop
 let has_pki_invariant #invs =
   has_local_bytes_state_predicate pki_tag_and_invariant
 
+val pki_tag_and_state_update_pred: {|crypto_invariants|} -> dtuple2 string local_bytes_state_update_predicate
+let pki_tag_and_state_update_pred #ci = mk_map_state_tag_and_update_pred pki_pred
+
+unfold
+val has_pki_state_update_invariant: {|protocol_invariants|} -> prop
+let has_pki_state_update_invariant #invs =
+  has_local_bytes_state_update_predicate pki_tag_and_state_update_pred
+
 (*** PKI API ***)
 
 [@@ "opaque_to_smt"]
@@ -87,7 +95,8 @@ val initialize_pki_invariant:
   Lemma
   (requires
     trace_invariant tr /\
-    has_pki_invariant
+    has_pki_invariant /\
+    has_pki_state_update_invariant
   )
   (ensures (
     let (_, tr_out) = initialize_pki prin tr in
@@ -95,6 +104,7 @@ val initialize_pki_invariant:
   ))
   [SMTPat (initialize_pki prin tr);
    SMTPat (has_pki_invariant);
+   SMTPat (has_pki_state_update_invariant);
    SMTPat (trace_invariant tr)]
 let initialize_pki_invariant #invs prin tr =
   reveal_opaque (`%initialize_pki) (initialize_pki)
@@ -106,7 +116,8 @@ val install_public_key_invariant:
   (requires
     is_public_key_for tr pk pk_type who /\
     trace_invariant tr /\
-    has_pki_invariant
+    has_pki_invariant /\
+    has_pki_state_update_invariant
   )
   (ensures (
     let (_, tr_out) = install_public_key prin sess_id pk_type who pk tr in
@@ -114,6 +125,7 @@ val install_public_key_invariant:
   ))
   [SMTPat (install_public_key prin sess_id pk_type who pk tr);
    SMTPat (has_pki_invariant);
+   SMTPat (has_pki_state_update_invariant);
    SMTPat (trace_invariant tr)]
 let install_public_key_invariant #invs prin sess_id pk_type who pk tr =
   reveal_opaque (`%install_public_key) (install_public_key)

--- a/src/lib/state/DY.Lib.State.PKI.fst
+++ b/src/lib/state/DY.Lib.State.PKI.fst
@@ -56,9 +56,15 @@ let pki_pred #cinvs = {
   pred_knowable = (fun tr prin sess_id key value -> ());
 }
 
-val pki_tag_and_invariant: {|crypto_invariants|} -> dtuple2 string local_bytes_state_predicate
-let pki_tag_and_invariant #ci = mk_map_state_tag_and_pred pki_pred
+val pki_tag_and_preds: {|crypto_invariants|} -> dtuple2 string local_bytes_state_predicates
+let pki_tag_and_preds #ci = mk_map_state_tag_and_preds pki_pred
 
+unfold
+val has_pki_preds: {|protocol_invariants|} -> prop
+let has_pki_preds #invs =
+  has_local_bytes_state_predicates pki_tag_and_preds
+
+(*
 unfold
 val has_pki_invariant: {|protocol_invariants|} -> prop
 let has_pki_invariant #invs =
@@ -71,6 +77,7 @@ unfold
 val has_pki_state_update_invariant: {|protocol_invariants|} -> prop
 let has_pki_state_update_invariant #invs =
   has_local_bytes_state_update_predicate pki_tag_and_state_update_pred
+*)
 
 (*** PKI API ***)
 
@@ -95,16 +102,18 @@ val initialize_pki_invariant:
   Lemma
   (requires
     trace_invariant tr /\
-    has_pki_invariant /\
-    has_pki_state_update_invariant
+    has_pki_preds
+//    has_pki_invariant /\
+//    has_pki_state_update_invariant
   )
   (ensures (
     let (_, tr_out) = initialize_pki prin tr in
     trace_invariant tr_out
   ))
   [SMTPat (initialize_pki prin tr);
-   SMTPat (has_pki_invariant);
-   SMTPat (has_pki_state_update_invariant);
+//   SMTPat (has_pki_invariant);
+//   SMTPat (has_pki_state_update_invariant);
+   SMTPat (has_pki_preds);
    SMTPat (trace_invariant tr)]
 let initialize_pki_invariant #invs prin tr =
   reveal_opaque (`%initialize_pki) (initialize_pki)
@@ -116,16 +125,18 @@ val install_public_key_invariant:
   (requires
     is_public_key_for tr pk pk_type who /\
     trace_invariant tr /\
-    has_pki_invariant /\
-    has_pki_state_update_invariant
+    has_pki_preds
+//    has_pki_invariant /\
+//    has_pki_state_update_invariant
   )
   (ensures (
     let (_, tr_out) = install_public_key prin sess_id pk_type who pk tr in
     trace_invariant tr_out
   ))
   [SMTPat (install_public_key prin sess_id pk_type who pk tr);
-   SMTPat (has_pki_invariant);
-   SMTPat (has_pki_state_update_invariant);
+   SMTPat (has_pki_preds);
+//   SMTPat (has_pki_invariant);
+//   SMTPat (has_pki_state_update_invariant);
    SMTPat (trace_invariant tr)]
 let install_public_key_invariant #invs prin sess_id pk_type who pk tr =
   reveal_opaque (`%install_public_key) (install_public_key)
@@ -148,7 +159,8 @@ val get_public_key_invariant:
   Lemma
   (requires
     trace_invariant tr /\
-    has_pki_invariant
+    has_pki_preds
+//    has_pki_invariant
   )
   (ensures (
     let (opt_public_key, tr_out) = get_public_key prin sess_id pk_type who tr in
@@ -158,7 +170,8 @@ val get_public_key_invariant:
         is_public_key_for tr public_key pk_type who
   ))
   [SMTPat (get_public_key prin sess_id pk_type who tr);
-   SMTPat (has_pki_invariant);
+   SMTPat (has_pki_preds);
+//   SMTPat (has_pki_invariant);
    SMTPat (trace_invariant tr)]
 let get_public_key_invariant #invs prin sess_id pk_type who tr =
   reveal_opaque (`%get_public_key) (get_public_key)

--- a/src/lib/state/DY.Lib.State.PKI.fst
+++ b/src/lib/state/DY.Lib.State.PKI.fst
@@ -64,21 +64,6 @@ val has_pki_preds: {|protocol_invariants|} -> prop
 let has_pki_preds #invs =
   has_local_bytes_state_predicates pki_tag_and_preds
 
-(*
-unfold
-val has_pki_invariant: {|protocol_invariants|} -> prop
-let has_pki_invariant #invs =
-  has_local_bytes_state_predicate pki_tag_and_invariant
-
-val pki_tag_and_state_update_pred: {|crypto_invariants|} -> dtuple2 string local_bytes_state_update_predicate
-let pki_tag_and_state_update_pred #ci = mk_map_state_tag_and_update_pred pki_pred
-
-unfold
-val has_pki_state_update_invariant: {|protocol_invariants|} -> prop
-let has_pki_state_update_invariant #invs =
-  has_local_bytes_state_update_predicate pki_tag_and_state_update_pred
-*)
-
 (*** PKI API ***)
 
 [@@ "opaque_to_smt"]
@@ -103,16 +88,12 @@ val initialize_pki_invariant:
   (requires
     trace_invariant tr /\
     has_pki_preds
-//    has_pki_invariant /\
-//    has_pki_state_update_invariant
   )
   (ensures (
     let (_, tr_out) = initialize_pki prin tr in
     trace_invariant tr_out
   ))
   [SMTPat (initialize_pki prin tr);
-//   SMTPat (has_pki_invariant);
-//   SMTPat (has_pki_state_update_invariant);
    SMTPat (has_pki_preds);
    SMTPat (trace_invariant tr)]
 let initialize_pki_invariant #invs prin tr =
@@ -126,8 +107,6 @@ val install_public_key_invariant:
     is_public_key_for tr pk pk_type who /\
     trace_invariant tr /\
     has_pki_preds
-//    has_pki_invariant /\
-//    has_pki_state_update_invariant
   )
   (ensures (
     let (_, tr_out) = install_public_key prin sess_id pk_type who pk tr in
@@ -135,8 +114,6 @@ val install_public_key_invariant:
   ))
   [SMTPat (install_public_key prin sess_id pk_type who pk tr);
    SMTPat (has_pki_preds);
-//   SMTPat (has_pki_invariant);
-//   SMTPat (has_pki_state_update_invariant);
    SMTPat (trace_invariant tr)]
 let install_public_key_invariant #invs prin sess_id pk_type who pk tr =
   reveal_opaque (`%install_public_key) (install_public_key)
@@ -160,7 +137,6 @@ val get_public_key_invariant:
   (requires
     trace_invariant tr /\
     has_pki_preds
-//    has_pki_invariant
   )
   (ensures (
     let (opt_public_key, tr_out) = get_public_key prin sess_id pk_type who tr in
@@ -171,7 +147,6 @@ val get_public_key_invariant:
   ))
   [SMTPat (get_public_key prin sess_id pk_type who tr);
    SMTPat (has_pki_preds);
-//   SMTPat (has_pki_invariant);
    SMTPat (trace_invariant tr)]
 let get_public_key_invariant #invs prin sess_id pk_type who tr =
   reveal_opaque (`%get_public_key) (get_public_key)

--- a/src/lib/state/DY.Lib.State.PrivateKeys.fst
+++ b/src/lib/state/DY.Lib.State.PrivateKeys.fst
@@ -110,6 +110,14 @@ val has_private_keys_invariant: {|protocol_invariants|} -> prop
 let has_private_keys_invariant #invs =
   has_local_bytes_state_predicate private_keys_tag_and_invariant
 
+val private_keys_tag_and_state_update_pred: {|crypto_invariants|} -> dtuple2 string local_bytes_state_update_predicate
+let private_keys_tag_and_state_update_pred #ci = mk_map_state_tag_and_update_pred private_keys_pred
+
+unfold
+val has_private_keys_state_update_invariant: {|protocol_invariants|} -> prop
+let has_private_keys_state_update_invariant #invs =
+  has_local_bytes_state_update_predicate private_keys_tag_and_state_update_pred
+
 (*** Private Keys API ***)
 
 [@@ "opaque_to_smt"]
@@ -144,7 +152,8 @@ val initialize_private_keys_invariant:
   Lemma
   (requires
     trace_invariant tr /\
-    has_private_keys_invariant
+    has_private_keys_invariant /\
+    has_private_keys_state_update_invariant
   )
   (ensures (
     let (_, tr_out) = initialize_private_keys prin tr in
@@ -152,6 +161,7 @@ val initialize_private_keys_invariant:
   ))
   [SMTPat (initialize_private_keys prin tr);
    SMTPat (has_private_keys_invariant);
+   SMTPat (has_private_keys_state_update_invariant);
    SMTPat (trace_invariant tr)]
 let initialize_private_keys_invariant #invs prin tr =
   reveal_opaque (`%initialize_private_keys) (initialize_private_keys)
@@ -162,7 +172,8 @@ val generate_private_key_invariant:
   Lemma
   (requires
     trace_invariant tr /\
-    has_private_keys_invariant
+    has_private_keys_invariant /\
+    has_private_keys_state_update_invariant
   )
   (ensures (
     let (_, tr_out) = generate_private_key prin sess_id sk_type tr in
@@ -170,6 +181,7 @@ val generate_private_key_invariant:
   ))
   [SMTPat (generate_private_key prin sess_id sk_type tr);
    SMTPat (has_private_keys_invariant);
+   SMTPat (has_private_keys_state_update_invariant);
    SMTPat (trace_invariant tr)]
 let generate_private_key_invariant #invs prin sess_id sk_type tr =
   reveal_opaque (`%generate_private_key) (generate_private_key)

--- a/src/lib/state/DY.Lib.State.PrivateKeys.fst
+++ b/src/lib/state/DY.Lib.State.PrivateKeys.fst
@@ -102,9 +102,15 @@ let private_keys_pred #cinvs = {
 }
 #pop-options
 
-val private_keys_tag_and_invariant: {|crypto_invariants|} -> dtuple2 string local_bytes_state_predicate
-let private_keys_tag_and_invariant #ci = mk_map_state_tag_and_pred private_keys_pred
+val private_keys_tag_and_preds: {|crypto_invariants|} -> dtuple2 string local_bytes_state_predicates
+let private_keys_tag_and_preds #ci = mk_map_state_tag_and_preds private_keys_pred
 
+unfold
+val has_private_keys_preds: {|protocol_invariants|} -> prop
+let has_private_keys_preds #invs =
+  has_local_bytes_state_predicates private_keys_tag_and_preds
+
+(*
 unfold
 val has_private_keys_invariant: {|protocol_invariants|} -> prop
 let has_private_keys_invariant #invs =
@@ -117,6 +123,7 @@ unfold
 val has_private_keys_state_update_invariant: {|protocol_invariants|} -> prop
 let has_private_keys_state_update_invariant #invs =
   has_local_bytes_state_update_predicate private_keys_tag_and_state_update_pred
+*)
 
 (*** Private Keys API ***)
 
@@ -152,16 +159,18 @@ val initialize_private_keys_invariant:
   Lemma
   (requires
     trace_invariant tr /\
-    has_private_keys_invariant /\
-    has_private_keys_state_update_invariant
+    has_private_keys_preds
+//    has_private_keys_invariant /\
+//    has_private_keys_state_update_invariant
   )
   (ensures (
     let (_, tr_out) = initialize_private_keys prin tr in
     trace_invariant tr_out
   ))
   [SMTPat (initialize_private_keys prin tr);
-   SMTPat (has_private_keys_invariant);
-   SMTPat (has_private_keys_state_update_invariant);
+   SMTPat (has_private_keys_preds);
+//   SMTPat (has_private_keys_invariant);
+//   SMTPat (has_private_keys_state_update_invariant);
    SMTPat (trace_invariant tr)]
 let initialize_private_keys_invariant #invs prin tr =
   reveal_opaque (`%initialize_private_keys) (initialize_private_keys)
@@ -172,16 +181,18 @@ val generate_private_key_invariant:
   Lemma
   (requires
     trace_invariant tr /\
-    has_private_keys_invariant /\
-    has_private_keys_state_update_invariant
+    has_private_keys_preds
+//    has_private_keys_invariant /\
+//    has_private_keys_state_update_invariant
   )
   (ensures (
     let (_, tr_out) = generate_private_key prin sess_id sk_type tr in
     trace_invariant tr_out
   ))
   [SMTPat (generate_private_key prin sess_id sk_type tr);
-   SMTPat (has_private_keys_invariant);
-   SMTPat (has_private_keys_state_update_invariant);
+   SMTPat (has_private_keys_preds);
+//   SMTPat (has_private_keys_invariant);
+//   SMTPat (has_private_keys_state_update_invariant);
    SMTPat (trace_invariant tr)]
 let generate_private_key_invariant #invs prin sess_id sk_type tr =
   reveal_opaque (`%generate_private_key) (generate_private_key)
@@ -204,7 +215,8 @@ val get_private_key_invariant:
   Lemma
   (requires
     trace_invariant tr /\
-    has_private_keys_invariant
+    has_private_keys_preds
+//    has_private_keys_invariant
   )
   (ensures (
     let (opt_private_key, tr_out) = get_private_key prin sess_id pk_type tr in
@@ -214,7 +226,8 @@ val get_private_key_invariant:
         is_private_key_for tr private_key pk_type prin
   ))
   [SMTPat (get_private_key prin sess_id pk_type tr);
-   SMTPat (has_private_keys_invariant);
+   SMTPat (has_private_keys_preds);
+//   SMTPat (has_private_keys_invariant);
    SMTPat (trace_invariant tr)]
 let get_private_key_invariant #invs prin sess_id pk_type tr =
   reveal_opaque (`%get_private_key) (get_private_key)
@@ -238,7 +251,8 @@ val compute_public_key_invariant:
   Lemma
   (requires
     trace_invariant tr /\
-    has_private_keys_invariant
+    has_private_keys_preds
+//    has_private_keys_invariant
   )
   (ensures (
     let (opt_private_key, tr_out) = compute_public_key prin sess_id pk_type tr in
@@ -248,7 +262,8 @@ val compute_public_key_invariant:
         is_public_key_for tr private_key pk_type prin
   ))
   [SMTPat (compute_public_key prin sess_id pk_type tr);
-   SMTPat (has_private_keys_invariant);
+   SMTPat (has_private_keys_preds);
+//   SMTPat (has_private_keys_invariant);
    SMTPat (trace_invariant tr)]
 let compute_public_key_invariant #invs prin sess_id pk_type tr =
   reveal_opaque (`%compute_public_key) (compute_public_key)

--- a/src/lib/state/DY.Lib.State.PrivateKeys.fst
+++ b/src/lib/state/DY.Lib.State.PrivateKeys.fst
@@ -110,21 +110,6 @@ val has_private_keys_preds: {|protocol_invariants|} -> prop
 let has_private_keys_preds #invs =
   has_local_bytes_state_predicates private_keys_tag_and_preds
 
-(*
-unfold
-val has_private_keys_invariant: {|protocol_invariants|} -> prop
-let has_private_keys_invariant #invs =
-  has_local_bytes_state_predicate private_keys_tag_and_invariant
-
-val private_keys_tag_and_state_update_pred: {|crypto_invariants|} -> dtuple2 string local_bytes_state_update_predicate
-let private_keys_tag_and_state_update_pred #ci = mk_map_state_tag_and_update_pred private_keys_pred
-
-unfold
-val has_private_keys_state_update_invariant: {|protocol_invariants|} -> prop
-let has_private_keys_state_update_invariant #invs =
-  has_local_bytes_state_update_predicate private_keys_tag_and_state_update_pred
-*)
-
 (*** Private Keys API ***)
 
 [@@ "opaque_to_smt"]
@@ -160,8 +145,6 @@ val initialize_private_keys_invariant:
   (requires
     trace_invariant tr /\
     has_private_keys_preds
-//    has_private_keys_invariant /\
-//    has_private_keys_state_update_invariant
   )
   (ensures (
     let (_, tr_out) = initialize_private_keys prin tr in
@@ -169,8 +152,6 @@ val initialize_private_keys_invariant:
   ))
   [SMTPat (initialize_private_keys prin tr);
    SMTPat (has_private_keys_preds);
-//   SMTPat (has_private_keys_invariant);
-//   SMTPat (has_private_keys_state_update_invariant);
    SMTPat (trace_invariant tr)]
 let initialize_private_keys_invariant #invs prin tr =
   reveal_opaque (`%initialize_private_keys) (initialize_private_keys)
@@ -182,8 +163,6 @@ val generate_private_key_invariant:
   (requires
     trace_invariant tr /\
     has_private_keys_preds
-//    has_private_keys_invariant /\
-//    has_private_keys_state_update_invariant
   )
   (ensures (
     let (_, tr_out) = generate_private_key prin sess_id sk_type tr in
@@ -191,8 +170,6 @@ val generate_private_key_invariant:
   ))
   [SMTPat (generate_private_key prin sess_id sk_type tr);
    SMTPat (has_private_keys_preds);
-//   SMTPat (has_private_keys_invariant);
-//   SMTPat (has_private_keys_state_update_invariant);
    SMTPat (trace_invariant tr)]
 let generate_private_key_invariant #invs prin sess_id sk_type tr =
   reveal_opaque (`%generate_private_key) (generate_private_key)
@@ -216,7 +193,6 @@ val get_private_key_invariant:
   (requires
     trace_invariant tr /\
     has_private_keys_preds
-//    has_private_keys_invariant
   )
   (ensures (
     let (opt_private_key, tr_out) = get_private_key prin sess_id pk_type tr in
@@ -227,7 +203,6 @@ val get_private_key_invariant:
   ))
   [SMTPat (get_private_key prin sess_id pk_type tr);
    SMTPat (has_private_keys_preds);
-//   SMTPat (has_private_keys_invariant);
    SMTPat (trace_invariant tr)]
 let get_private_key_invariant #invs prin sess_id pk_type tr =
   reveal_opaque (`%get_private_key) (get_private_key)
@@ -252,7 +227,6 @@ val compute_public_key_invariant:
   (requires
     trace_invariant tr /\
     has_private_keys_preds
-//    has_private_keys_invariant
   )
   (ensures (
     let (opt_private_key, tr_out) = compute_public_key prin sess_id pk_type tr in
@@ -263,7 +237,6 @@ val compute_public_key_invariant:
   ))
   [SMTPat (compute_public_key prin sess_id pk_type tr);
    SMTPat (has_private_keys_preds);
-//   SMTPat (has_private_keys_invariant);
    SMTPat (trace_invariant tr)]
 let compute_public_key_invariant #invs prin sess_id pk_type tr =
   reveal_opaque (`%compute_public_key) (compute_public_key)

--- a/src/lib/state/DY.Lib.State.Tagged.fst
+++ b/src/lib/state/DY.Lib.State.Tagged.fst
@@ -426,7 +426,7 @@ let traceful_modifies_get_tagged_state tag prin sess_id tr =
   reveal_opaque (`%get_tagged_state) (get_tagged_state)
 
 val set_tagged_state_state_was_set:
-  tag:string -> 
+  tag:string ->
   prin:principal -> sess_id:state_id -> content:bytes -> tr:trace ->
   Lemma
   (ensures (
@@ -462,12 +462,12 @@ let set_tagged_state_invariant #invs tag spred prin sess_id content tr =
   local_eq_global_lemma split_local_bytes_state_predicate_params state_pred.pred tag spred (tr, prin, sess_id, serialize _ full_content) tag (tr, prin, sess_id, content)
 
 val get_tagged_state_same_trace:
-  tag:string -> 
+  tag:string ->
   prin:principal -> sess_id:state_id -> tr:trace ->
   Lemma
   (ensures (
     let (opt_content, tr_out) = get_tagged_state tag prin sess_id tr in
-    tr == tr_out 
+    tr == tr_out
   ))
   [SMTPat (get_tagged_state tag prin sess_id tr);]
 let get_tagged_state_same_trace tag prin sess_id tr =
@@ -475,7 +475,7 @@ let get_tagged_state_same_trace tag prin sess_id tr =
 
 
 val get_tagged_state_state_was_set:
-  tag:string -> 
+  tag:string ->
   prin:principal -> sess_id:state_id -> tr:trace ->
   Lemma
   (ensures (
@@ -493,7 +493,7 @@ let get_tagged_state_state_was_set tag prin sess_id tr =
   | (None, _) -> ()
   | (Some _, _) -> (
     let (Some full_cont_bytes, _) = get_state prin sess_id tr in
-    serialize_parse_inv_lemma #bytes tagged_state full_cont_bytes    
+    serialize_parse_inv_lemma #bytes tagged_state full_cont_bytes
   )
 
 (*** Theorem ***)

--- a/src/lib/state/DY.Lib.State.Tagged.fst
+++ b/src/lib/state/DY.Lib.State.Tagged.fst
@@ -166,6 +166,15 @@ type local_bytes_state_update_predicate {|crypto_invariants|} (tag:string) = {
   ;
 }
 
+val default_local_bytes_state_update_pred:
+  {|crypto_invariants|} -> (tag:string) ->
+  local_bytes_state_update_predicate tag
+let default_local_bytes_state_update_pred tag = {
+  update_pred = (fun tr prin sess_id content1 content2 -> True);
+  update_pred_later = (fun tr1 tr2 prin sess_id content1 content2 -> ());
+  update_pred_trans = (fun tr prin sess_id content1 content2 content3 -> ());
+}
+
 let split_local_bytes_state_predicate_params {|crypto_invariants|} : split_function_parameters = {
   singleton_split_function_parameters string with
 

--- a/src/lib/state/DY.Lib.State.Tagged.fst
+++ b/src/lib/state/DY.Lib.State.Tagged.fst
@@ -640,8 +640,6 @@ val set_tagged_state_invariant:
     ) /\
     trace_invariant tr /\
     has_local_bytes_state_predicates (|tag, spred|)
-//    has_local_bytes_state_predicate (|tag, spred|) /\
-//    has_local_bytes_state_update_predicate (|tag, supred|)
   )
   (ensures (
     let ((), tr_out) = set_tagged_state tag prin sess_id content tr in
@@ -650,7 +648,6 @@ val set_tagged_state_invariant:
   [SMTPat (set_tagged_state tag prin sess_id content tr);
    SMTPat (trace_invariant tr);
    SMTPat (has_local_bytes_state_predicates (|tag, spred|));
-//   SMTPat (has_local_bytes_state_update_predicate (|tag, supred|));
   ]
 let set_tagged_state_invariant #invs tag spred prin sess_id content tr =
   reveal_opaque (`%has_local_bytes_state_predicates) (has_local_bytes_state_predicates);

--- a/src/lib/state/DY.Lib.State.Tagged.fst
+++ b/src/lib/state/DY.Lib.State.Tagged.fst
@@ -166,6 +166,21 @@ type local_bytes_state_update_predicate {|crypto_invariants|} (tag:string) = {
   ;
 }
 
+noeq
+type local_bytes_state_predicates {|crypto_invariants|} (tag:string) = {
+  local_bytes_state_pred:local_bytes_state_predicate tag;
+  local_bytes_state_update_pred:local_bytes_state_update_predicate tag;
+}
+
+val default_local_bytes_state_pred:
+  {|crypto_invariants|} -> (tag:string) ->
+  local_bytes_state_predicate tag
+let default_local_bytes_state_pred tag = {
+  pred = (fun tr prin sess_id content -> False);
+  pred_later = (fun tr1 tr2 prin sess_id content -> ());
+  pred_knowable = (fun tr prin sess_id content -> ());
+}
+
 val default_local_bytes_state_update_pred:
   {|crypto_invariants|} -> (tag:string) ->
   local_bytes_state_update_predicate tag
@@ -173,6 +188,14 @@ let default_local_bytes_state_update_pred tag = {
   update_pred = (fun tr prin sess_id content1 content2 -> True);
   update_pred_later = (fun tr1 tr2 prin sess_id content1 content2 -> ());
   update_pred_trans = (fun tr prin sess_id content1 content2 content3 -> ());
+}
+
+val default_local_bytes_state_preds:
+  {|crypto_invariants|} -> (tag:string) ->
+  local_bytes_state_predicates tag
+let default_local_bytes_state_preds #cinvs tag = {
+  local_bytes_state_pred = default_local_bytes_state_pred tag;
+  local_bytes_state_update_pred = default_local_bytes_state_update_pred tag;
 }
 
 let split_local_bytes_state_predicate_params {|crypto_invariants|} : split_function_parameters = {
@@ -188,13 +211,13 @@ let split_local_bytes_state_predicate_params {|crypto_invariants|} : split_funct
     | None -> None
   ));
 
-  local_fun_t = local_bytes_state_predicate;
+  local_fun_t = local_bytes_state_predicates;
   global_fun_t = trace -> principal -> state_id -> bytes -> prop;
 
   default_global_fun = (fun tr prin sess_id sess_content -> False);
 
   apply_local_fun = (fun lpred (tr, prin, sess_id, content) ->
-    lpred.pred tr prin sess_id content
+    lpred.local_bytes_state_pred.pred tr prin sess_id content
   );
   apply_global_fun = (fun gpred (tr, prin, sess_id, content) ->
     gpred tr prin sess_id content
@@ -231,7 +254,7 @@ let split_local_bytes_state_update_predicate_params {|crypto_invariants|} : spli
     | _ -> None
   ));
 
-  local_fun_t = local_bytes_state_update_predicate;
+  local_fun_t = local_bytes_state_predicates;
   global_fun_t = trace -> principal -> state_id -> bytes -> bytes -> prop;
 
   default_global_fun = (fun tr prin sess_id sess_content1 sess_content2 -> False);
@@ -240,7 +263,7 @@ let split_local_bytes_state_update_predicate_params {|crypto_invariants|} : spli
     match data_opt with
     | None -> False
     | Some (tr, prin, sess_id, content1, content2) ->
-      lpred.update_pred tr prin sess_id content1 content2
+      lpred.local_bytes_state_update_pred.update_pred tr prin sess_id content1 content2
   );
   apply_global_fun = (fun gpred (tr, prin, sess_id, content1, content2) ->
     gpred tr prin sess_id content1 content2
@@ -252,29 +275,25 @@ let split_local_bytes_state_update_predicate_params {|crypto_invariants|} : spli
 }
 
 [@@ "opaque_to_smt"]
-val has_local_bytes_state_predicate: {|protocol_invariants|} -> (dtuple2 string local_bytes_state_predicate) -> prop
-let has_local_bytes_state_predicate #invs (|tag, spred|) =
-  has_local_fun split_local_bytes_state_predicate_params state_pred.pred (|tag, spred|)
-
-[@@ "opaque_to_smt"]
-val has_local_bytes_state_update_predicate: {|protocol_invariants|} -> (dtuple2 string local_bytes_state_update_predicate) -> prop
-let has_local_bytes_state_update_predicate #invs (|tag, spred|) =
+val has_local_bytes_state_predicates: {|protocol_invariants|} -> (dtuple2 string local_bytes_state_predicates) -> prop
+let has_local_bytes_state_predicates #invs (|tag, spred|) =
+  has_local_fun split_local_bytes_state_predicate_params state_pred.pred (|tag, spred|) /\
   has_local_fun split_local_bytes_state_update_predicate_params state_update_pred.update_pred (|tag, spred|)
 
 (*** Global tagged state predicate builder ***)
 
-val mk_global_local_bytes_state_predicate: {|crypto_invariants|} -> list (dtuple2 string local_bytes_state_predicate) -> trace -> principal -> state_id -> bytes -> prop
+val mk_global_local_bytes_state_predicate: {|crypto_invariants|} -> list (dtuple2 string local_bytes_state_predicates) -> trace -> principal -> state_id -> bytes -> prop
 let mk_global_local_bytes_state_predicate #cinvs tagged_local_preds =
   mk_global_fun split_local_bytes_state_predicate_params tagged_local_preds
 
-val mk_global_local_bytes_state_update_predicate: {|crypto_invariants|} -> list (dtuple2 string local_bytes_state_update_predicate) -> trace -> principal -> state_id -> bytes -> bytes -> prop
+val mk_global_local_bytes_state_update_predicate: {|crypto_invariants|} -> list (dtuple2 string local_bytes_state_predicates) -> trace -> principal -> state_id -> bytes -> bytes -> prop
 let mk_global_local_bytes_state_update_predicate #cinvs tagged_local_preds =
   mk_global_fun split_local_bytes_state_update_predicate_params tagged_local_preds
 
 
 #push-options "--ifuel 2" // to deconstruct nested tuples
 val mk_global_local_bytes_state_predicate_later:
-  {|crypto_invariants|} -> tagged_local_preds:list (dtuple2 string local_bytes_state_predicate) ->
+  {|crypto_invariants|} -> tagged_local_preds:list (dtuple2 string local_bytes_state_predicates) ->
   tr1:trace -> tr2:trace -> prin:principal -> sess_id:state_id -> full_content:bytes -> Lemma
   (requires mk_global_local_bytes_state_predicate tagged_local_preds tr1 prin sess_id full_content /\ tr1 <$ tr2)
   (ensures mk_global_local_bytes_state_predicate tagged_local_preds tr2 prin sess_id full_content)
@@ -282,12 +301,12 @@ let mk_global_local_bytes_state_predicate_later #cinvs tagged_local_preds tr1 tr
   mk_global_fun_eq split_local_bytes_state_predicate_params tagged_local_preds (tr1, prin, sess_id, full_content);
   mk_global_fun_eq split_local_bytes_state_predicate_params tagged_local_preds (tr2, prin, sess_id, full_content);
   introduce forall tag_set lpred content. split_local_bytes_state_predicate_params.apply_local_fun #tag_set lpred (tr1, prin, sess_id, content) ==> split_local_bytes_state_predicate_params.apply_local_fun lpred (tr2, prin, sess_id, content) with (
-    introduce _ ==> _ with _. lpred.pred_later tr1 tr2 prin sess_id content
+    introduce _ ==> _ with _. lpred.local_bytes_state_pred.pred_later tr1 tr2 prin sess_id content
   )
 #pop-options
 
 val mk_global_local_bytes_state_predicate_knowable:
-  {|crypto_invariants|} -> tagged_local_preds:list (dtuple2 string local_bytes_state_predicate) ->
+  {|crypto_invariants|} -> tagged_local_preds:list (dtuple2 string local_bytes_state_predicates) ->
   tr:trace -> prin:principal -> sess_id:state_id -> full_content:bytes ->
   Lemma
   (requires mk_global_local_bytes_state_predicate tagged_local_preds tr prin sess_id full_content)
@@ -299,7 +318,7 @@ let mk_global_local_bytes_state_predicate_knowable #cinvs tagged_local_preds tr 
     match find_local_fun split_local_bytes_state_predicate_params tagged_local_preds tag with
     | Some (|_, lpred|) -> (
       find_local_fun_returns_belonging_tag_set split_local_bytes_state_predicate_params tagged_local_preds tag;
-      lpred.pred_knowable tr prin sess_id content;
+      lpred.local_bytes_state_pred.pred_knowable tr prin sess_id content;
       serialize_parse_inv_lemma tagged_state full_content;
       serialize_wf_lemma tagged_state (is_knowable_by (principal_tag_state_content_label prin tag sess_id content) tr) ({tag; content})
     )
@@ -309,7 +328,7 @@ let mk_global_local_bytes_state_predicate_knowable #cinvs tagged_local_preds tr 
 
 #push-options "--ifuel 2" // to deconstruct nested tuples
 val mk_global_local_bytes_state_update_predicate_later:
-  {|crypto_invariants|} -> tagged_local_preds:list (dtuple2 string local_bytes_state_update_predicate) ->
+  {|crypto_invariants|} -> tagged_local_preds:list (dtuple2 string local_bytes_state_predicates) ->
   tr1:trace -> tr2:trace -> prin:principal -> sess_id:state_id -> full_content1:bytes -> full_content2:bytes -> Lemma
   (requires
     mk_global_local_bytes_state_update_predicate tagged_local_preds tr1 prin sess_id full_content1 full_content2 /\
@@ -320,13 +339,13 @@ let mk_global_local_bytes_state_update_predicate_later #cinvs tagged_local_preds
   mk_global_fun_eq split_local_bytes_state_update_predicate_params tagged_local_preds (tr1, prin, sess_id, full_content1, full_content2);
   mk_global_fun_eq split_local_bytes_state_update_predicate_params tagged_local_preds (tr2, prin, sess_id, full_content1, full_content2);
   introduce forall tag_set lpred content1 content2. split_local_bytes_state_update_predicate_params.apply_local_fun #tag_set lpred (Some (tr1, prin, sess_id, content1, content2)) ==> split_local_bytes_state_update_predicate_params.apply_local_fun lpred (Some (tr2, prin, sess_id, content1, content2)) with (
-    introduce _ ==> _ with _. lpred.update_pred_later tr1 tr2 prin sess_id content1 content2
+    introduce _ ==> _ with _. lpred.local_bytes_state_update_pred.update_pred_later tr1 tr2 prin sess_id content1 content2
   )
 #pop-options
 
 #push-options "--ifuel 2" // to deconstruct nested tuples
 val mk_global_local_bytes_state_update_predicate_trans:
-  {|crypto_invariants|} -> tagged_local_preds:list (dtuple2 string local_bytes_state_update_predicate) ->
+  {|crypto_invariants|} -> tagged_local_preds:list (dtuple2 string local_bytes_state_predicates) ->
   tr:trace -> prin:principal -> sess_id:state_id -> full_content1:bytes -> full_content2:bytes -> full_content3:bytes ->
   Lemma
   (requires
@@ -342,11 +361,11 @@ let mk_global_local_bytes_state_update_predicate_trans #cinvs tagged_local_preds
     (split_local_bytes_state_update_predicate_params.apply_local_fun #tag_set lpred (Some (tr, prin, sess_id, content1, content2)) /\
     split_local_bytes_state_update_predicate_params.apply_local_fun #tag_set lpred (Some (tr, prin, sess_id, content2, content3))) ==>
       split_local_bytes_state_update_predicate_params.apply_local_fun lpred (Some (tr, prin, sess_id, content1, content3)) with (
-    introduce _ ==> _ with _. lpred.update_pred_trans tr prin sess_id content1 content2 content3
+    introduce _ ==> _ with _. lpred.local_bytes_state_update_pred.update_pred_trans tr prin sess_id content1 content2 content3
   )
 #pop-options
 
-val mk_state_pred: {|crypto_invariants|} -> list (dtuple2 string local_bytes_state_predicate) -> state_predicate
+val mk_state_pred: {|crypto_invariants|} -> list (dtuple2 string local_bytes_state_predicates) -> state_predicate
 let mk_state_pred #cinvs tagged_local_preds =
   {
     pred = mk_global_local_bytes_state_predicate tagged_local_preds;
@@ -354,20 +373,7 @@ let mk_state_pred #cinvs tagged_local_preds =
     pred_knowable = mk_global_local_bytes_state_predicate_knowable tagged_local_preds;
   }
 
-val mk_state_pred_correct: {|protocol_invariants|} -> tagged_local_preds:list (dtuple2 string local_bytes_state_predicate) -> Lemma
-  (requires
-    state_pred == mk_state_pred tagged_local_preds /\
-    List.Tot.no_repeats_p (List.Tot.map dfst tagged_local_preds)
-  )
-  (ensures for_allP has_local_bytes_state_predicate tagged_local_preds)
-let mk_state_pred_correct #invs tagged_local_preds =
-  reveal_opaque (`%has_local_bytes_state_predicate) (has_local_bytes_state_predicate);
-  no_repeats_p_implies_for_all_pairsP_unequal (List.Tot.map dfst tagged_local_preds);
-  for_allP_eq has_local_bytes_state_predicate tagged_local_preds;
-  FStar.Classical.forall_intro_2 (FStar.Classical.move_requires_2 (mk_global_fun_correct split_local_bytes_state_predicate_params tagged_local_preds))
-
-
-val mk_state_update_pred: {|crypto_invariants|} -> list (dtuple2 string local_bytes_state_update_predicate) -> state_update_predicate
+val mk_state_update_pred: {|crypto_invariants|} -> list (dtuple2 string local_bytes_state_predicates) -> state_update_predicate
 let mk_state_update_pred #cinvs tagged_local_preds =
   {
     update_pred = mk_global_local_bytes_state_update_predicate tagged_local_preds;
@@ -375,16 +381,23 @@ let mk_state_update_pred #cinvs tagged_local_preds =
     update_pred_trans = mk_global_local_bytes_state_update_predicate_trans tagged_local_preds;
   }
 
-val mk_state_update_pred_correct: {|protocol_invariants|} -> tagged_local_preds:list (dtuple2 string local_bytes_state_update_predicate) -> Lemma
+val mk_state_preds: {|crypto_invariants|} -> list (dtuple2 string local_bytes_state_predicates) -> state_predicates
+let mk_state_preds #cinvs tagged_local_preds = {
+  state_pred = mk_state_pred tagged_local_preds;
+  state_update_pred = mk_state_update_pred tagged_local_preds;
+}
+
+val mk_state_preds_correct: {|invs:protocol_invariants|} -> tagged_local_preds:list (dtuple2 string local_bytes_state_predicates) -> Lemma
   (requires
-    state_update_pred == mk_state_update_pred tagged_local_preds /\
+    invs.trace_invs.state_preds == mk_state_preds tagged_local_preds /\
     List.Tot.no_repeats_p (List.Tot.map dfst tagged_local_preds)
   )
-  (ensures for_allP has_local_bytes_state_update_predicate tagged_local_preds)
-let mk_state_update_pred_correct #invs tagged_local_preds =
-  reveal_opaque (`%has_local_bytes_state_update_predicate) (has_local_bytes_state_update_predicate);
+  (ensures for_allP has_local_bytes_state_predicates tagged_local_preds)
+let mk_state_preds_correct #invs tagged_local_preds =
+  reveal_opaque (`%has_local_bytes_state_predicates) (has_local_bytes_state_predicates);
   no_repeats_p_implies_for_all_pairsP_unequal (List.Tot.map dfst tagged_local_preds);
-  for_allP_eq has_local_bytes_state_update_predicate tagged_local_preds;
+  for_allP_eq has_local_bytes_state_predicates tagged_local_preds;
+  FStar.Classical.forall_intro_2 (FStar.Classical.move_requires_2 (mk_global_fun_correct split_local_bytes_state_predicate_params tagged_local_preds));
   FStar.Classical.forall_intro_2 (FStar.Classical.move_requires_2 (mk_global_fun_correct split_local_bytes_state_update_predicate_params tagged_local_preds))
 
 (*** Predicates on trace ***)
@@ -615,19 +628,20 @@ let set_tagged_state_state_was_set tag prin sess_id content tr =
 
 val set_tagged_state_invariant:
   {|protocol_invariants|} ->
-  tag:string -> spred:local_bytes_state_predicate tag -> supred:local_bytes_state_update_predicate tag ->
+  tag:string -> spred:local_bytes_state_predicates tag ->
   prin:principal -> sess_id:state_id -> content:bytes -> tr:trace ->
   Lemma
   (requires
-    spred.pred tr prin sess_id content /\
+    spred.local_bytes_state_pred.pred tr prin sess_id content /\
     (
       match get_tagged_state tag prin sess_id tr with
       | (None, _) -> is_most_recent_state_for prin sess_id None tr
-      | (Some old_content, _) -> supred.update_pred tr prin sess_id old_content content
+      | (Some old_content, _) -> spred.local_bytes_state_update_pred.update_pred tr prin sess_id old_content content
     ) /\
     trace_invariant tr /\
-    has_local_bytes_state_predicate (|tag, spred|) /\
-    has_local_bytes_state_update_predicate (|tag, supred|)
+    has_local_bytes_state_predicates (|tag, spred|)
+//    has_local_bytes_state_predicate (|tag, spred|) /\
+//    has_local_bytes_state_update_predicate (|tag, supred|)
   )
   (ensures (
     let ((), tr_out) = set_tagged_state tag prin sess_id content tr in
@@ -635,22 +649,20 @@ val set_tagged_state_invariant:
   ))
   [SMTPat (set_tagged_state tag prin sess_id content tr);
    SMTPat (trace_invariant tr);
-   SMTPat (has_local_bytes_state_predicate (|tag, spred|));
-   SMTPat (has_local_bytes_state_update_predicate (|tag, supred|));
+   SMTPat (has_local_bytes_state_predicates (|tag, spred|));
+//   SMTPat (has_local_bytes_state_update_predicate (|tag, supred|));
   ]
-let set_tagged_state_invariant #invs tag spred supred prin sess_id content tr =
-  reveal_opaque (`%has_local_bytes_state_predicate) (has_local_bytes_state_predicate);
+let set_tagged_state_invariant #invs tag spred prin sess_id content tr =
+  reveal_opaque (`%has_local_bytes_state_predicates) (has_local_bytes_state_predicates);
   reveal_opaque (`%set_tagged_state) (set_tagged_state);
   let full_content = {tag; content;} in
   local_eq_global_lemma split_local_bytes_state_predicate_params state_pred.pred tag spred (tr, prin, sess_id, serialize _ full_content) tag (tr, prin, sess_id, content);
   // Handle update predicate if applicable
-  reveal_opaque (`%has_local_bytes_state_update_predicate) (has_local_bytes_state_update_predicate);
-
   match get_tagged_state tag prin sess_id tr with
   | (None, _) -> assert(get_most_recent_state_for_ghost tr prin sess_id == None)
   | (Some old_content, _) -> (
     let old_full_content = {tag; content=old_content;} in
-    local_eq_global_lemma split_local_bytes_state_update_predicate_params state_update_pred.update_pred tag supred (tr, prin, sess_id, serialize _ old_full_content, serialize _ full_content) tag (Some (tr, prin, sess_id, old_content, content));
+    local_eq_global_lemma split_local_bytes_state_update_predicate_params state_update_pred.update_pred tag spred (tr, prin, sess_id, serialize _ old_full_content, serialize _ full_content) tag (Some (tr, prin, sess_id, old_content, content));
     assert(get_most_recent_state_for_ghost tr prin sess_id == Some (serialize _ old_full_content));
     ()
   )
@@ -694,21 +706,21 @@ let get_tagged_state_state_was_set tag prin sess_id tr =
 
 val tagged_state_was_set_implies_pred:
   {|protocol_invariants|} -> tr:trace ->
-  tag:string -> spred:local_bytes_state_predicate tag ->
+  tag:string -> spred:local_bytes_state_predicates tag ->
   prin:principal -> sess_id:state_id -> content:bytes ->
   Lemma
   (requires
     tagged_state_was_set tr tag prin sess_id content /\
     trace_invariant tr /\
-    has_local_bytes_state_predicate (|tag, spred|)
+    has_local_bytes_state_predicates (|tag, spred|)
   )
-  (ensures spred.pred tr prin sess_id content)
+  (ensures spred.local_bytes_state_pred.pred tr prin sess_id content)
   [SMTPat (tagged_state_was_set tr tag prin sess_id content);
    SMTPat (trace_invariant tr);
-   SMTPat (has_local_bytes_state_predicate (|tag, spred|));
+   SMTPat (has_local_bytes_state_predicates (|tag, spred|));
   ]
 let tagged_state_was_set_implies_pred #invs tr tag spred prin sess_id content =
-  reveal_opaque (`%has_local_bytes_state_predicate) (has_local_bytes_state_predicate);
+  reveal_opaque (`%has_local_bytes_state_predicates) (has_local_bytes_state_predicates);
   reveal_opaque (`%tagged_state_was_set) (tagged_state_was_set);
   let full_content = {tag; content;} in
   parse_serialize_inv_lemma #bytes tagged_state full_content;
@@ -718,7 +730,7 @@ let tagged_state_was_set_implies_pred #invs tr tag spred prin sess_id content =
 val tagged_state_was_set_twice_implies_update_pred:
   {|protocol_invariants|} -> tr:trace ->
   ts1:timestamp -> ts2:timestamp ->
-  tag:string -> supred:local_bytes_state_update_predicate tag ->
+  tag:string -> spred:local_bytes_state_predicates tag ->
   prin:principal -> sess_id:state_id ->
   content1:bytes -> content2:bytes ->
   Lemma
@@ -727,13 +739,13 @@ val tagged_state_was_set_twice_implies_update_pred:
     tagged_state_was_set_at tr ts2 tag prin sess_id content2 /\
     ts1 < ts2 /\
     trace_invariant tr /\
-    has_local_bytes_state_update_predicate (|tag, supred|)
+    has_local_bytes_state_predicates (|tag, spred|)
   )
   (ensures
-    supred.update_pred tr prin sess_id content1 content2
+    spred.local_bytes_state_update_pred.update_pred tr prin sess_id content1 content2
   )
-let tagged_state_was_set_twice_implies_update_pred tr ts1 ts2 tag supred prin sess_id content1 content2 =
-  reveal_opaque (`%has_local_bytes_state_update_predicate) (has_local_bytes_state_update_predicate);
+let tagged_state_was_set_twice_implies_update_pred tr ts1 ts2 tag spred prin sess_id content1 content2 =
+  reveal_opaque (`%has_local_bytes_state_predicates) (has_local_bytes_state_predicates);
   reveal_opaque (`%tagged_state_was_set_at) (tagged_state_was_set_at);
   let full_content1 = {tag; content=content1;} in
   let full_content2 = {tag; content=content2;} in
@@ -741,35 +753,35 @@ let tagged_state_was_set_twice_implies_update_pred tr ts1 ts2 tag supred prin se
   parse_serialize_inv_lemma #bytes tagged_state full_content2;
   let full_content1_bytes: bytes = serialize tagged_state full_content1 in
   let full_content2_bytes: bytes = serialize tagged_state full_content2 in
-  local_eq_global_lemma split_local_bytes_state_update_predicate_params state_update_pred.update_pred tag supred (tr, prin, sess_id, full_content1_bytes, full_content2_bytes) tag (Some (tr, prin, sess_id, content1, content2))
+  local_eq_global_lemma split_local_bytes_state_update_predicate_params state_update_pred.update_pred tag spred (tr, prin, sess_id, full_content1_bytes, full_content2_bytes) tag (Some (tr, prin, sess_id, content1, content2))
 
 val most_recent_tagged_state_update_pred:
   {|protocol_invariants|} ->
   tr:trace ->
-  tag:string -> supred:local_bytes_state_update_predicate tag ->
+  tag:string -> spred:local_bytes_state_predicates tag ->
   prin:principal -> sess_id:state_id ->
   content:bytes ->
   Lemma
   (requires
     tagged_state_was_set tr tag prin sess_id content /\
     trace_invariant tr /\
-    has_local_bytes_state_update_predicate (|tag, supred|)
+    has_local_bytes_state_predicates (|tag, spred|)
   )
   (ensures (
     match get_tagged_state tag prin sess_id tr with
     | (None, _) -> False
     | (Some new_content, _) -> (
-      supred.update_pred tr prin sess_id content new_content \/
+      spred.local_bytes_state_update_pred.update_pred tr prin sess_id content new_content \/
       content == new_content
     )
   ))
   [SMTPat (tagged_state_was_set tr tag prin sess_id content);
    SMTPat (trace_invariant tr);
-   SMTPat (has_local_bytes_state_update_predicate (|tag, supred|));
+   SMTPat (has_local_bytes_state_predicates (|tag, spred|));
    SMTPat (get_tagged_state tag prin sess_id tr);
   ]
-let most_recent_tagged_state_update_pred #invs tr tag supred prin sess_id content =
-  reveal_opaque (`%has_local_bytes_state_update_predicate) (has_local_bytes_state_update_predicate);
+let most_recent_tagged_state_update_pred #invs tr tag spred prin sess_id content =
+  reveal_opaque (`%has_local_bytes_state_predicates) (has_local_bytes_state_predicates);
   reveal_opaque (`%get_tagged_state) (get_tagged_state);
   reveal_opaque (`%tagged_state_was_set) (tagged_state_was_set);
   let st = serialize tagged_state {tag; content;} in
@@ -785,7 +797,7 @@ let most_recent_tagged_state_update_pred #invs tr tag supred prin sess_id conten
     | None -> ()
     | Some (tag', raw_content) -> (
       assert(tag == tag');
-      local_eq_global_lemma split_local_bytes_state_update_predicate_params state_update_pred.update_pred tag supred (tr, prin, sess_id, st, new_st) tag raw_content;
+      local_eq_global_lemma split_local_bytes_state_update_predicate_params state_update_pred.update_pred tag spred (tr, prin, sess_id, st, new_st) tag raw_content;
       ()
     )
   )

--- a/src/lib/state/DY.Lib.State.Typed.fst
+++ b/src/lib/state/DY.Lib.State.Typed.fst
@@ -459,7 +459,7 @@ val set_state_invariant:
     spred.pred tr prin sess_id content /\
     (
       match get_state prin sess_id tr with
-      | (None, _) -> is_most_recent_state_for prin sess_id None tr
+      | (None, _) -> DY.Core.Trace.Base.is_most_recent_state_for prin sess_id None tr
       | (Some old_content, _) -> supred.update_pred tr prin sess_id old_content content
     ) /\
     trace_invariant tr /\

--- a/src/lib/state/DY.Lib.State.Typed.fst
+++ b/src/lib/state/DY.Lib.State.Typed.fst
@@ -118,6 +118,30 @@ type local_state_predicate {|crypto_invariants|} (a:Type) {|local_state a|} = {
   ;
 }
 
+noeq
+type local_state_update_predicate {|crypto_invariants|} (a:Type) {|local_state a|} = {
+  update_pred: trace -> principal -> state_id -> a -> a -> prop;
+  update_pred_later:
+    tr1:trace -> tr2:trace ->
+    prin:principal -> sess_id:state_id ->
+    content1:a -> content2:a ->
+    Lemma
+    (requires update_pred tr1 prin sess_id content1 content2 /\ tr1 <$ tr2)
+    (ensures update_pred tr2 prin sess_id content1 content2)
+  ;
+  update_pred_trans:
+    tr:trace ->
+    prin:principal -> sess_id:state_id ->
+    content1:a -> content2:a -> content3:a ->
+    Lemma
+    (requires
+      update_pred tr prin sess_id content1 content2 /\
+      update_pred tr prin sess_id content2 content3
+    )
+    (ensures update_pred tr prin sess_id content1 content3)
+  ;
+}
+
 val local_state_predicate_to_local_bytes_state_predicate:
   {|crypto_invariants|} ->
   #a:Type -> {|local_state a|} ->
@@ -141,12 +165,40 @@ let local_state_predicate_to_local_bytes_state_predicate #cinvs #a #ps_a tspred 
     );
   }
 
+val local_state_update_predicate_to_local_bytes_state_update_predicate:
+  {|crypto_invariants|} ->
+  #a:Type -> {|local_state a|} ->
+  local_state_update_predicate a -> local_bytes_state_update_predicate (tag #a)
+let local_state_update_predicate_to_local_bytes_state_update_predicate #cinvs #a #ps_a tsupred =
+  {
+    update_pred = (fun tr prin sess_id content_bytes1 content_bytes2 ->
+      match (parse a content_bytes1, parse a content_bytes2) with
+      | (Some content1, Some content2) -> tsupred.update_pred tr prin sess_id content1 content2
+      | _ -> False
+    );
+    update_pred_later = (fun tr1 tr2 prin sess_id content_bytes1 content_bytes2 ->
+      let (Some content1, Some content2) = (parse a content_bytes1, parse a content_bytes2) in
+      tsupred.update_pred_later tr1 tr2 prin sess_id content1 content2
+    );
+    update_pred_trans = (fun tr prin sess_id content_bytes1 content_bytes2 content_bytes3 ->
+      let (Some content1, Some content2, Some content3) = (parse a content_bytes1, parse a content_bytes2, parse a content_bytes3) in
+      tsupred.update_pred_trans tr prin sess_id content1 content2 content3
+    );
+  }
+
 val mk_local_state_tag_and_pred:
   #a:Type -> {|local_state a|} ->
   {|crypto_invariants|} -> local_state_predicate a ->
   dtuple2 string local_bytes_state_predicate
 let mk_local_state_tag_and_pred #a #ls_a #cinvs spred =
   (|ls_a.tag, (local_state_predicate_to_local_bytes_state_predicate spred)|)
+
+val mk_local_state_tag_and_update_pred:
+  #a:Type -> {|local_state a|} ->
+  {|crypto_invariants|} -> local_state_update_predicate a ->
+  dtuple2 string local_bytes_state_update_predicate
+let mk_local_state_tag_and_update_pred #a #ls_a #cinvs supred =
+  (|ls_a.tag, (local_state_update_predicate_to_local_bytes_state_update_predicate supred)|)
 
 unfold
 val has_local_state_predicate:
@@ -156,6 +208,14 @@ val has_local_state_predicate:
 let has_local_state_predicate #a #ls #invs spred =
   has_local_bytes_state_predicate (mk_local_state_tag_and_pred spred)
 
+unfold
+val has_local_state_update_predicate:
+  #a:Type -> {|local_state a|} ->
+  {|protocol_invariants|} -> local_state_update_predicate a ->
+  prop
+let has_local_state_update_predicate #a #ls #invs supred =
+  has_local_bytes_state_update_predicate (mk_local_state_tag_and_update_pred supred)
+
 [@@ "opaque_to_smt"]
 val state_was_set:
   #a:Type -> {|local_state a|} ->
@@ -163,6 +223,14 @@ val state_was_set:
   prop
 let state_was_set #a #ls tr prin sess_id content =
   tagged_state_was_set tr ls.tag prin sess_id (serialize _ content)
+
+[@@ "opaque_to_smt"]
+val state_was_set_at:
+  #a:Type -> {|local_state a|} ->
+  trace -> timestamp -> principal -> state_id -> a ->
+  prop
+let state_was_set_at #a #ls tr ts prin sess_id content =
+  tagged_state_was_set_at tr ts ls.tag prin sess_id (serialize _ content)
 
 val state_was_set_grows:
   #a:Type -> {|local_state a|} ->
@@ -174,6 +242,17 @@ val state_was_set_grows:
   [SMTPat (state_was_set tr1 prin sid content); SMTPat (tr1 <$ tr2)]
 let state_was_set_grows #a #ls tr1 tr2 prin sid content =
   reveal_opaque (`%state_was_set) (state_was_set #a)
+
+val state_was_set_at_grows:
+  #a:Type -> {|local_state a|} ->
+  tr1:trace -> tr2:trace -> ts:timestamp ->
+  prin:principal -> sid:state_id -> content:a  ->
+  Lemma
+  (requires state_was_set_at tr1 ts prin sid content /\ tr1 <$ tr2)
+  (ensures state_was_set_at tr2 ts prin sid content)
+  [SMTPat (state_was_set_at tr1 ts prin sid content); SMTPat (tr1 <$ tr2)]
+let state_was_set_at_grows #a #ls tr1 tr2 ts prin sid content =
+  reveal_opaque (`%state_was_set_at) (state_was_set_at #a)
 
 [@@ "opaque_to_smt"]
 val set_state:
@@ -361,15 +440,21 @@ let set_state_state_was_set #a #ls  prin sess_id content tr =
   reveal_opaque (`%state_was_set) (state_was_set #a #ls)
 
 val set_state_invariant:
-  #a:Type -> {|local_state a|} ->
+  #a:Type -> {|ls:local_state a|} ->
   {|protocol_invariants|} ->
-  spred:local_state_predicate a ->
+  spred:local_state_predicate a -> supred:local_state_update_predicate a ->
   prin:principal -> sess_id:state_id -> content:a -> tr:trace ->
   Lemma
   (requires
     spred.pred tr prin sess_id content /\
+    (
+      match get_state prin sess_id tr with
+      | (None, _) -> is_most_recent_state_for prin sess_id None tr
+      | (Some old_content, _) -> supred.update_pred tr prin sess_id old_content content
+    ) /\
     trace_invariant tr /\
-    has_local_state_predicate spred
+    has_local_state_predicate spred /\
+    has_local_state_update_predicate supred
   )
   (ensures (
     let ((), tr_out) = set_state prin sess_id content tr in
@@ -377,11 +462,15 @@ val set_state_invariant:
   ))
   [SMTPat (set_state prin sess_id content tr);
    SMTPat (trace_invariant tr);
-   SMTPat (has_local_state_predicate spred)]
-let set_state_invariant #a #ls #invs spred prin sess_id content tr =
+   SMTPat (has_local_state_predicate spred);
+   SMTPat (has_local_state_update_predicate supred);
+  ]
+let set_state_invariant #a #ls #invs spred supred prin sess_id content tr =
   reveal_opaque (`%set_state) (set_state #a);
-  parse_serialize_inv_lemma #bytes a content
-
+  parse_serialize_inv_lemma #bytes a content;
+  // Handle update predicate if applicable
+  reveal_opaque (`%get_state) (get_state #a);
+  ()
 
 val get_state_same_trace:
   #a:Type -> {|ls:local_state a|} ->
@@ -404,7 +493,7 @@ val get_state_state_was_set:
     let (opt_content, tr_out) = get_state #a #ls prin sess_id tr in
     match opt_content with
     | None -> True
-    | Some content -> 
+    | Some content ->
         state_was_set tr prin sess_id content
   ))
   [SMTPat (get_state #a #ls prin sess_id tr)]

--- a/src/lib/state/DY.Lib.State.Typed.fst
+++ b/src/lib/state/DY.Lib.State.Typed.fst
@@ -142,6 +142,16 @@ type local_state_update_predicate {|crypto_invariants|} (a:Type) {|local_state a
   ;
 }
 
+val default_local_state_update_pred:
+  {|crypto_invariants|} ->
+  a:Type -> {|local_state a|} ->
+  local_state_update_predicate a
+let default_local_state_update_pred #cinvs a #ls_a = {
+  update_pred = (fun tr prin sess_id content1 content2 -> True);
+  update_pred_later = (fun tr1 tr2 prin sess_id content1 content2 -> ());
+  update_pred_trans = (fun tr prin sess_id content1 content2 content3 -> ());
+}
+
 val local_state_predicate_to_local_bytes_state_predicate:
   {|crypto_invariants|} ->
   #a:Type -> {|local_state a|} ->

--- a/src/lib/state/DY.Lib.State.Typed.fst
+++ b/src/lib/state/DY.Lib.State.Typed.fst
@@ -237,40 +237,6 @@ val mk_local_state_tag_and_preds:
 let mk_local_state_tag_and_preds #a #ls_a #cinvs spred =
   (|ls_a.tag, (local_state_predicates_to_local_bytes_state_predicates spred)|)
 
-(*
-val mk_local_state_tag_and_pred:
-  #a:Type -> {|local_state a|} ->
-  {|crypto_invariants|} -> local_state_predicate a ->
-  dtuple2 string local_bytes_state_predicate
-let mk_local_state_tag_and_pred #a #ls_a #cinvs spred =
-  (|ls_a.tag, (local_state_predicate_to_local_bytes_state_predicate spred)|)
-
-val mk_local_state_tag_and_update_pred:
-  #a:Type -> {|local_state a|} ->
-  {|crypto_invariants|} -> local_state_update_predicate a ->
-  dtuple2 string local_bytes_state_update_predicate
-let mk_local_state_tag_and_update_pred #a #ls_a #cinvs supred =
-  (|ls_a.tag, (local_state_update_predicate_to_local_bytes_state_update_predicate supred)|)
-*)
-
-(*
-unfold
-val has_local_state_predicate:
-  #a:Type -> {|local_state a|} ->
-  {|protocol_invariants|} -> local_state_predicate a ->
-  prop
-let has_local_state_predicate #a #ls #invs spred =
-  has_local_bytes_state_predicate (mk_local_state_tag_and_pred spred)
-
-unfold
-val has_local_state_update_predicate:
-  #a:Type -> {|local_state a|} ->
-  {|protocol_invariants|} -> local_state_update_predicate a ->
-  prop
-let has_local_state_update_predicate #a #ls #invs supred =
-  has_local_bytes_state_update_predicate (mk_local_state_tag_and_update_pred supred)
-*)
-
 unfold
 val has_local_state_predicates:
   #a:Type -> {|local_state a|} ->

--- a/src/lib/state/DY.Lib.State.Typed.fst
+++ b/src/lib/state/DY.Lib.State.Typed.fst
@@ -142,6 +142,22 @@ type local_state_update_predicate {|crypto_invariants|} (a:Type) {|local_state a
   ;
 }
 
+noeq
+type local_state_predicates {|crypto_invariants|} (a:Type) {|local_state a|} = {
+  local_state_pred: local_state_predicate a;
+  local_state_update_pred: local_state_update_predicate a;
+}
+
+val default_local_state_pred:
+  {|crypto_invariants|} ->
+  a:Type -> {|local_state a|} ->
+  local_state_predicate a
+let default_local_state_pred #cinvs a #ls_a = {
+  pred = (fun tr prin sess_id content -> False);
+  pred_later = (fun tr1 tr2 prin sess_id content -> ());
+  pred_knowable = (fun tr prin sess_id content -> ());
+}
+
 val default_local_state_update_pred:
   {|crypto_invariants|} ->
   a:Type -> {|local_state a|} ->
@@ -150,6 +166,15 @@ let default_local_state_update_pred #cinvs a #ls_a = {
   update_pred = (fun tr prin sess_id content1 content2 -> True);
   update_pred_later = (fun tr1 tr2 prin sess_id content1 content2 -> ());
   update_pred_trans = (fun tr prin sess_id content1 content2 content3 -> ());
+}
+
+val default_local_state_preds:
+  {|crypto_invariants|} ->
+  a:Type -> {|local_state a|} ->
+  local_state_predicates a
+let default_local_state_preds #cinvs a #ls_a = {
+  local_state_pred = default_local_state_pred a;
+  local_state_update_pred = default_local_state_update_pred a;
 }
 
 val local_state_predicate_to_local_bytes_state_predicate:
@@ -196,6 +221,23 @@ let local_state_update_predicate_to_local_bytes_state_update_predicate #cinvs #a
     );
   }
 
+val local_state_predicates_to_local_bytes_state_predicates:
+  {|crypto_invariants|} ->
+  #a:Type -> {|local_state a|} ->
+  local_state_predicates a -> local_bytes_state_predicates (tag #a)
+let local_state_predicates_to_local_bytes_state_predicates #cinvs #a #ls_a typed_spred = {
+  local_bytes_state_pred = local_state_predicate_to_local_bytes_state_predicate typed_spred.local_state_pred;
+  local_bytes_state_update_pred = local_state_update_predicate_to_local_bytes_state_update_predicate typed_spred.local_state_update_pred;
+}
+
+val mk_local_state_tag_and_preds:
+  #a:Type -> {|local_state a|} ->
+  {|crypto_invariants|} -> local_state_predicates a ->
+  dtuple2 string local_bytes_state_predicates
+let mk_local_state_tag_and_preds #a #ls_a #cinvs spred =
+  (|ls_a.tag, (local_state_predicates_to_local_bytes_state_predicates spred)|)
+
+(*
 val mk_local_state_tag_and_pred:
   #a:Type -> {|local_state a|} ->
   {|crypto_invariants|} -> local_state_predicate a ->
@@ -209,7 +251,9 @@ val mk_local_state_tag_and_update_pred:
   dtuple2 string local_bytes_state_update_predicate
 let mk_local_state_tag_and_update_pred #a #ls_a #cinvs supred =
   (|ls_a.tag, (local_state_update_predicate_to_local_bytes_state_update_predicate supred)|)
+*)
 
+(*
 unfold
 val has_local_state_predicate:
   #a:Type -> {|local_state a|} ->
@@ -225,6 +269,16 @@ val has_local_state_update_predicate:
   prop
 let has_local_state_update_predicate #a #ls #invs supred =
   has_local_bytes_state_update_predicate (mk_local_state_tag_and_update_pred supred)
+*)
+
+unfold
+val has_local_state_predicates:
+  #a:Type -> {|local_state a|} ->
+  {|protocol_invariants|} -> local_state_predicates a ->
+  prop
+let has_local_state_predicates #a #ls #invs spred =
+  has_local_bytes_state_predicates (mk_local_state_tag_and_preds spred)
+
 
 [@@ "opaque_to_smt"]
 val state_was_set:
@@ -452,19 +506,18 @@ let set_state_state_was_set #a #ls  prin sess_id content tr =
 val set_state_invariant:
   #a:Type -> {|ls:local_state a|} ->
   {|protocol_invariants|} ->
-  spred:local_state_predicate a -> supred:local_state_update_predicate a ->
+  spred:local_state_predicates a ->
   prin:principal -> sess_id:state_id -> content:a -> tr:trace ->
   Lemma
   (requires
-    spred.pred tr prin sess_id content /\
+    spred.local_state_pred.pred tr prin sess_id content /\
     (
       match get_state prin sess_id tr with
       | (None, _) -> DY.Core.Trace.Base.is_most_recent_state_for prin sess_id None tr
-      | (Some old_content, _) -> supred.update_pred tr prin sess_id old_content content
+      | (Some old_content, _) -> spred.local_state_update_pred.update_pred tr prin sess_id old_content content
     ) /\
     trace_invariant tr /\
-    has_local_state_predicate spred /\
-    has_local_state_update_predicate supred
+    has_local_state_predicates spred
   )
   (ensures (
     let ((), tr_out) = set_state prin sess_id content tr in
@@ -472,10 +525,9 @@ val set_state_invariant:
   ))
   [SMTPat (set_state prin sess_id content tr);
    SMTPat (trace_invariant tr);
-   SMTPat (has_local_state_predicate spred);
-   SMTPat (has_local_state_update_predicate supred);
+   SMTPat (has_local_state_predicates spred);
   ]
-let set_state_invariant #a #ls #invs spred supred prin sess_id content tr =
+let set_state_invariant #a #ls #invs spred prin sess_id content tr =
   reveal_opaque (`%set_state) (set_state #a);
   parse_serialize_inv_lemma #bytes a content;
   // Handle update predicate if applicable
@@ -519,18 +571,18 @@ let get_state_state_was_set #a #ls prin sess_id tr =
 val state_was_set_implies_pred:
   #a:Type -> {|local_state a|} ->
   {|protocol_invariants|} -> tr:trace ->
-  spred:local_state_predicate a ->
+  spred:local_state_predicates a ->
   prin:principal -> sess_id:state_id -> content:a ->
   Lemma
   (requires
     state_was_set tr prin sess_id content /\
     trace_invariant tr /\
-    has_local_state_predicate spred
+    has_local_state_predicates spred
   )
-  (ensures spred.pred tr prin sess_id content)
+  (ensures spred.local_state_pred.pred tr prin sess_id content)
   [SMTPat (state_was_set tr prin sess_id content);
    SMTPat (trace_invariant tr);
-   SMTPat (has_local_state_predicate spred);
+   SMTPat (has_local_state_predicates spred);
   ]
 let state_was_set_implies_pred #a #ls #invs tr spred prin sess_id content =
   parse_serialize_inv_lemma #bytes a content;
@@ -540,7 +592,7 @@ val state_was_set_twice_implies_update_pred:
   #a:Type -> {|local_state a|} ->
   {|protocol_invariants|} -> tr:trace ->
   ts1:timestamp -> ts2:timestamp ->
-  supred:local_state_update_predicate a ->
+  spred:local_state_predicates a ->
   prin:principal -> sess_id:state_id ->
   content1:a -> content2:a ->
   Lemma
@@ -549,54 +601,54 @@ val state_was_set_twice_implies_update_pred:
     state_was_set_at tr ts2 prin sess_id content2 /\
     ts1 < ts2 /\
     trace_invariant tr /\
-    has_local_state_update_predicate supred
+    has_local_state_predicates spred
   )
   (ensures
-    supred.update_pred tr prin sess_id content1 content2
+    spred.local_state_update_pred.update_pred tr prin sess_id content1 content2
   )
   [SMTPat (state_was_set_at tr ts1 prin sess_id content1);
    SMTPat (state_was_set_at tr ts2 prin sess_id content2);
    SMTPat (trace_invariant tr);
-   SMTPat (has_local_state_update_predicate supred);
+   SMTPat (has_local_state_predicates spred);
   ]
-let state_was_set_twice_implies_update_pred #a #ls_a #invs tr ts1 ts2 supred prin sess_id content1 content2 =
+let state_was_set_twice_implies_update_pred #a #ls_a #invs tr ts1 ts2 spred prin sess_id content1 content2 =
   reveal_opaque (`%state_was_set_at) (state_was_set_at #a);
   let content1_bytes = serialize _ content1 in
   let content2_bytes = serialize _ content2 in
-  let tagged_supred = local_state_update_predicate_to_local_bytes_state_update_predicate supred in
-  tagged_state_was_set_twice_implies_update_pred tr ts1 ts2 ls_a.tag tagged_supred prin sess_id content1_bytes content2_bytes;
+  let tagged_spred = local_state_predicates_to_local_bytes_state_predicates spred in
+  tagged_state_was_set_twice_implies_update_pred tr ts1 ts2 ls_a.tag tagged_spred prin sess_id content1_bytes content2_bytes;
   ()
 
 val most_recent_state_update_pred:
   #a:Type -> {|local_state a|} ->
   {|protocol_invariants|} ->
   tr:trace ->
-  supred:local_state_update_predicate a ->
+  spred:local_state_predicates a ->
   prin:principal -> sess_id:state_id ->
   content:a ->
   Lemma
   (requires
     state_was_set tr prin sess_id content /\
     trace_invariant tr /\
-    has_local_state_update_predicate supred
+    has_local_state_predicates spred
   )
   (ensures (
     match get_state prin sess_id tr with
     | (None, _) -> False
     | (Some new_content, _) -> (
-      supred.update_pred tr prin sess_id content new_content \/
+      spred.local_state_update_pred.update_pred tr prin sess_id content new_content \/
       content == new_content
     )
   ))
   [SMTPat (state_was_set tr prin sess_id content);
    SMTPat (trace_invariant tr);
-   SMTPat (has_local_state_update_predicate supred);
+   SMTPat (has_local_state_predicates spred);
    SMTPat (get_state #a prin sess_id tr);
   ]
-let most_recent_state_update_pred #a #ls_a #invs tr supred prin sess_id content =
+let most_recent_state_update_pred #a #ls_a #invs tr spred prin sess_id content =
   reveal_opaque (`%state_was_set) (state_was_set #a);
   reveal_opaque (`%get_state) (get_state #a);
   let content_bytes = serialize _ content in
-  let tagged_supred = local_state_update_predicate_to_local_bytes_state_update_predicate supred in
-  most_recent_tagged_state_update_pred tr ls_a.tag tagged_supred prin sess_id content_bytes;
+  let tagged_spred = local_state_predicates_to_local_bytes_state_predicates spred in
+  most_recent_tagged_state_update_pred tr ls_a.tag tagged_spred prin sess_id content_bytes;
   ()


### PR DESCRIPTION
In the existing DY* framework, state updates are only constrained *locally* --- that is, we check if the state is allowed to be set in isolation, regardless of what the current value of the state at that address is.

This PR adds support for update predicates, which constrain how state may be modified. Intuitively, the predicate `update_pred tr prin sess_id b1 b2` is true when, in the context of the trace `tr`, it would be allowed to update the state belonging to `prin` with state ID `sess_id` from `b1` to `b2`. Note that this predicate does not make any claims about what the current state value at address `(prin, sess_id)` on `tr` is.

With this sort of predicate, we can express more precise constrants about the evolution of state through a protocol. The basic use cases include enforcing that some component of a state is constant once initially set, or enforcing that some portion of a state is monotonic (e.g., a version counter), neither of which can be strictly enforced within the existing framework.

Some points for consideration:
- Currently, this PR requires that update predicates are *stable* and *transitive*. Stability seems quite natural, as with the existing state predicate --- if we are allowed to update from `b1` to `b2` at some point, then it seems natural that that update should still be allowed later, especially with our general handling of state with stable conditions. Transitivity is more open to discussion --- of course, this restricts what sorts of predicates can be written down, but much of what we want to express is naturally transitive, and also working with non-transitive update predicates would be more complex. See, for example, the lemma `state_was_set_twice_implies_update_pred`, which currently relies on transitivity to have a clean postcondition, and would need to rely on some notion of transitive closure otherwise.
- In some sense, the state update predicate strictly generalizes the existing state predicate --- by ignoring the `b1` argument, `update_pred tr prin sess_id _ b2` can take over all use cases of `state_pred tr prin sess_id b2`.  In practice, however, it seems like keeping these two notions separate matches better with the intuition of what each is used for, at least for now. It might make sense to reconsider this in the future, especially with an eye to making a library on top that can provide a more intuitive interface.
- The predicate `is_state_for` seems to come up quite a bit, and maybe should be pulled out as a separate helper function somewhere, rather than redefined locally in several different places. That said, I don't see a very natural place for it to go.
- A weak argument could be made for update predicates being reflexive, so that we can always update from `b` to `b`. This doesn't seem to give very strong practical benefits --- the main gain would be in replacing `<` with `<=` in `state_was_set_twice_implies_update_pred`, but there may be some more subtle benefits as well. I think in general, being able to express strict orders is more useful than any benefits that come from generically requiring reflexivity, though.

Examples also likely need to still be updated (work in progress), but I expect that any example that already exists can get a constant true update predicate and verify fine with no further changes.

Any feedback on this concept is welcome --- I think the general idea is right here, but there's certainly room for improvement in the implementation.