### PR TITLE
Comm Layer Extensibility Improvements

### DIFF
--- a/src/lib/communication/DY.Lib.Communication.Core.Invariants.fst
+++ b/src/lib/communication/DY.Lib.Communication.Core.Invariants.fst
@@ -17,8 +17,8 @@ open DY.Lib.Communication.Core
 
 (*** PkEnc Predicates ***)
 
-val pke_crypto_predicates_communication_layer: {|comm_layer_event_core_tag|} -> {|cusages:crypto_usages|} -> pke_crypto_predicate
-let pke_crypto_predicates_communication_layer #event_tag #cusages = {
+val pke_crypto_predicates_communication_layer: {|comm_layer_core_tag|} -> {|cusages:crypto_usages|} -> pke_crypto_predicate
+let pke_crypto_predicates_communication_layer #tag #cusages = {
   pred = (fun tr sk_usage pk msg ->
     (exists sender receiver.
       sk_usage == long_term_key_type_to_usage (LongTermPkeKey comm_layer_pkenc_tag)  receiver /\
@@ -30,17 +30,17 @@ let pke_crypto_predicates_communication_layer #event_tag #cusages = {
 }
 
 val pke_crypto_predicates_communication_layer_and_tag:
-  {|comm_layer_event_core_tag|} ->
+  {|comm_layer_core_tag|} ->
   {|cusages:crypto_usages|} ->
   (string & pke_crypto_predicate)
-let pke_crypto_predicates_communication_layer_and_tag #event_tag #cusages =
+let pke_crypto_predicates_communication_layer_and_tag #tag #cusages =
   (comm_layer_pkenc_tag, pke_crypto_predicates_communication_layer)
 
 (*** Sign Predicates ***)
 
 #push-options "--ifuel 3 --fuel 0"
-val sign_crypto_predicates_communication_layer: {|comm_layer_event_core_tag|} -> {|cusages:crypto_usages|} -> sign_crypto_predicate
-let sign_crypto_predicates_communication_layer #event_tag #cusages = {
+val sign_crypto_predicates_communication_layer: {|comm_layer_core_tag|} -> {|cusages:crypto_usages|} -> sign_crypto_predicate
+let sign_crypto_predicates_communication_layer #tag #cusages = {
   pred = (fun tr sk_usage vk sig_msg ->
     (match parse signature_input sig_msg with
     | Some (Plain sender receiver payload_bytes) -> (
@@ -67,17 +67,17 @@ let sign_crypto_predicates_communication_layer #event_tag #cusages = {
 #pop-options
 
 val sign_crypto_predicates_communication_layer_and_tag:
-  {|comm_layer_event_core_tag|} ->
+  {|comm_layer_core_tag|} ->
   {|cusages:crypto_usages|} ->
   (string & sign_crypto_predicate)
-let sign_crypto_predicates_communication_layer_and_tag #event_tag #cusages =
+let sign_crypto_predicates_communication_layer_and_tag #tag #cusages =
   (comm_layer_sign_tag, sign_crypto_predicates_communication_layer)
 
 val has_communication_layer_crypto_predicates:
-  {|comm_layer_event_core_tag|} ->
+  {|comm_layer_core_tag|} ->
   {|crypto_invariants|} ->
   prop
-let has_communication_layer_crypto_predicates #event_tag #cinvs =
+let has_communication_layer_crypto_predicates #tag #cinvs =
   has_pke_predicate pke_crypto_predicates_communication_layer_and_tag /\
   has_sign_predicate sign_crypto_predicates_communication_layer_and_tag
 
@@ -133,7 +133,7 @@ let default_comm_higher_layer_event_preds (a:Type) {| parseable_serializeable by
 
 #push-options "--ifuel 1 --fuel 0"
 let event_predicate_communication_layer
-  {|comm_layer_event_core_tag|}
+  {|comm_layer_core_tag|}
   {|cinvs:crypto_invariants|}
   (#a:Type) {| parseable_serializeable bytes a |}
   (higher_layer_preds:comm_higher_layer_event_preds a) :
@@ -187,7 +187,7 @@ let event_predicate_communication_layer
 #pop-options
 
 val event_predicate_communication_layer_and_tag:
-  {|comm_layer_event_core_tag|} ->
+  {|comm_layer_core_tag|} ->
   {|cinvs:crypto_invariants|} ->
   #a:Type -> {| parseable_serializeable bytes a |} ->
   comm_higher_layer_event_preds a ->
@@ -196,10 +196,10 @@ let event_predicate_communication_layer_and_tag #cinvs higher_layer_preds =
   mk_event_tag_and_pred (event_predicate_communication_layer higher_layer_preds)
 
 val has_communication_layer_event_predicates:
-  {|comm_layer_event_core_tag|} ->
+  {|comm_layer_core_tag|} ->
   {|protocol_invariants|} ->
   #a:Type -> {| parseable_serializeable bytes a |} ->
   comm_higher_layer_event_preds a ->
   prop
-let has_communication_layer_event_predicates #event_tag #invs higher_layer_preds =
+let has_communication_layer_event_predicates #tag #invs higher_layer_preds =
   has_event_pred (event_predicate_communication_layer higher_layer_preds)

--- a/src/lib/communication/DY.Lib.Communication.Core.Invariants.fst
+++ b/src/lib/communication/DY.Lib.Communication.Core.Invariants.fst
@@ -17,8 +17,8 @@ open DY.Lib.Communication.Core
 
 (*** PkEnc Predicates ***)
 
-val pke_crypto_predicates_communication_layer: {|cusages:crypto_usages|} -> pke_crypto_predicate
-let pke_crypto_predicates_communication_layer #cusages = {
+val pke_crypto_predicates_communication_layer: {|comm_layer_event_core_tag|} -> {|cusages:crypto_usages|} -> pke_crypto_predicate
+let pke_crypto_predicates_communication_layer #event_tag #cusages = {
   pred = (fun tr sk_usage pk msg ->
     (exists sender receiver.
       sk_usage == long_term_key_type_to_usage (LongTermPkeKey comm_layer_pkenc_tag)  receiver /\
@@ -30,16 +30,17 @@ let pke_crypto_predicates_communication_layer #cusages = {
 }
 
 val pke_crypto_predicates_communication_layer_and_tag:
+  {|comm_layer_event_core_tag|} ->
   {|cusages:crypto_usages|} ->
   (string & pke_crypto_predicate)
-let pke_crypto_predicates_communication_layer_and_tag #cusages =
+let pke_crypto_predicates_communication_layer_and_tag #event_tag #cusages =
   (comm_layer_pkenc_tag, pke_crypto_predicates_communication_layer)
 
 (*** Sign Predicates ***)
 
 #push-options "--ifuel 3 --fuel 0"
-val sign_crypto_predicates_communication_layer: {|cusages:crypto_usages|} -> sign_crypto_predicate
-let sign_crypto_predicates_communication_layer #cusages = {
+val sign_crypto_predicates_communication_layer: {|comm_layer_event_core_tag|} -> {|cusages:crypto_usages|} -> sign_crypto_predicate
+let sign_crypto_predicates_communication_layer #event_tag #cusages = {
   pred = (fun tr sk_usage vk sig_msg ->
     (match parse signature_input sig_msg with
     | Some (Plain sender receiver payload_bytes) -> (
@@ -66,15 +67,17 @@ let sign_crypto_predicates_communication_layer #cusages = {
 #pop-options
 
 val sign_crypto_predicates_communication_layer_and_tag:
+  {|comm_layer_event_core_tag|} ->
   {|cusages:crypto_usages|} ->
   (string & sign_crypto_predicate)
-let sign_crypto_predicates_communication_layer_and_tag #cusages =
+let sign_crypto_predicates_communication_layer_and_tag #event_tag #cusages =
   (comm_layer_sign_tag, sign_crypto_predicates_communication_layer)
 
 val has_communication_layer_crypto_predicates:
+  {|comm_layer_event_core_tag|} ->
   {|crypto_invariants|} ->
   prop
-let has_communication_layer_crypto_predicates #cinvs =
+let has_communication_layer_crypto_predicates #event_tag #cinvs =
   has_pke_predicate pke_crypto_predicates_communication_layer_and_tag /\
   has_sign_predicate sign_crypto_predicates_communication_layer_and_tag
 
@@ -130,6 +133,7 @@ let default_comm_higher_layer_event_preds (a:Type) {| parseable_serializeable by
 
 #push-options "--ifuel 1 --fuel 0"
 let event_predicate_communication_layer
+  {|comm_layer_event_core_tag|}
   {|cinvs:crypto_invariants|}
   (#a:Type) {| parseable_serializeable bytes a |}
   (higher_layer_preds:comm_higher_layer_event_preds a) :
@@ -183,6 +187,7 @@ let event_predicate_communication_layer
 #pop-options
 
 val event_predicate_communication_layer_and_tag:
+  {|comm_layer_event_core_tag|} ->
   {|cinvs:crypto_invariants|} ->
   #a:Type -> {| parseable_serializeable bytes a |} ->
   comm_higher_layer_event_preds a ->
@@ -191,9 +196,10 @@ let event_predicate_communication_layer_and_tag #cinvs higher_layer_preds =
   mk_event_tag_and_pred (event_predicate_communication_layer higher_layer_preds)
 
 val has_communication_layer_event_predicates:
+  {|comm_layer_event_core_tag|} ->
   {|protocol_invariants|} ->
   #a:Type -> {| parseable_serializeable bytes a |} ->
   comm_higher_layer_event_preds a ->
   prop
-let has_communication_layer_event_predicates #invs higher_layer_preds =
-  has_event_pred (event_predicate_communication_layer #invs.crypto_invs higher_layer_preds)
+let has_communication_layer_event_predicates #event_tag #invs higher_layer_preds =
+  has_event_pred (event_predicate_communication_layer higher_layer_preds)

--- a/src/lib/communication/DY.Lib.Communication.Core.Invariants.fst
+++ b/src/lib/communication/DY.Lib.Communication.Core.Invariants.fst
@@ -17,48 +17,57 @@ open DY.Lib.Communication.Core
 
 (*** PkEnc Predicates ***)
 
-val pke_crypto_predicates_communication_layer: {|comm_layer_core_tag|} -> {|cusages:crypto_usages|} -> pke_crypto_predicate
-let pke_crypto_predicates_communication_layer #tag #cusages = {
+#push-options "--ifuel 1"
+val pke_crypto_predicates_communication_layer: {|cusages:crypto_usages|} -> a:Type0 -> {|comm_layer_core_config a|} -> pke_crypto_predicate
+let pke_crypto_predicates_communication_layer #cusages a #config  = {
   pred = (fun tr sk_usage pk msg ->
     (exists sender receiver.
-      sk_usage == long_term_key_type_to_usage (LongTermPkeKey comm_layer_pkenc_tag)  receiver /\
+      sk_usage == long_term_key_type_to_usage (LongTermPkeKey (comm_layer_pkenc_tag a))  receiver /\
       (get_label tr msg) `can_flow tr` (comm_label sender receiver) /\
-      event_triggered tr sender (CommConfSendMsg sender receiver msg)
+      (match parse a msg with
+      | None -> False
+      | Some msg_parsed -> event_triggered tr sender (CommConfSendMsg sender receiver msg_parsed <: communication_core_event a))
+      
     )
     );
   pred_later = (fun tr1 tr2 sk_usage pk msg -> ());
 }
+#pop-options
 
 val pke_crypto_predicates_communication_layer_and_tag:
-  {|comm_layer_core_tag|} ->
   {|cusages:crypto_usages|} ->
+  (a:Type0) -> {|comm_layer_core_config a|} ->  
   (string & pke_crypto_predicate)
-let pke_crypto_predicates_communication_layer_and_tag #tag #cusages =
-  (comm_layer_pkenc_tag, pke_crypto_predicates_communication_layer)
+let pke_crypto_predicates_communication_layer_and_tag #cusages a #config =
+  ((comm_layer_pkenc_tag a), pke_crypto_predicates_communication_layer a)
 
 (*** Sign Predicates ***)
 
 #push-options "--ifuel 3 --fuel 0"
-val sign_crypto_predicates_communication_layer: {|comm_layer_core_tag|} -> {|cusages:crypto_usages|} -> sign_crypto_predicate
-let sign_crypto_predicates_communication_layer #tag #cusages = {
+val sign_crypto_predicates_communication_layer: {|cusages:crypto_usages|} -> a:Type0 -> {|comm_layer_core_config a|} -> sign_crypto_predicate
+let sign_crypto_predicates_communication_layer #cusages a #config = {
   pred = (fun tr sk_usage vk sig_msg ->
     (match parse signature_input sig_msg with
     | Some (Plain sender receiver payload_bytes) -> (
-      sk_usage == long_term_key_type_to_usage (LongTermSigKey comm_layer_sign_tag) sender /\
+      sk_usage == long_term_key_type_to_usage (LongTermSigKey (comm_layer_sign_tag a)) sender /\
       get_label tr payload_bytes `can_flow tr` public /\
-      event_triggered tr sender (CommAuthSendMsg sender payload_bytes)
-    )
-    | Some (Encrypted sender receiver payload_bytes pk_receiver) -> (
-      match parse com_send_byte payload_bytes with
+      (match parse a payload_bytes with
       | None -> False
-      | Some payload -> (
-        get_label tr payload_bytes `can_flow tr` public /\
+      | Some payload -> event_triggered tr sender (CommAuthSendMsg sender payload <: communication_core_event a))
+    )
+    | Some (Encrypted sender receiver payload pk_receiver) -> (
+      (*match parse comm_send_byte payload_bytes with
+      | None -> False
+      | Some payload -> ( *)
+        get_label tr payload `can_flow tr` public /\
+        sk_usage == long_term_key_type_to_usage (LongTermSigKey (comm_layer_sign_tag a)) sender /\
         (exists plain_payload nonce.
-          sk_usage == long_term_key_type_to_usage (LongTermSigKey comm_layer_sign_tag) sender /\
-          payload.b == pke_enc pk_receiver nonce plain_payload /\
-          event_triggered tr sender (CommConfAuthSendMsg sender receiver plain_payload)
+          payload == pke_enc pk_receiver nonce plain_payload /\
+          (match parse a plain_payload with
+          | None -> False
+          | Some plain_payload_parsed -> event_triggered tr sender (CommConfAuthSendMsg sender receiver plain_payload_parsed <: communication_core_event a))
         )
-      )
+      //)
     )
     | None -> False)
   );
@@ -67,24 +76,24 @@ let sign_crypto_predicates_communication_layer #tag #cusages = {
 #pop-options
 
 val sign_crypto_predicates_communication_layer_and_tag:
-  {|comm_layer_core_tag|} ->
   {|cusages:crypto_usages|} ->
+  (a:Type0) -> {|comm_layer_core_config a|} -> 
   (string & sign_crypto_predicate)
-let sign_crypto_predicates_communication_layer_and_tag #tag #cusages =
-  (comm_layer_sign_tag, sign_crypto_predicates_communication_layer)
+let sign_crypto_predicates_communication_layer_and_tag #cusages a #config =
+  (comm_layer_sign_tag a, sign_crypto_predicates_communication_layer a)
 
 val has_communication_layer_crypto_predicates:
-  {|comm_layer_core_tag|} ->
   {|crypto_invariants|} ->
+  (a:Type0) -> {|comm_layer_core_config a|} -> 
   prop
-let has_communication_layer_crypto_predicates #tag #cinvs =
-  has_pke_predicate pke_crypto_predicates_communication_layer_and_tag /\
-  has_sign_predicate sign_crypto_predicates_communication_layer_and_tag
+let has_communication_layer_crypto_predicates #cinvs a #config =
+  has_pke_predicate (pke_crypto_predicates_communication_layer_and_tag a) /\
+  has_sign_predicate (sign_crypto_predicates_communication_layer_and_tag a)
 
 (*** Event Predicates ***)
 
 noeq
-type comm_higher_layer_event_preds (a:Type) {| parseable_serializeable bytes a |} = {
+type comm_higher_layer_event_preds (a:Type) {|comm_layer_core_config a|} = {
   send_conf: tr:trace -> sender:principal -> receiver:principal -> payload:a -> prop;
   send_conf_later:
     tr1:trace -> tr2:trace ->
@@ -122,7 +131,7 @@ type comm_higher_layer_event_preds (a:Type) {| parseable_serializeable bytes a |
     (ensures send_conf_auth tr2 sender receiver payload)
 }
 
-let default_comm_higher_layer_event_preds (a:Type) {| parseable_serializeable bytes a |} : comm_higher_layer_event_preds a = {
+let default_comm_higher_layer_event_preds (a:Type) {|comm_layer_core_config a|} : comm_higher_layer_event_preds a = {
   send_conf = (fun tr sender receiver payload -> False);
   send_conf_later = (fun tr1 tr2 sender receiver payload -> ());
   send_auth = (fun tr sender payload -> False);
@@ -133,38 +142,33 @@ let default_comm_higher_layer_event_preds (a:Type) {| parseable_serializeable by
 
 #push-options "--ifuel 1 --fuel 0"
 let event_predicate_communication_layer
-  {|comm_layer_core_tag|}
   {|cinvs:crypto_invariants|}
-  (#a:Type) {| parseable_serializeable bytes a |}
+  (#a:Type0) {|comm_layer_core_config a|}
   (higher_layer_preds:comm_higher_layer_event_preds a) :
-  event_predicate communication_event =
+  event_predicate (communication_core_event a) =
   fun tr prin e ->
     (match e with
     | CommConfSendMsg sender receiver payload -> (
-      is_knowable_by (comm_label sender receiver) tr payload /\
-      parse_and_pred (higher_layer_preds.send_conf tr sender receiver) payload
+      is_well_formed a (is_knowable_by (comm_label sender receiver) tr) payload /\
+      higher_layer_preds.send_conf tr sender receiver payload
     )
     | CommConfReceiveMsg receiver payload -> (
-      Some? (parse a payload) /\
-      (
-        (exists sender. event_triggered tr sender (CommConfSendMsg sender receiver payload)) \/
-        is_publishable tr payload
-      )
+      (exists sender. event_triggered tr sender (CommConfSendMsg sender receiver payload <: communication_core_event a)) \/
+      is_well_formed a (is_publishable tr) payload
     )
     | CommAuthSendMsg sender payload -> (
-      parse_and_pred (higher_layer_preds.send_auth tr sender) payload
+      higher_layer_preds.send_auth tr sender payload
     )
     | CommAuthReceiveMsg sender receiver payload -> (
-      Some? (parse a payload) /\
-      is_publishable tr payload /\
+      is_well_formed a (is_publishable tr) payload /\
       (
-        event_triggered tr sender (CommAuthSendMsg sender payload) \/
+        event_triggered tr sender (CommAuthSendMsg sender payload <: communication_core_event a) \/
         is_corrupt tr (long_term_key_label sender)
       )
     )
     | CommConfAuthSendMsg sender receiver payload -> (
-      is_knowable_by (comm_label sender receiver) tr payload /\
-      parse_and_pred (higher_layer_preds.send_conf_auth tr sender receiver) payload
+      is_well_formed a (is_knowable_by (comm_label sender receiver) tr) payload /\
+      higher_layer_preds.send_conf_auth tr sender receiver payload
     )
     | CommConfAuthReceiveMsg sender receiver payload -> (
       // We can only show the following about the decrypted ciphertext (payload):
@@ -177,9 +181,8 @@ let event_predicate_communication_layer
       // Since the attacker can freely choose the sender/receiver information, the
       // receiver cannot guarantee that the full confidential/authenticated message
       // was honestly generated by the stated sender.
-      Some? (parse a payload) /\
       (
-        event_triggered tr sender (CommConfAuthSendMsg sender receiver payload) \/
+        event_triggered tr sender (CommConfAuthSendMsg sender receiver payload <: communication_core_event a) \/
         is_corrupt tr (long_term_key_label sender)
       )
     )
@@ -187,19 +190,17 @@ let event_predicate_communication_layer
 #pop-options
 
 val event_predicate_communication_layer_and_tag:
-  {|comm_layer_core_tag|} ->
   {|cinvs:crypto_invariants|} ->
-  #a:Type -> {| parseable_serializeable bytes a |} ->
+  #a:Type0 -> {|comm_layer_core_config a|} ->
   comm_higher_layer_event_preds a ->
   (string & compiled_event_predicate)
-let event_predicate_communication_layer_and_tag #cinvs higher_layer_preds =
+let event_predicate_communication_layer_and_tag #cinvs #a higher_layer_preds =
   mk_event_tag_and_pred (event_predicate_communication_layer higher_layer_preds)
 
 val has_communication_layer_event_predicates:
-  {|comm_layer_core_tag|} ->
   {|protocol_invariants|} ->
-  #a:Type -> {| parseable_serializeable bytes a |} ->
+  a:Type0 -> {|comm_layer_core_config a|} ->
   comm_higher_layer_event_preds a ->
   prop
-let has_communication_layer_event_predicates #tag #invs higher_layer_preds =
+let has_communication_layer_event_predicates #invs a higher_layer_preds =
   has_event_pred (event_predicate_communication_layer higher_layer_preds)

--- a/src/lib/communication/DY.Lib.Communication.Core.Invariants.fst
+++ b/src/lib/communication/DY.Lib.Communication.Core.Invariants.fst
@@ -18,42 +18,39 @@ open DY.Lib.Communication.Core
 (*** PkEnc Predicates ***)
 
 #push-options "--ifuel 1"
-val pke_crypto_predicates_communication_layer: {|cusages:crypto_usages|} -> a:Type0 -> {|comm_layer_core_config a|} -> pke_crypto_predicate
-let pke_crypto_predicates_communication_layer #cusages a #config  = {
+val pke_crypto_predicates_communication_layer_core: {|cusages:crypto_usages|} -> a:Type0 -> {|comm_layer_core_config a|} -> pke_crypto_predicate
+let pke_crypto_predicates_communication_layer_core #cusages a #config  = {
   pred = (fun tr sk_usage pk msg ->
     (exists sender receiver.
       sk_usage == long_term_key_type_to_usage (LongTermPkeKey (comm_layer_pkenc_tag a))  receiver /\
       (get_label tr msg) `can_flow tr` (comm_label sender receiver) /\
-      (match parse a msg with
-      | None -> False
-      | Some msg_parsed -> event_triggered tr sender (CommConfSendMsg sender receiver msg_parsed <: communication_core_event a))
-      
+      parse_and_pred 
+        (fun msg_parsed -> event_triggered tr sender (CommConfSendMsg sender receiver msg_parsed <: communication_core_event a)) 
+        msg      
     )
     );
   pred_later = (fun tr1 tr2 sk_usage pk msg -> ());
 }
 #pop-options
 
-val pke_crypto_predicates_communication_layer_core_and_tag:
+val pke_crypto_predicates_and_tag_communication_layer_core:
   {|cusages:crypto_usages|} ->
   (a:Type0) -> {|comm_layer_core_config a|} ->  
   (string & pke_crypto_predicate)
-let pke_crypto_predicates_communication_layer_core_and_tag #cusages a #config =
-  ((comm_layer_pkenc_tag a), pke_crypto_predicates_communication_layer a)
+let pke_crypto_predicates_and_tag_communication_layer_core #cusages a #config =
+  ((comm_layer_pkenc_tag a), pke_crypto_predicates_communication_layer_core a)
 
 (*** Sign Predicates ***)
 
 #push-options "--ifuel 3 --fuel 0"
-val sign_crypto_predicates_communication_layer: {|cusages:crypto_usages|} -> a:Type0 -> {|comm_layer_core_config a|} -> sign_crypto_predicate
-let sign_crypto_predicates_communication_layer #cusages a #config = {
+val sign_crypto_predicate_communication_layer_core: {|cusages:crypto_usages|} -> a:Type0 -> {|comm_layer_core_config a|} -> sign_crypto_predicate
+let sign_crypto_predicate_communication_layer_core #cusages a #config = {
   pred = (fun tr sk_usage vk sig_msg ->
-    (match parse signature_input sig_msg with
-    | Some (Plain sender receiver payload_bytes) -> (
+    (match parse (signature_input a) sig_msg with
+    | Some (Plain sender receiver payload) -> (
       sk_usage == long_term_key_type_to_usage (LongTermSigKey (comm_layer_sign_tag a)) sender /\
-      get_label tr payload_bytes `can_flow tr` public /\
-      (match parse a payload_bytes with
-      | None -> False
-      | Some payload -> event_triggered tr sender (CommAuthSendMsg sender payload <: communication_core_event a))
+      get_label tr (serialize a payload) `can_flow tr` public /\
+      event_triggered tr sender (CommAuthSendMsg sender payload <: communication_core_event a)
     )
     | Some (Encrypted sender receiver payload pk_receiver) -> (
       get_label tr payload `can_flow tr` public /\
@@ -67,24 +64,32 @@ let sign_crypto_predicates_communication_layer #cusages a #config = {
     )
     | None -> False)
   );
-  pred_later = (fun tr1 tr2 sk_usage vk msg -> parse_wf_lemma signature_input (bytes_well_formed tr1) msg);
+  pred_later = (fun tr1 tr2 sk_usage vk msg -> (
+    parse_wf_lemma (signature_input a) (bytes_well_formed tr1) msg);
+    match parse (signature_input a) msg with
+    | Some (Plain sender receiver payload) -> (
+      serialize_wf_lemma a (bytes_well_formed tr1) payload;
+      ()
+    )
+    | _ -> ()
+  );
 }
 #pop-options
 
-val sign_crypto_predicates_communication_layer_core_and_tag:
+val sign_crypto_predicate_and_tag_communication_layer_core:
   {|cusages:crypto_usages|} ->
   (a:Type0) -> {|comm_layer_core_config a|} -> 
   (string & sign_crypto_predicate)
-let sign_crypto_predicates_communication_layer_core_and_tag #cusages a #config =
-  (comm_layer_sign_tag a, sign_crypto_predicates_communication_layer a)
+let sign_crypto_predicate_and_tag_communication_layer_core #cusages a #config =
+  (comm_layer_sign_tag a, sign_crypto_predicate_communication_layer_core a)
 
 val has_communication_layer_core_crypto_predicates:
   {|crypto_invariants|} ->
   (a:Type0) -> {|comm_layer_core_config a|} -> 
   prop
 let has_communication_layer_core_crypto_predicates #cinvs a #config =
-  has_pke_predicate (pke_crypto_predicates_communication_layer_core_and_tag a) /\
-  has_sign_predicate (sign_crypto_predicates_communication_layer_core_and_tag a)
+  has_pke_predicate (pke_crypto_predicates_and_tag_communication_layer_core a) /\
+  has_sign_predicate (sign_crypto_predicate_and_tag_communication_layer_core a)
 
 (*** Event Predicates ***)
 
@@ -185,18 +190,30 @@ let event_predicate_communication_layer_core
     )
 #pop-options
 
-val event_predicate_communication_layer_core_and_tag:
+val event_predicate_and_tag_communication_layer_core:
   {|cinvs:crypto_invariants|} ->
   #a:Type0 -> {|comm_layer_core_config a|} ->
   comm_core_higher_layer_event_preds a ->
   (string & compiled_event_predicate)
-let event_predicate_communication_layer_core_and_tag #cinvs #a higher_layer_preds =
+let event_predicate_and_tag_communication_layer_core #cinvs #a higher_layer_preds =
   mk_event_tag_and_pred (event_predicate_communication_layer_core higher_layer_preds)
 
-val has_communication_layer_core_event_predicates:
+val has_communication_layer_core_event_predicate:
   {|protocol_invariants|} ->
-  a:Type0 -> {|comm_layer_core_config a|} ->
+  #a:Type0 -> {|comm_layer_core_config a|} ->
   comm_core_higher_layer_event_preds a ->
   prop
-let has_communication_layer_core_event_predicates #invs a higher_layer_preds =
+let has_communication_layer_core_event_predicate #invs #a higher_layer_preds =
   has_event_pred (event_predicate_communication_layer_core higher_layer_preds)
+
+
+(*** All Communication Layer Core Predicates ***)
+
+val has_communication_layer_core_predicates:
+  {|protocol_invariants|} ->
+  #a:Type0 -> {|comm_layer_core_config a|} ->
+  comm_core_higher_layer_event_preds a ->
+  prop
+let has_communication_layer_core_predicates #invs #a higher_layer_preds =
+  has_communication_layer_core_crypto_predicates a /\
+  has_communication_layer_core_event_predicate higher_layer_preds

--- a/src/lib/communication/DY.Lib.Communication.Core.Invariants.fst
+++ b/src/lib/communication/DY.Lib.Communication.Core.Invariants.fst
@@ -93,7 +93,8 @@ let sign_crypto_predicate_communication_layer_core #cusages a #config = {
       serialize_wf_lemma a (bytes_well_formed tr1) payload;
       ()
     )
-    | _ -> ()
+    | Some (Encrypted _ _ _ _) -> ()
+    | None -> assert(False)
   );
 }
 #pop-options

--- a/src/lib/communication/DY.Lib.Communication.Core.Invariants.fst
+++ b/src/lib/communication/DY.Lib.Communication.Core.Invariants.fst
@@ -34,11 +34,11 @@ let pke_crypto_predicates_communication_layer #cusages a #config  = {
 }
 #pop-options
 
-val pke_crypto_predicates_communication_layer_and_tag:
+val pke_crypto_predicates_communication_layer_core_and_tag:
   {|cusages:crypto_usages|} ->
   (a:Type0) -> {|comm_layer_core_config a|} ->  
   (string & pke_crypto_predicate)
-let pke_crypto_predicates_communication_layer_and_tag #cusages a #config =
+let pke_crypto_predicates_communication_layer_core_and_tag #cusages a #config =
   ((comm_layer_pkenc_tag a), pke_crypto_predicates_communication_layer a)
 
 (*** Sign Predicates ***)
@@ -56,18 +56,14 @@ let sign_crypto_predicates_communication_layer #cusages a #config = {
       | Some payload -> event_triggered tr sender (CommAuthSendMsg sender payload <: communication_core_event a))
     )
     | Some (Encrypted sender receiver payload pk_receiver) -> (
-      (*match parse comm_send_byte payload_bytes with
-      | None -> False
-      | Some payload -> ( *)
-        get_label tr payload `can_flow tr` public /\
-        sk_usage == long_term_key_type_to_usage (LongTermSigKey (comm_layer_sign_tag a)) sender /\
-        (exists plain_payload nonce.
-          payload == pke_enc pk_receiver nonce plain_payload /\
-          (match parse a plain_payload with
-          | None -> False
-          | Some plain_payload_parsed -> event_triggered tr sender (CommConfAuthSendMsg sender receiver plain_payload_parsed <: communication_core_event a))
-        )
-      //)
+      get_label tr payload `can_flow tr` public /\
+      sk_usage == long_term_key_type_to_usage (LongTermSigKey (comm_layer_sign_tag a)) sender /\
+      (exists plain_payload nonce.
+        payload == pke_enc pk_receiver nonce plain_payload /\
+        (match parse a plain_payload with
+        | None -> False
+        | Some plain_payload_parsed -> event_triggered tr sender (CommConfAuthSendMsg sender receiver plain_payload_parsed <: communication_core_event a))
+      )
     )
     | None -> False)
   );
@@ -75,25 +71,25 @@ let sign_crypto_predicates_communication_layer #cusages a #config = {
 }
 #pop-options
 
-val sign_crypto_predicates_communication_layer_and_tag:
+val sign_crypto_predicates_communication_layer_core_and_tag:
   {|cusages:crypto_usages|} ->
   (a:Type0) -> {|comm_layer_core_config a|} -> 
   (string & sign_crypto_predicate)
-let sign_crypto_predicates_communication_layer_and_tag #cusages a #config =
+let sign_crypto_predicates_communication_layer_core_and_tag #cusages a #config =
   (comm_layer_sign_tag a, sign_crypto_predicates_communication_layer a)
 
-val has_communication_layer_crypto_predicates:
+val has_communication_layer_core_crypto_predicates:
   {|crypto_invariants|} ->
   (a:Type0) -> {|comm_layer_core_config a|} -> 
   prop
-let has_communication_layer_crypto_predicates #cinvs a #config =
-  has_pke_predicate (pke_crypto_predicates_communication_layer_and_tag a) /\
-  has_sign_predicate (sign_crypto_predicates_communication_layer_and_tag a)
+let has_communication_layer_core_crypto_predicates #cinvs a #config =
+  has_pke_predicate (pke_crypto_predicates_communication_layer_core_and_tag a) /\
+  has_sign_predicate (sign_crypto_predicates_communication_layer_core_and_tag a)
 
 (*** Event Predicates ***)
 
 noeq
-type comm_higher_layer_event_preds (a:Type) {|comm_layer_core_config a|} = {
+type comm_core_higher_layer_event_preds (a:Type) {|comm_layer_core_config a|} = {
   send_conf: tr:trace -> sender:principal -> receiver:principal -> payload:a -> prop;
   send_conf_later:
     tr1:trace -> tr2:trace ->
@@ -131,7 +127,7 @@ type comm_higher_layer_event_preds (a:Type) {|comm_layer_core_config a|} = {
     (ensures send_conf_auth tr2 sender receiver payload)
 }
 
-let default_comm_higher_layer_event_preds (a:Type) {|comm_layer_core_config a|} : comm_higher_layer_event_preds a = {
+let default_comm_core_higher_layer_event_preds (a:Type) {|comm_layer_core_config a|} : comm_core_higher_layer_event_preds a = {
   send_conf = (fun tr sender receiver payload -> False);
   send_conf_later = (fun tr1 tr2 sender receiver payload -> ());
   send_auth = (fun tr sender payload -> False);
@@ -141,10 +137,10 @@ let default_comm_higher_layer_event_preds (a:Type) {|comm_layer_core_config a|} 
 }
 
 #push-options "--ifuel 1 --fuel 0"
-let event_predicate_communication_layer
+let event_predicate_communication_layer_core
   {|cinvs:crypto_invariants|}
   (#a:Type0) {|comm_layer_core_config a|}
-  (higher_layer_preds:comm_higher_layer_event_preds a) :
+  (higher_layer_preds:comm_core_higher_layer_event_preds a) :
   event_predicate (communication_core_event a) =
   fun tr prin e ->
     (match e with
@@ -189,18 +185,18 @@ let event_predicate_communication_layer
     )
 #pop-options
 
-val event_predicate_communication_layer_and_tag:
+val event_predicate_communication_layer_core_and_tag:
   {|cinvs:crypto_invariants|} ->
   #a:Type0 -> {|comm_layer_core_config a|} ->
-  comm_higher_layer_event_preds a ->
+  comm_core_higher_layer_event_preds a ->
   (string & compiled_event_predicate)
-let event_predicate_communication_layer_and_tag #cinvs #a higher_layer_preds =
-  mk_event_tag_and_pred (event_predicate_communication_layer higher_layer_preds)
+let event_predicate_communication_layer_core_and_tag #cinvs #a higher_layer_preds =
+  mk_event_tag_and_pred (event_predicate_communication_layer_core higher_layer_preds)
 
-val has_communication_layer_event_predicates:
+val has_communication_layer_core_event_predicates:
   {|protocol_invariants|} ->
   a:Type0 -> {|comm_layer_core_config a|} ->
-  comm_higher_layer_event_preds a ->
+  comm_core_higher_layer_event_preds a ->
   prop
-let has_communication_layer_event_predicates #invs a higher_layer_preds =
-  has_event_pred (event_predicate_communication_layer higher_layer_preds)
+let has_communication_layer_core_event_predicates #invs a higher_layer_preds =
+  has_event_pred (event_predicate_communication_layer_core higher_layer_preds)

--- a/src/lib/communication/DY.Lib.Communication.Core.Invariants.fst
+++ b/src/lib/communication/DY.Lib.Communication.Core.Invariants.fst
@@ -15,6 +15,32 @@ open DY.Lib.Communication.Core
 
 #set-options "--fuel 0 --ifuel 0 --z3cliopt 'smt.qi.eager_threshold=100'"
 
+(*** Helper Predicates ***)
+
+unfold
+val comm_conf_send_event_triggered:
+  #a:Type0 -> {|comm_layer_core_config a|} ->
+  trace -> principal -> principal -> a ->
+  prop
+let comm_conf_send_event_triggered #a tr sender receiver payload =
+  event_triggered tr sender (CommConfSendMsg sender receiver payload <: communication_core_event a)
+
+unfold
+val comm_auth_send_event_triggered:
+  #a:Type0 -> {|comm_layer_core_config a|} ->
+  trace -> principal -> a ->
+  prop
+let comm_auth_send_event_triggered #a tr sender payload =
+  event_triggered tr sender (CommAuthSendMsg sender payload <: communication_core_event a)
+
+unfold
+val comm_conf_auth_send_event_triggered:
+  #a:Type0 -> {|comm_layer_core_config a|} ->
+  trace -> principal -> principal -> a ->
+  prop
+let comm_conf_auth_send_event_triggered #a tr sender receiver payload =
+  event_triggered tr sender (CommConfAuthSendMsg sender receiver payload <: communication_core_event a)
+
 (*** PkEnc Predicates ***)
 
 #push-options "--ifuel 1"
@@ -24,9 +50,7 @@ let pke_crypto_predicates_communication_layer_core #cusages a #config  = {
     (exists sender receiver.
       sk_usage == long_term_key_type_to_usage (LongTermPkeKey (comm_layer_pkenc_tag a))  receiver /\
       (get_label tr msg) `can_flow tr` (comm_label sender receiver) /\
-      parse_and_pred 
-        (fun msg_parsed -> event_triggered tr sender (CommConfSendMsg sender receiver msg_parsed <: communication_core_event a)) 
-        msg      
+      parse_and_pred (comm_conf_send_event_triggered #a tr sender receiver) msg
     )
     );
   pred_later = (fun tr1 tr2 sk_usage pk msg -> ());
@@ -35,7 +59,7 @@ let pke_crypto_predicates_communication_layer_core #cusages a #config  = {
 
 val pke_crypto_predicates_and_tag_communication_layer_core:
   {|cusages:crypto_usages|} ->
-  (a:Type0) -> {|comm_layer_core_config a|} ->  
+  (a:Type0) -> {|comm_layer_core_config a|} ->
   (string & pke_crypto_predicate)
 let pke_crypto_predicates_and_tag_communication_layer_core #cusages a #config =
   ((comm_layer_pkenc_tag a), pke_crypto_predicates_communication_layer_core a)
@@ -50,16 +74,14 @@ let sign_crypto_predicate_communication_layer_core #cusages a #config = {
     | Some (Plain sender receiver payload) -> (
       sk_usage == long_term_key_type_to_usage (LongTermSigKey (comm_layer_sign_tag a)) sender /\
       get_label tr (serialize a payload) `can_flow tr` public /\
-      event_triggered tr sender (CommAuthSendMsg sender payload <: communication_core_event a)
+      comm_auth_send_event_triggered #a tr sender payload
     )
     | Some (Encrypted sender receiver payload pk_receiver) -> (
       get_label tr payload `can_flow tr` public /\
       sk_usage == long_term_key_type_to_usage (LongTermSigKey (comm_layer_sign_tag a)) sender /\
       (exists plain_payload nonce.
         payload == pke_enc pk_receiver nonce plain_payload /\
-        (match parse a plain_payload with
-        | None -> False
-        | Some plain_payload_parsed -> event_triggered tr sender (CommConfAuthSendMsg sender receiver plain_payload_parsed <: communication_core_event a))
+        parse_and_pred #a (comm_conf_auth_send_event_triggered tr sender receiver) plain_payload
       )
     )
     | None -> False)
@@ -78,14 +100,14 @@ let sign_crypto_predicate_communication_layer_core #cusages a #config = {
 
 val sign_crypto_predicate_and_tag_communication_layer_core:
   {|cusages:crypto_usages|} ->
-  (a:Type0) -> {|comm_layer_core_config a|} -> 
+  (a:Type0) -> {|comm_layer_core_config a|} ->
   (string & sign_crypto_predicate)
 let sign_crypto_predicate_and_tag_communication_layer_core #cusages a #config =
   (comm_layer_sign_tag a, sign_crypto_predicate_communication_layer_core a)
 
 val has_communication_layer_core_crypto_predicates:
   {|crypto_invariants|} ->
-  (a:Type0) -> {|comm_layer_core_config a|} -> 
+  (a:Type0) -> {|comm_layer_core_config a|} ->
   prop
 let has_communication_layer_core_crypto_predicates #cinvs a #config =
   has_pke_predicate (pke_crypto_predicates_and_tag_communication_layer_core a) /\
@@ -154,7 +176,7 @@ let event_predicate_communication_layer_core
       higher_layer_preds.send_conf tr sender receiver payload
     )
     | CommConfReceiveMsg receiver payload -> (
-      (exists sender. event_triggered tr sender (CommConfSendMsg sender receiver payload <: communication_core_event a)) \/
+      (exists sender. comm_conf_send_event_triggered #a tr sender receiver payload) \/
       is_well_formed a (is_publishable tr) payload
     )
     | CommAuthSendMsg sender payload -> (
@@ -163,7 +185,7 @@ let event_predicate_communication_layer_core
     | CommAuthReceiveMsg sender receiver payload -> (
       is_well_formed a (is_publishable tr) payload /\
       (
-        event_triggered tr sender (CommAuthSendMsg sender payload <: communication_core_event a) \/
+        comm_auth_send_event_triggered #a tr sender payload \/
         is_corrupt tr (long_term_key_label sender)
       )
     )
@@ -183,7 +205,7 @@ let event_predicate_communication_layer_core
       // receiver cannot guarantee that the full confidential/authenticated message
       // was honestly generated by the stated sender.
       (
-        event_triggered tr sender (CommConfAuthSendMsg sender receiver payload <: communication_core_event a) \/
+        comm_conf_auth_send_event_triggered #a tr sender receiver payload \/
         is_corrupt tr (long_term_key_label sender)
       )
     )

--- a/src/lib/communication/DY.Lib.Communication.Core.Lemmas.fst
+++ b/src/lib/communication/DY.Lib.Communication.Core.Lemmas.fst
@@ -65,6 +65,7 @@ let initialize_communication_proof tr sender receiver =
 (**** Confidential Send and Receive Lemmas ****)
 
 val encrypt_message_proof:
+  {|comm_layer_event_core_tag|} ->
   {|cinvs:crypto_invariants|} ->
   #a:Type -> {| parseable_serializeable bytes a |} ->
   tr:trace ->
@@ -83,10 +84,11 @@ val encrypt_message_proof:
   (ensures
     is_publishable tr (encrypt_message pk_receiver nonce payload)
   )
-let encrypt_message_proof #cinvs #a tr sender receiver pk_receiver nonce pkenc_in =
+let encrypt_message_proof #event_tag #cinvs #a tr sender receiver pk_receiver nonce pkenc_in =
   reveal_opaque (`%encrypt_message) (encrypt_message #a)
 
 val send_confidential_proof:
+  {|comm_layer_event_core_tag|} ->
   {|invs:protocol_invariants|} ->
   #a:Type -> {| parseable_serializeable bytes a |} ->
   tr:trace ->
@@ -114,8 +116,8 @@ val send_confidential_proof:
   [SMTPat (trace_invariant #invs tr);
    SMTPat (send_confidential keys_sess_ids sender receiver payload tr);
    SMTPat (core_comm_layer_lemmas_enabled higher_layer_preds)]
-let send_confidential_proof #invs #a tr higher_layer_preds keys_sess_ids sender receiver payload =
-  reveal_opaque (`%send_confidential) (send_confidential #a);
+let send_confidential_proof #event_tag #invs #a tr higher_layer_preds keys_sess_ids sender receiver payload =
+  reveal_opaque (`%send_confidential) (send_confidential #event_tag #a);
   match send_confidential keys_sess_ids sender receiver payload tr with
   | (None, tr_out) -> ()
   | (Some _, tr_out) -> (
@@ -133,6 +135,7 @@ let send_confidential_proof #invs #a tr higher_layer_preds keys_sess_ids sender 
   )
 
 val decrypt_message_proof:
+  {|comm_layer_event_core_tag|} ->
   {|cinvs:crypto_invariants|} ->
   #a:Type -> {| parseable_serializeable bytes a |} ->
   tr:trace ->
@@ -157,7 +160,7 @@ val decrypt_message_proof:
       )
     )
   )
-let decrypt_message_proof #cinvs #a tr receiver sk_receiver msg_encrypted =
+let decrypt_message_proof #event_tag #cinvs #a tr receiver sk_receiver msg_encrypted =
   reveal_opaque (`%decrypt_message) (decrypt_message #a);
   match decrypt_message #a sk_receiver msg_encrypted with
   | None -> ()
@@ -168,6 +171,7 @@ let decrypt_message_proof #cinvs #a tr receiver sk_receiver msg_encrypted =
   )
 
 val receive_confidential_proof:
+  {|event_tag:comm_layer_event_core_tag|} ->
   {|invs:protocol_invariants|} ->
   #a:Type -> {| parseable_serializeable bytes a |} ->
   tr:trace ->
@@ -182,7 +186,7 @@ val receive_confidential_proof:
     has_communication_layer_event_predicates higher_layer_preds
   )
   (ensures (
-    match receive_confidential #a comm_keys_ids receiver msg_id tr with
+    match receive_confidential comm_keys_ids receiver msg_id tr with
     | (None, tr_out) -> trace_invariant tr_out
     | (Some payload, tr_out) ->
       trace_invariant tr_out /\
@@ -190,16 +194,16 @@ val receive_confidential_proof:
       is_well_formed a (is_knowable_by (principal_label receiver) tr) payload
   ))
   [SMTPat (trace_invariant tr);
-   SMTPat (receive_confidential #a comm_keys_ids receiver msg_id tr);
+   SMTPat (receive_confidential #event_tag #a comm_keys_ids receiver msg_id tr);
    SMTPat (core_comm_layer_lemmas_enabled higher_layer_preds)]
-let receive_confidential_proof #invs #a tr higher_layer_preds comm_keys_ids receiver msg_id =
-  reveal_opaque (`%receive_confidential) (receive_confidential #a);
-  match receive_confidential #a comm_keys_ids receiver msg_id tr with
+let receive_confidential_proof #event_tag #invs #a tr higher_layer_preds comm_keys_ids receiver msg_id =
+  reveal_opaque (`%receive_confidential) (receive_confidential #event_tag #a);
+  match receive_confidential comm_keys_ids receiver msg_id tr with
   | (None, tr_out) -> ()
   | (Some payload, tr_out) -> (
     let (Some sk_receiver, tr) = get_private_key receiver comm_keys_ids.private_keys (LongTermPkeKey comm_layer_pkenc_tag) tr in
     let (Some msg_encrypted, tr) = recv_msg msg_id tr in
-    decrypt_message_proof #invs.crypto_invs #a tr receiver sk_receiver msg_encrypted;
+    decrypt_message_proof #event_tag #invs.crypto_invs #a tr receiver sk_receiver msg_encrypted;
     let Some msg_plain = decrypt_message #a sk_receiver msg_encrypted in
     let ((), tr) = trigger_event receiver (CommConfReceiveMsg receiver (serialize a payload)) tr in
     assert(tr_out == tr);
@@ -211,6 +215,7 @@ let receive_confidential_proof #invs #a tr higher_layer_preds comm_keys_ids rece
 (**** Authenticated Send and Receive Lemmas ****)
 
 val sign_message_proof:
+  {|comm_layer_event_core_tag|} ->
   {|cinvs:crypto_invariants|} ->
   #a:Type -> {| parseable_serializeable bytes a |} ->
   tr:trace ->
@@ -242,7 +247,7 @@ val sign_message_proof:
   (ensures
     is_publishable tr (sign_message sender receiver payload pk_receiver sk_sender nonce)
   )
-let sign_message_proof #cinvs #a tr sender receiver payload pk_receiver sk_sender nonce =
+let sign_message_proof #event_tag #cinvs #a tr sender receiver payload pk_receiver sk_sender nonce =
   reveal_opaque (`%sign_message) (sign_message #a);
   let payload_bytes = serialize a payload in
   assert(is_publishable tr payload_bytes);
@@ -259,6 +264,7 @@ let sign_message_proof #cinvs #a tr sender receiver payload pk_receiver sk_sende
   ()
 
 val send_authenticated_proof:
+  {|event_tag:comm_layer_event_core_tag|} ->
   {|invs:protocol_invariants|} ->
   #a:Type -> {| parseable_serializeable bytes a |} ->
   tr:trace ->
@@ -275,14 +281,14 @@ val send_authenticated_proof:
     is_well_formed a (is_publishable tr) payload
   )
   (ensures (
-    let (_, tr_out) = send_authenticated #a comm_keys_ids sender receiver payload tr in
+    let (_, tr_out) = send_authenticated comm_keys_ids sender receiver payload tr in
     trace_invariant tr_out
   ))
   [SMTPat (trace_invariant #invs tr);
    SMTPat (send_authenticated comm_keys_ids sender receiver payload tr);
    SMTPat (core_comm_layer_lemmas_enabled higher_layer_preds)]
-let send_authenticated_proof #invs #a tr higher_layer_preds comm_keys_ids sender receiver payload =
-    reveal_opaque (`%send_authenticated) (send_authenticated #a);
+let send_authenticated_proof #event_tag #invs #a tr higher_layer_preds comm_keys_ids sender receiver payload =
+    reveal_opaque (`%send_authenticated) (send_authenticated #event_tag #a);
     match send_authenticated comm_keys_ids sender receiver payload tr with
     | (None, tr_out) -> ()
     | (Some _, tr_out) -> (
@@ -292,7 +298,7 @@ let send_authenticated_proof #invs #a tr higher_layer_preds comm_keys_ids sender
       let payload_bytes = serialize a payload in
       let ((), tr') = trigger_event sender (CommAuthSendMsg sender payload_bytes) tr' in
       assert(event_triggered tr' sender (CommAuthSendMsg sender payload_bytes));
-      sign_message_proof #invs.crypto_invs #a tr' sender receiver payload None sk_sender nonce;
+      sign_message_proof #event_tag #invs.crypto_invs #a tr' sender receiver payload None sk_sender nonce;
       let msg_signed = sign_message #a sender receiver payload None sk_sender nonce in
       let (msg_id, tr') = send_msg msg_signed tr' in
       assert(tr_out == tr');
@@ -303,6 +309,7 @@ let send_authenticated_proof #invs #a tr higher_layer_preds comm_keys_ids sender
 
 #push-options "--z3rlimit 50"
 val verify_message_proof:
+  {|comm_layer_event_core_tag|} ->
   {|cinvs:crypto_invariants|} ->
   #a:Type -> {| ps:parseable_serializeable bytes a |} ->
   tr:trace ->
@@ -348,7 +355,7 @@ val verify_message_proof:
     )
     | _ -> True
   ))
-let verify_message_proof #cinvs #a #ps tr sender receiver msg_bytes sk_receiver_opt vk_sender =
+let verify_message_proof #event_tag #cinvs #a #ps tr sender receiver msg_bytes sk_receiver_opt vk_sender =
   assert(get_signkey_label tr vk_sender == long_term_key_label sender);
   match verify_message #a receiver msg_bytes sk_receiver_opt vk_sender with
   | None -> ()
@@ -373,6 +380,7 @@ let verify_message_proof #cinvs #a #ps tr sender receiver msg_bytes sk_receiver_
 #pop-options
 
 val receive_authenticated_proof:
+  {|event_tag:comm_layer_event_core_tag|} ->
   {|invs:protocol_invariants|} ->
   #a:Type -> {| parseable_serializeable bytes a |} ->
   tr:trace ->
@@ -387,7 +395,7 @@ val receive_authenticated_proof:
     has_communication_layer_event_predicates higher_layer_preds
   )
   (ensures (
-    match receive_authenticated #a comm_keys_ids receiver msg_id tr with
+    match receive_authenticated comm_keys_ids receiver msg_id tr with
     | (None, tr_out) -> trace_invariant tr_out
     | (Some cm, tr_out) -> (
       trace_invariant tr_out /\
@@ -396,17 +404,17 @@ val receive_authenticated_proof:
     )
   ))
   [SMTPat (trace_invariant #invs tr);
-   SMTPat (receive_authenticated #a comm_keys_ids receiver msg_id tr);
+   SMTPat (receive_authenticated #event_tag #a comm_keys_ids receiver msg_id tr);
    SMTPat (core_comm_layer_lemmas_enabled higher_layer_preds)]
-let receive_authenticated_proof #invs #a tr higher_layer_preds comm_keys_ids receiver msg_id =
-  reveal_opaque (`%receive_authenticated) (receive_authenticated #a);
-  match receive_authenticated #a comm_keys_ids receiver msg_id tr with
+let receive_authenticated_proof #event_tag #invs #a tr higher_layer_preds comm_keys_ids receiver msg_id =
+  reveal_opaque (`%receive_authenticated) (receive_authenticated #event_tag #a);
+  match receive_authenticated #event_tag #a comm_keys_ids receiver msg_id tr with
   | (None, tr_out) -> ()
   | (Some cm', tr_out) -> (
     let (Some msg_signed_bytes, tr) = recv_msg msg_id tr in
     let Some sender = get_sender msg_signed_bytes in
     let (Some vk_sender, tr) = get_public_key receiver comm_keys_ids.pki (LongTermSigKey comm_layer_sign_tag) sender tr in
-    verify_message_proof #invs.crypto_invs #a tr sender receiver msg_signed_bytes None vk_sender;
+    verify_message_proof #event_tag #invs.crypto_invs #a tr sender receiver msg_signed_bytes None vk_sender;
     let (Some cm) = verify_message #a receiver msg_signed_bytes None vk_sender in
     let ((), tr) = trigger_event receiver (CommAuthReceiveMsg sender receiver (serialize a cm.payload)) tr in
     assert(tr_out == tr);
@@ -418,6 +426,7 @@ let receive_authenticated_proof #invs #a tr higher_layer_preds comm_keys_ids rec
 (**** Confidential and Authenticates Send and Receive Lemmas ****)
 
 val encrypt_and_sign_message_proof:
+  {|comm_layer_event_core_tag|} ->
   {|cinvs:crypto_invariants|} ->
   #a:Type -> {| parseable_serializeable bytes a |} ->
   tr:trace ->
@@ -440,15 +449,16 @@ val encrypt_and_sign_message_proof:
   (ensures
     is_publishable tr (encrypt_and_sign_message sender receiver payload pk_receiver sk_sender enc_nonce sign_nonce)
   )
-let encrypt_and_sign_message_proof #cinvs #a tr sender receiver payload pk_receiver sk_sender enc_nonce sign_nonce =
+let encrypt_and_sign_message_proof #event_tag #cinvs #a tr sender receiver payload pk_receiver sk_sender enc_nonce sign_nonce =
   reveal_opaque (`%encrypt_and_sign_message) (encrypt_and_sign_message #a);
   reveal_opaque (`%encrypt_message) (encrypt_message #a); // TODO: This should be removeable.
-  encrypt_message_proof #cinvs #a tr sender receiver pk_receiver enc_nonce payload;
+  encrypt_message_proof tr sender receiver pk_receiver enc_nonce payload;
   let enc_payload = encrypt_message pk_receiver enc_nonce payload in
-  sign_message_proof #cinvs #com_send_byte tr sender receiver {b=enc_payload} (Some pk_receiver) sk_sender sign_nonce;
+  sign_message_proof tr sender receiver {b=enc_payload} (Some pk_receiver) sk_sender sign_nonce;
   ()
 
 val send_confidential_authenticated_proof:
+  {|event_tag:comm_layer_event_core_tag|} ->
   {|invs:protocol_invariants|} ->
   #a:Type -> {| parseable_serializeable bytes a |} ->
   tr:trace ->
@@ -471,10 +481,10 @@ val send_confidential_authenticated_proof:
     trace_invariant tr_out
   ))
   [SMTPat (trace_invariant #invs tr);
-   SMTPat (send_confidential_authenticated #a comm_keys_ids sender receiver payload tr);
+   SMTPat (send_confidential_authenticated #event_tag #a comm_keys_ids sender receiver payload tr);
    SMTPat (core_comm_layer_lemmas_enabled higher_layer_preds)]
-let send_confidential_authenticated_proof #invs #a tr higher_layer_preds comm_keys_ids sender receiver payload =
-  reveal_opaque (`%send_confidential_authenticated) (send_confidential_authenticated #a);
+let send_confidential_authenticated_proof #event_tag #invs #a tr higher_layer_preds comm_keys_ids sender receiver payload =
+  reveal_opaque (`%send_confidential_authenticated) (send_confidential_authenticated #event_tag #a);
   match send_confidential_authenticated comm_keys_ids sender receiver payload tr with
   | (None, tr_out) -> ()
   | (Some _, tr_out) -> (
@@ -503,6 +513,7 @@ let send_confidential_authenticated_proof #invs #a tr higher_layer_preds comm_ke
 
 #push-options "--ifuel 1 --z3rlimit 40"
 val verify_and_decrypt_message_proof:
+  {|comm_layer_event_core_tag|} ->
   {|cinvs:crypto_invariants|} ->
   #a:Type -> {| parseable_serializeable bytes a |} ->
   tr:trace ->
@@ -527,13 +538,13 @@ val verify_and_decrypt_message_proof:
       )
     )
   ))
-let verify_and_decrypt_message_proof #cinvs #a tr sender receiver msg_encrypted_signed sk_receiver vk_sender =
+let verify_and_decrypt_message_proof #event_tag #cinvs #a tr sender receiver msg_encrypted_signed sk_receiver vk_sender =
   reveal_opaque (`%verify_and_decrypt_message) (verify_and_decrypt_message #a);
   reveal_opaque (`%decrypt_message) (decrypt_message #a);
   match verify_and_decrypt_message #a receiver sk_receiver vk_sender msg_encrypted_signed with
   | None -> ()
   | Some cm -> (
-    verify_message_proof #cinvs #com_send_byte tr sender receiver msg_encrypted_signed (Some sk_receiver) vk_sender;
+    verify_message_proof #event_tag #cinvs #com_send_byte tr sender receiver msg_encrypted_signed (Some sk_receiver) vk_sender;
     let Some cm' = verify_message #com_send_byte receiver msg_encrypted_signed (Some sk_receiver) vk_sender in
 
     let Some msg_signed_t = parse com_message_t msg_encrypted_signed in
@@ -562,6 +573,7 @@ let verify_and_decrypt_message_proof #cinvs #a tr sender receiver msg_encrypted_
 #pop-options
 
 val receive_confidential_authenticated_proof:
+  {|event_tag:comm_layer_event_core_tag|} ->
   {|invs:protocol_invariants|} ->
   #a:Type -> {| parseable_serializeable bytes a |} ->
   tr:trace ->
@@ -578,7 +590,7 @@ val receive_confidential_authenticated_proof:
   )
   (ensures
     (
-      match receive_confidential_authenticated #a comm_keys_ids receiver msg_id tr with
+      match receive_confidential_authenticated #event_tag #a comm_keys_ids receiver msg_id tr with
       | (None, tr_out) -> trace_invariant tr_out
       | (Some cm, tr_out) -> (
         trace_invariant tr_out /\
@@ -588,19 +600,19 @@ val receive_confidential_authenticated_proof:
     )
   )
   [SMTPat (trace_invariant #invs tr);
-   SMTPat (receive_confidential_authenticated #a comm_keys_ids receiver msg_id tr);
+   SMTPat (receive_confidential_authenticated #event_tag #a comm_keys_ids receiver msg_id tr);
    SMTPat (core_comm_layer_lemmas_enabled higher_layer_preds)]
-let receive_confidential_authenticated_proof #invs #a tr higher_layer_preds comm_keys_ids receiver msg_id =
-  reveal_opaque (`%receive_confidential_authenticated) (receive_confidential_authenticated #a);
+let receive_confidential_authenticated_proof #event_tag #invs #a tr higher_layer_preds comm_keys_ids receiver msg_id =
+  reveal_opaque (`%receive_confidential_authenticated) (receive_confidential_authenticated #event_tag #a);
   reveal_opaque (`%verify_and_decrypt_message) (verify_and_decrypt_message #a); // TODO: These reveals should be removeable.
-  match receive_confidential_authenticated #a comm_keys_ids receiver msg_id tr with
+  match receive_confidential_authenticated #event_tag #a comm_keys_ids receiver msg_id tr with
   | (None, tr_out) -> ()
   | (Some cm, tr_out) -> (
     let (Some msg_encrypted_signed, tr) = recv_msg msg_id tr in
     let (Some sk_receiver, tr) = get_private_key receiver comm_keys_ids.private_keys (LongTermPkeKey comm_layer_pkenc_tag) tr in
     let Some sender = get_sender msg_encrypted_signed in
     let (Some vk_sender, tr) = get_public_key receiver comm_keys_ids.pki (LongTermSigKey comm_layer_sign_tag) sender tr in
-    verify_and_decrypt_message_proof #invs.crypto_invs #a tr sender receiver msg_encrypted_signed sk_receiver vk_sender;
+    verify_and_decrypt_message_proof #event_tag #invs.crypto_invs #a tr sender receiver msg_encrypted_signed sk_receiver vk_sender;
     let Some cm = verify_and_decrypt_message #a receiver sk_receiver vk_sender msg_encrypted_signed in
     let ((), tr) = trigger_event receiver (CommConfAuthReceiveMsg sender receiver (serialize a cm.payload)) tr in
     assert(event_triggered tr receiver (CommConfAuthReceiveMsg sender receiver (serialize a cm.payload)));

--- a/src/lib/communication/DY.Lib.Communication.Core.Lemmas.fst
+++ b/src/lib/communication/DY.Lib.Communication.Core.Lemmas.fst
@@ -7,6 +7,7 @@ open DY.Lib.Crypto.Signature.Split
 open DY.Lib.State.PKI
 open DY.Lib.State.PrivateKeys
 open DY.Lib.Event.Typed
+open DY.Lib.Comparse.DYUtils
 
 open DY.Lib.Communication.Data
 open DY.Lib.Communication.Core
@@ -41,7 +42,7 @@ let enable_core_comm_layer_lemmas preds =
 (**** Initialization Satisfies the Trace Invariants ****)
 
 #push-options "--ifuel 2 --z3rlimit 25"
-val initialize_communication_core_proof
+val initialize_communication_core_proof:
   {|invs:protocol_invariants|} ->
   tr:trace ->
   a:Type -> {|comm_layer_core_config a|} ->
@@ -65,13 +66,6 @@ let initialize_communication_core_proof tr a sender receiver =
 
 (**** Confidential Send and Receive Lemmas ****)
 
-val comm_conf_send_event_triggered:
-  #a:Type0 -> {|comm_layer_core_config a|} ->
-  trace -> principal -> principal -> a ->
-  prop
-let comm_conf_send_event_triggered #a tr sender receiver payload =
-  event_triggered tr sender (CommConfSendMsg sender receiver payload <: communication_core_event a)
-
 val encrypt_message_proof:
   {|cinvs:crypto_invariants|} ->
   #a:Type -> {|comm_layer_core_config a|} ->
@@ -88,7 +82,7 @@ val encrypt_message_proof:
     comm_conf_send_event_triggered tr sender receiver payload
   ))
   (ensures
-    is_publishable tr (encrypt_message pk_receiver nonce payload) 
+    is_publishable tr (encrypt_message pk_receiver nonce payload)
   )
 let encrypt_message_proof #cinvs #a tr sender receiver pk_receiver nonce pkenc_in =
   reveal_opaque (`%encrypt_message) (encrypt_message #a)
@@ -212,20 +206,6 @@ let receive_confidential_proof #invs #a tr higher_layer_preds comm_keys_ids rece
 
 
 (**** Authenticated Send and Receive Lemmas ****)
-
-val comm_auth_send_event_triggered:
-  #a:Type0 -> {|comm_layer_core_config a|} ->
-  trace -> principal -> a ->
-  prop
-let comm_auth_send_event_triggered #a tr sender payload =
-  event_triggered tr sender (CommAuthSendMsg sender payload <: communication_core_event a)
-
-val comm_conf_auth_send_event_triggered:
-  #a:Type0 -> {|comm_layer_core_config a|} ->
-  trace -> principal -> principal -> a ->
-  prop
-let comm_conf_auth_send_event_triggered #a tr sender receiver payload =
-  event_triggered tr sender (CommConfAuthSendMsg sender receiver payload <: communication_core_event a)
 
 #push-options "--ifuel 1 --fuel 0 --z3rlimit 50"
 val sign_message_proof:
@@ -365,9 +345,7 @@ val verify_message_proof:
             (
               exists plain_payload nonce.
                 (Inr?.v payload) == pke_enc pk_receiver nonce plain_payload /\
-                (match parse a plain_payload with
-                | None -> False
-                | Some plain_payload_parsed -> comm_conf_auth_send_event_triggered tr sender receiver plain_payload_parsed)
+                parse_and_pred #a (comm_conf_auth_send_event_triggered tr sender receiver) plain_payload
             ) \/ (
               is_corrupt tr (long_term_key_label sender)
             )
@@ -488,7 +466,7 @@ val send_confidential_authenticated_proof:
     has_communication_layer_core_predicates higher_layer_preds /\
     higher_layer_preds.send_conf tr sender receiver payload /\
     higher_layer_preds.send_conf_auth tr sender receiver payload /\
-    is_well_formed a (is_knowable_by (join (principal_label sender) (principal_label receiver)) tr) payload
+    is_well_formed a (is_knowable_by (comm_label sender receiver) tr) payload
   )
   (ensures (
     let (_, tr_out) = send_confidential_authenticated comm_keys_ids sender receiver payload tr in
@@ -574,8 +552,7 @@ let verify_and_decrypt_message_proof #cinvs #a tr sender receiver msg_encrypted_
     with _. (
       eliminate exists plain_payload nonce.
           payload_enc == pke_enc pk_receiver nonce plain_payload /\
-          Some? (parse a plain_payload) /\
-          comm_conf_auth_send_event_triggered tr sender receiver (Some?.v (parse a plain_payload))
+          parse_and_pred #a (comm_conf_auth_send_event_triggered tr sender receiver) plain_payload
       returns comm_conf_auth_send_event_triggered tr sender receiver cm.payload
       with _. (
         pke_dec_enc sk_receiver nonce plain_payload;

--- a/src/lib/communication/DY.Lib.Communication.Core.Lemmas.fst
+++ b/src/lib/communication/DY.Lib.Communication.Core.Lemmas.fst
@@ -333,7 +333,7 @@ val verify_message_proof:
           (
             sender == sender' /\
             receiver == receiver' /\
-            comm_auth_send_event_triggered tr sender (Inl?.v payload) \/ 
+            comm_auth_send_event_triggered tr sender (Inl?.v payload) \/
             is_corrupt tr (long_term_key_label sender)
           )
         )
@@ -522,7 +522,6 @@ val verify_and_decrypt_message_proof:
     | None -> True
     | Some cm -> (
       is_well_formed a (is_knowable_by (principal_label receiver) tr) cm.payload /\
-      //is_knowable_by (principal_label receiver) tr (serialize a cm.payload) /\
       (
         comm_conf_auth_send_event_triggered tr sender receiver cm.payload \/
         is_corrupt tr (long_term_key_label sender)

--- a/src/lib/communication/DY.Lib.Communication.Core.Lemmas.fst
+++ b/src/lib/communication/DY.Lib.Communication.Core.Lemmas.fst
@@ -308,6 +308,7 @@ let send_authenticated_proof #invs #a tr higher_layer_preds comm_keys_ids sender
     )
 
 
+#push-options "--z3rlimit 20"
 val verify_message_proof:
   {|cinvs:crypto_invariants|} ->
   #a:Type -> {|config:comm_layer_core_config a|} ->
@@ -373,6 +374,7 @@ let verify_message_proof #cinvs #a #config tr sender receiver msg_bytes sk_recei
       ()
     )
   )
+#pop-options
 
 val receive_authenticated_proof:
   {|invs:protocol_invariants|} ->

--- a/src/lib/communication/DY.Lib.Communication.Core.Lemmas.fst
+++ b/src/lib/communication/DY.Lib.Communication.Core.Lemmas.fst
@@ -27,12 +27,12 @@ open DY.Lib.Communication.Core.Invariants
 
 [@@"opaque_to_smt"]
 val core_comm_layer_lemmas_enabled:
-  #a:Type -> {| parseable_serializeable bytes a |} ->
+  #a:Type -> {|comm_layer_core_config a|} ->
   comm_higher_layer_event_preds a -> prop
 let core_comm_layer_lemmas_enabled _ = True
 
 val enable_core_comm_layer_lemmas:
-  #a:Type -> {| parseable_serializeable bytes a |} ->
+  #a:Type -> {|comm_layer_core_config a|} ->
   preds:comm_higher_layer_event_preds a ->
   Lemma (core_comm_layer_lemmas_enabled preds)
 let enable_core_comm_layer_lemmas preds =
@@ -42,9 +42,9 @@ let enable_core_comm_layer_lemmas preds =
 
 #push-options "--ifuel 2"
 val initialize_communication_proof:
-  {|comm_layer_core_tag|} ->
   {|invs:protocol_invariants|} ->
   tr:trace ->
+  a:Type -> {|comm_layer_core_config a|} ->
   sender:principal -> receiver:principal ->
   Lemma
   (requires
@@ -53,45 +53,42 @@ val initialize_communication_proof:
     has_pki_invariant
   )
   (ensures (
-    let (_, tr_out) = initialize_communication sender receiver tr in
+    let (_, tr_out) = initialize_communication a sender receiver tr in
     trace_invariant tr_out
   ))
   [SMTPat (trace_invariant #invs tr);
-   SMTPat (initialize_communication sender receiver tr);
+   SMTPat (initialize_communication a sender receiver tr);
   ]
-let initialize_communication_proof tr sender receiver =
-  reveal_opaque (`%initialize_communication) (initialize_communication sender receiver)
+let initialize_communication_proof tr a sender receiver =
+  reveal_opaque (`%initialize_communication) (initialize_communication a sender receiver)
 #pop-options
 
 (**** Confidential Send and Receive Lemmas ****)
 
 val encrypt_message_proof:
-  {|comm_layer_core_tag|} ->
   {|cinvs:crypto_invariants|} ->
-  #a:Type -> {| parseable_serializeable bytes a |} ->
+  #a:Type -> {|comm_layer_core_config a|} ->
   tr:trace ->
   sender:principal -> receiver:principal ->
   pk_receiver:bytes -> nonce:bytes -> payload:a ->
   Lemma
   (requires (
-    let payload_bytes = serialize #bytes a payload in
-    has_communication_layer_crypto_predicates /\
+    has_communication_layer_crypto_predicates a /\
     is_secret (long_term_key_label sender) tr nonce /\
     nonce `has_usage tr` PkeNonce /\
-    is_public_key_for tr pk_receiver (LongTermPkeKey comm_layer_pkenc_tag) receiver /\
-    is_knowable_by (join (principal_label sender) (principal_label receiver)) tr payload_bytes /\
-    event_triggered tr sender (CommConfSendMsg sender receiver payload_bytes)
+    is_public_key_for tr pk_receiver (LongTermPkeKey (comm_layer_pkenc_tag a)) receiver /\
+    is_well_formed a (is_knowable_by (join (principal_label sender) (principal_label receiver)) tr) payload /\
+    event_triggered tr sender (CommConfSendMsg sender receiver payload <: communication_core_event a)
   ))
   (ensures
     is_publishable tr (encrypt_message pk_receiver nonce payload)
   )
-let encrypt_message_proof #tag #cinvs #a tr sender receiver pk_receiver nonce pkenc_in =
+let encrypt_message_proof #cinvs #a tr sender receiver pk_receiver nonce pkenc_in =
   reveal_opaque (`%encrypt_message) (encrypt_message #a)
 
 val send_confidential_proof:
-  {|comm_layer_core_tag|} ->
   {|invs:protocol_invariants|} ->
-  #a:Type -> {| parseable_serializeable bytes a |} ->
+  #a:Type0 -> {|comm_layer_core_config a|} ->
   tr:trace ->
   higher_layer_preds:comm_higher_layer_event_preds a ->
   keys_sess_ids:communication_keys_sess_ids ->
@@ -100,8 +97,8 @@ val send_confidential_proof:
   (requires (
     trace_invariant tr /\
     has_pki_invariant /\
-    has_communication_layer_crypto_predicates /\
-    has_communication_layer_event_predicates higher_layer_preds /\
+    has_communication_layer_crypto_predicates a /\
+    has_communication_layer_event_predicates a higher_layer_preds /\
     higher_layer_preds.send_conf tr sender receiver payload /\
     // We only require the payload to flow to the sender and receiver to allow
     // the sender to send a payload readable by other principals. If you want
@@ -117,17 +114,15 @@ val send_confidential_proof:
   [SMTPat (trace_invariant #invs tr);
    SMTPat (send_confidential keys_sess_ids sender receiver payload tr);
    SMTPat (core_comm_layer_lemmas_enabled higher_layer_preds)]
-let send_confidential_proof #tag #invs #a tr higher_layer_preds keys_sess_ids sender receiver payload =
-  reveal_opaque (`%send_confidential) (send_confidential #tag #a);
+let send_confidential_proof #invs #a tr higher_layer_preds keys_sess_ids sender receiver payload =
+  reveal_opaque (`%send_confidential) (send_confidential #a);
   match send_confidential keys_sess_ids sender receiver payload tr with
   | (None, tr_out) -> ()
   | (Some _, tr_out) -> (
-    let (Some pk_receiver, tr') = get_public_key sender keys_sess_ids.pki (LongTermPkeKey comm_layer_pkenc_tag) receiver tr in
+    let (Some pk_receiver, tr') = get_public_key sender keys_sess_ids.pki (LongTermPkeKey (comm_layer_pkenc_tag a)) receiver tr in
     let (nonce, tr') = mk_rand PkeNonce (long_term_key_label sender) 32 tr' in
-    let payload_bytes = serialize #bytes a payload in
-    assert(is_knowable_by (comm_label sender receiver) tr payload_bytes);
     higher_layer_preds.send_conf_later tr tr' sender receiver payload;
-    let ((), tr') = trigger_event sender (CommConfSendMsg sender receiver payload_bytes) tr' in
+    let ((), tr') = trigger_event sender (CommConfSendMsg sender receiver payload <: communication_core_event a) tr' in
     encrypt_message_proof tr' sender receiver pk_receiver nonce payload;
     let msg_encrypted = encrypt_message pk_receiver nonce payload in
     let (msg_id, tr') = send_msg msg_encrypted tr' in
@@ -136,15 +131,14 @@ let send_confidential_proof #tag #invs #a tr higher_layer_preds keys_sess_ids se
   )
 
 val decrypt_message_proof:
-  {|comm_layer_core_tag|} ->
   {|cinvs:crypto_invariants|} ->
-  #a:Type -> {| parseable_serializeable bytes a |} ->
+  #a:Type0 -> {|comm_layer_core_config a|} ->
   tr:trace ->
   receiver:principal -> sk_receiver:bytes -> msg_encrypted:bytes ->
   Lemma
   (requires
-    has_communication_layer_crypto_predicates /\
-    is_private_key_for tr sk_receiver (LongTermPkeKey comm_layer_pkenc_tag) receiver /\
+    has_communication_layer_crypto_predicates a /\
+    is_private_key_for tr sk_receiver (LongTermPkeKey (comm_layer_pkenc_tag a)) receiver /\
     bytes_invariant tr msg_encrypted
   )
   (ensures
@@ -153,15 +147,15 @@ val decrypt_message_proof:
       | None -> True
       | Some payload -> (exists sender.
         is_well_formed a (is_knowable_by (comm_label sender receiver) tr) payload /\
-        is_knowable_by (comm_label sender receiver) tr (serialize a payload) /\
+        is_well_formed a (is_knowable_by (comm_label sender receiver) tr) payload /\
         (
-          event_triggered tr sender (CommConfSendMsg sender receiver (serialize a payload)) \/
+          event_triggered tr sender (CommConfSendMsg sender receiver payload <: communication_core_event a) \/
           is_well_formed a (is_publishable tr) payload
         )
       )
     )
   )
-let decrypt_message_proof #tag #cinvs #a tr receiver sk_receiver msg_encrypted =
+let decrypt_message_proof #cinvs #a tr receiver sk_receiver msg_encrypted =
   reveal_opaque (`%decrypt_message) (decrypt_message #a);
   match decrypt_message #a sk_receiver msg_encrypted with
   | None -> ()
@@ -172,9 +166,8 @@ let decrypt_message_proof #tag #cinvs #a tr receiver sk_receiver msg_encrypted =
   )
 
 val receive_confidential_proof:
-  {|tag:comm_layer_core_tag|} ->
   {|invs:protocol_invariants|} ->
-  #a:Type -> {| parseable_serializeable bytes a |} ->
+  #a:Type0 -> {|comm_layer_core_config a|} ->
   tr:trace ->
   higher_layer_preds:comm_higher_layer_event_preds a ->
   comm_keys_ids:communication_keys_sess_ids ->
@@ -183,30 +176,30 @@ val receive_confidential_proof:
   (requires
     trace_invariant tr /\
     has_private_keys_invariant /\
-    has_communication_layer_crypto_predicates /\
-    has_communication_layer_event_predicates higher_layer_preds
+    has_communication_layer_crypto_predicates a /\
+    has_communication_layer_event_predicates a higher_layer_preds
   )
   (ensures (
     match receive_confidential comm_keys_ids receiver msg_id tr with
     | (None, tr_out) -> trace_invariant tr_out
     | (Some payload, tr_out) ->
       trace_invariant tr_out /\
-      event_triggered tr_out receiver (CommConfReceiveMsg receiver (serialize a payload)) /\
+      event_triggered tr_out receiver (CommConfReceiveMsg receiver payload <: communication_core_event a) /\
       is_well_formed a (is_knowable_by (principal_label receiver) tr) payload
   ))
   [SMTPat (trace_invariant tr);
-   SMTPat (receive_confidential #tag #a comm_keys_ids receiver msg_id tr);
+   SMTPat (receive_confidential #a comm_keys_ids receiver msg_id tr);
    SMTPat (core_comm_layer_lemmas_enabled higher_layer_preds)]
-let receive_confidential_proof #tag #invs #a tr higher_layer_preds comm_keys_ids receiver msg_id =
-  reveal_opaque (`%receive_confidential) (receive_confidential #tag #a);
+let receive_confidential_proof #invs #a tr higher_layer_preds comm_keys_ids receiver msg_id =
+  reveal_opaque (`%receive_confidential) (receive_confidential #a);
   match receive_confidential comm_keys_ids receiver msg_id tr with
   | (None, tr_out) -> ()
   | (Some payload, tr_out) -> (
-    let (Some sk_receiver, tr) = get_private_key receiver comm_keys_ids.private_keys (LongTermPkeKey comm_layer_pkenc_tag) tr in
+    let (Some sk_receiver, tr) = get_private_key receiver comm_keys_ids.private_keys (LongTermPkeKey (comm_layer_pkenc_tag a)) tr in
     let (Some msg_encrypted, tr) = recv_msg msg_id tr in
-    decrypt_message_proof #tag #invs.crypto_invs #a tr receiver sk_receiver msg_encrypted;
+    decrypt_message_proof #invs.crypto_invs #a tr receiver sk_receiver msg_encrypted;
     let Some msg_plain = decrypt_message #a sk_receiver msg_encrypted in
-    let ((), tr) = trigger_event receiver (CommConfReceiveMsg receiver (serialize a payload)) tr in
+    let ((), tr) = trigger_event receiver (CommConfReceiveMsg receiver payload <: communication_core_event a) tr in
     assert(tr_out == tr);
     assert(trace_invariant tr_out);
     ()
@@ -216,58 +209,57 @@ let receive_confidential_proof #tag #invs #a tr higher_layer_preds comm_keys_ids
 (**** Authenticated Send and Receive Lemmas ****)
 
 val sign_message_proof:
-  {|comm_layer_core_tag|} ->
   {|cinvs:crypto_invariants|} ->
-  #a:Type -> {| parseable_serializeable bytes a |} ->
+  #a:Type0 -> {|config:comm_layer_core_config a|} ->
   tr:trace ->
-  sender:principal -> receiver:principal -> payload:a -> pk_receiver:option bytes ->
+  sender:principal -> receiver:principal -> payload:either a bytes -> pk_receiver:option bytes ->
   sk_sender:bytes -> nonce:bytes ->
   Lemma
   (requires (
-    let payload_bytes = serialize a payload in
-    has_communication_layer_crypto_predicates /\
+    (Some? pk_receiver <==> Inr? payload) /\ 
+    (None? pk_receiver <==> Inl? payload) /\
+    has_communication_layer_crypto_predicates a /\
     is_secret (long_term_key_label sender) tr nonce /\
     nonce `has_usage tr` SigNonce /\
-    is_private_key_for tr sk_sender (LongTermSigKey comm_layer_sign_tag) sender /\
-    is_well_formed a (is_publishable tr) payload /\
+    is_private_key_for tr sk_sender (LongTermSigKey (comm_layer_sign_tag a)) sender /\
     (
       match pk_receiver with
-      | None -> event_triggered tr sender (CommAuthSendMsg sender payload_bytes)
+      | None -> (
+        is_well_formed a (is_publishable tr) (Inl?.v payload) /\
+        event_triggered tr sender (CommAuthSendMsg sender (Inl?.v payload) <: communication_core_event a)
+      )
       | Some pk -> (
-        match parse com_send_byte payload_bytes with
-        | None -> False
-        | Some payload ->
-          (exists plain_payload nonce.
-            is_publishable tr pk /\
-            payload.b == pke_enc pk nonce plain_payload /\
-            event_triggered tr sender (CommConfAuthSendMsg sender receiver plain_payload)
-          )
+        is_publishable tr (Inr?.v payload) /\
+        is_publishable tr pk /\
+        (exists plain_payload nonce.
+          Inr?.v payload == pke_enc pk nonce plain_payload /\
+          (match parse a #(parseable_serializeable_bytes_a #a) plain_payload with
+          | None -> False
+          | Some plain_payload_parsed -> event_triggered tr sender (CommConfAuthSendMsg sender receiver plain_payload_parsed <: communication_core_event a))
+        )
       )
     )
   ))
   (ensures
     is_publishable tr (sign_message sender receiver payload pk_receiver sk_sender nonce)
   )
-let sign_message_proof #tag #cinvs #a tr sender receiver payload pk_receiver sk_sender nonce =
+let sign_message_proof #cinvs #a #config tr sender receiver payload pk_receiver sk_sender nonce =
   reveal_opaque (`%sign_message) (sign_message #a);
-  let payload_bytes = serialize a payload in
-  assert(is_publishable tr payload_bytes);
   let sig_input = match pk_receiver with
-    | None -> Plain sender receiver payload_bytes
-    | Some pk -> Encrypted sender receiver payload_bytes pk
-  in
+    | None -> Plain sender receiver (serialize a (Inl?.v payload))
+    | Some pk -> Encrypted sender receiver (Inr?.v payload) pk
+  in 
   let sig_input_bytes = serialize signature_input sig_input in
   serialize_wf_lemma signature_input (is_publishable tr) sig_input;
   let signature = sign sk_sender nonce sig_input_bytes in
   let msg_signed = SigMessage {msg=sig_input_bytes; signature} in
   assert(bytes_invariant tr signature);
-  serialize_wf_lemma com_message_t (is_publishable tr) msg_signed;
+  serialize_wf_lemma comm_message_t (is_publishable tr) msg_signed;
   ()
 
 val send_authenticated_proof:
-  {|event_tag:comm_layer_core_tag|} ->
   {|invs:protocol_invariants|} ->
-  #a:Type -> {| parseable_serializeable bytes a |} ->
+  #a:Type -> {|comm_layer_core_config a|} ->
   tr:trace ->
   higher_layer_preds:comm_higher_layer_event_preds a ->
   comm_keys_ids:communication_keys_sess_ids ->
@@ -276,8 +268,8 @@ val send_authenticated_proof:
   (requires
     trace_invariant tr /\
     has_private_keys_invariant /\
-    has_communication_layer_crypto_predicates /\
-    has_communication_layer_event_predicates higher_layer_preds /\
+    has_communication_layer_crypto_predicates a /\
+    has_communication_layer_event_predicates a higher_layer_preds /\
     higher_layer_preds.send_auth tr sender payload /\
     is_well_formed a (is_publishable tr) payload
   )
@@ -288,19 +280,18 @@ val send_authenticated_proof:
   [SMTPat (trace_invariant #invs tr);
    SMTPat (send_authenticated comm_keys_ids sender receiver payload tr);
    SMTPat (core_comm_layer_lemmas_enabled higher_layer_preds)]
-let send_authenticated_proof #tag #invs #a tr higher_layer_preds comm_keys_ids sender receiver payload =
-    reveal_opaque (`%send_authenticated) (send_authenticated #tag #a);
+let send_authenticated_proof #invs #a tr higher_layer_preds comm_keys_ids sender receiver payload =
+    reveal_opaque (`%send_authenticated) (send_authenticated #a);
     match send_authenticated comm_keys_ids sender receiver payload tr with
     | (None, tr_out) -> ()
     | (Some _, tr_out) -> (
-      let (Some sk_sender, tr') = get_private_key sender comm_keys_ids.private_keys (LongTermSigKey comm_layer_sign_tag) tr in
+      let (Some sk_sender, tr') = get_private_key sender comm_keys_ids.private_keys (LongTermSigKey (comm_layer_sign_tag a)) tr in
       let (nonce,  tr') = mk_rand SigNonce (long_term_key_label sender) 32 tr' in
       higher_layer_preds.send_auth_later tr tr' sender payload;
-      let payload_bytes = serialize a payload in
-      let ((), tr') = trigger_event sender (CommAuthSendMsg sender payload_bytes) tr' in
-      assert(event_triggered tr' sender (CommAuthSendMsg sender payload_bytes));
-      sign_message_proof #tag #invs.crypto_invs #a tr' sender receiver payload None sk_sender nonce;
-      let msg_signed = sign_message #a sender receiver payload None sk_sender nonce in
+      let ((), tr') = trigger_event sender (CommAuthSendMsg sender payload <: communication_core_event a) tr' in
+      assert(event_triggered tr' sender (CommAuthSendMsg sender payload <: communication_core_event a));
+      sign_message_proof #invs.crypto_invs #a tr' sender receiver (Inl payload) None sk_sender nonce;
+      let msg_signed = sign_message #a sender receiver (Inl payload) None sk_sender nonce in
       let (msg_id, tr') = send_msg msg_signed tr' in
       assert(tr_out == tr');
       assert(trace_invariant tr_out);
@@ -308,82 +299,75 @@ let send_authenticated_proof #tag #invs #a tr higher_layer_preds comm_keys_ids s
     )
 
 
-#push-options "--z3rlimit 50"
 val verify_message_proof:
-  {|comm_layer_core_tag|} ->
   {|cinvs:crypto_invariants|} ->
-  #a:Type -> {| ps:parseable_serializeable bytes a |} ->
+  #a:Type -> {|config:comm_layer_core_config a|} ->
   tr:trace ->
   sender:principal -> receiver:principal ->
   msg_bytes:bytes -> sk_receiver_opt:option bytes ->
   vk_sender:bytes ->
   Lemma
   (requires
-    has_communication_layer_crypto_predicates /\
+    has_communication_layer_crypto_predicates a /\
     is_publishable tr msg_bytes /\
-    is_public_key_for tr vk_sender (LongTermSigKey comm_layer_sign_tag) sender
+    is_public_key_for tr vk_sender (LongTermSigKey (comm_layer_sign_tag a)) sender
   )
   (ensures (
     match verify_message #a receiver msg_bytes sk_receiver_opt vk_sender with
-    | Some cm -> (
-      let Some msg_signed_t = parse com_message_t msg_bytes in
+    | Some payload -> (
+      let Some msg_signed_t = parse comm_message_t msg_bytes in
       let SigMessage msg_signed = msg_signed_t in
-      let Some sign_input = parse signature_input #parseable_serializeable_bytes_signature_input msg_signed.msg in
-      let payload_bytes = serialize a cm.payload in
-      is_well_formed a (is_publishable tr) cm.payload /\
+      let Some sign_input = parse signature_input msg_signed.msg in
       (
-        (
-          cm.sender == sender /\
-          cm.receiver == receiver /\
-          (match sign_input with
-            | Plain sender' receiver' payload_bytes' -> (
-              event_triggered tr sender (CommAuthSendMsg sender payload_bytes)
-            )
-            | Encrypted sender' receiver' payload_bytes' pk_receiver -> (
-              match parse com_send_byte payload_bytes with
-              | None -> True
-              | Some payload -> (
-                exists plain_payload nonce.
-                  payload.b == pke_enc pk_receiver nonce plain_payload /\
-                  event_triggered tr sender (CommConfAuthSendMsg sender receiver plain_payload)
-                )
+        match sign_input with
+        | Plain sender' receiver' payload_bytes' -> (
+          is_well_formed a (is_publishable tr) (Inl?.v payload) /\
+          (
+            event_triggered tr sender (CommAuthSendMsg sender (Inl?.v payload) <: communication_core_event a) \/ 
+            is_corrupt tr (long_term_key_label sender)
+          )
+        )
+        | Encrypted sender' receiver' payload_bytes' pk_receiver -> (
+          is_publishable tr (Inr?.v payload) /\
+          (
+            (
+              exists plain_payload nonce.
+                (Inr?.v payload) == pke_enc pk_receiver nonce plain_payload /\
+                (match parse a plain_payload with
+                | None -> False
+                | Some plain_payload_parsed -> event_triggered tr sender (CommConfAuthSendMsg sender receiver plain_payload_parsed <: communication_core_event a))
+            ) \/ (
+              is_corrupt tr (long_term_key_label sender)
             )
           )
-        ) \/ (
-          is_corrupt tr (long_term_key_label sender)
         )
       )
     )
     | _ -> True
   ))
-let verify_message_proof #tag #cinvs #a #ps tr sender receiver msg_bytes sk_receiver_opt vk_sender =
+let verify_message_proof #cinvs #a #config tr sender receiver msg_bytes sk_receiver_opt vk_sender =
   assert(get_signkey_label tr vk_sender == long_term_key_label sender);
   match verify_message #a receiver msg_bytes sk_receiver_opt vk_sender with
   | None -> ()
-  | Some cm -> (
-    parse_wf_lemma com_message_t (is_publishable tr) msg_bytes;
-    let Some msg_signed_t = parse com_message_t msg_bytes in
+  | Some payload -> (
+    parse_wf_lemma comm_message_t (is_publishable tr) msg_bytes;
+    let Some msg_signed_t = parse comm_message_t msg_bytes in
     let SigMessage msg_signed = msg_signed_t in
-    parse_wf_lemma signature_input #parseable_serializeable_bytes_signature_input (is_publishable tr) msg_signed.msg;
-    let Some sign_input = parse signature_input #parseable_serializeable_bytes_signature_input msg_signed.msg in
-
+    parse_wf_lemma signature_input (is_publishable tr) msg_signed.msg;
+    let Some sign_input = parse signature_input msg_signed.msg in
     match sign_input with
     | Plain sender' receiver' payload_bytes' -> (
-      serialize_parse_inv_lemma #bytes a #ps payload_bytes';
+      serialize_parse_inv_lemma a payload_bytes';
       ()
     )
     | Encrypted sender' receiver' payload_bytes' pk_receiver -> (
-      serialize_parse_inv_lemma #bytes a #ps payload_bytes';
-      assert(payload_bytes' == serialize a cm.payload);
       ()
     )
   )
-#pop-options
 
 val receive_authenticated_proof:
-  {|tag:comm_layer_core_tag|} ->
   {|invs:protocol_invariants|} ->
-  #a:Type -> {| parseable_serializeable bytes a |} ->
+  #a:Type -> {|config:comm_layer_core_config a|} ->
   tr:trace ->
   higher_layer_preds:comm_higher_layer_event_preds a ->
   comm_keys_ids:communication_keys_sess_ids ->
@@ -392,76 +376,76 @@ val receive_authenticated_proof:
   (requires
     trace_invariant tr /\
     has_pki_invariant /\
-    has_communication_layer_crypto_predicates /\
-    has_communication_layer_event_predicates higher_layer_preds
+    has_communication_layer_crypto_predicates a /\
+    has_communication_layer_event_predicates a higher_layer_preds
   )
   (ensures (
     match receive_authenticated comm_keys_ids receiver msg_id tr with
     | (None, tr_out) -> trace_invariant tr_out
     | (Some cm, tr_out) -> (
       trace_invariant tr_out /\
-      event_triggered tr_out receiver (CommAuthReceiveMsg cm.sender receiver (serialize a cm.payload)) /\
+      event_triggered tr_out receiver (CommAuthReceiveMsg cm.sender receiver cm.payload <: communication_core_event a) /\
       is_well_formed a (is_publishable tr) cm.payload
     )
   ))
   [SMTPat (trace_invariant #invs tr);
-   SMTPat (receive_authenticated #tag #a comm_keys_ids receiver msg_id tr);
+   SMTPat (receive_authenticated #a comm_keys_ids receiver msg_id tr);
    SMTPat (core_comm_layer_lemmas_enabled higher_layer_preds)]
-let receive_authenticated_proof #tag #invs #a tr higher_layer_preds comm_keys_ids receiver msg_id =
-  reveal_opaque (`%receive_authenticated) (receive_authenticated #tag #a);
-  match receive_authenticated #tag #a comm_keys_ids receiver msg_id tr with
+let receive_authenticated_proof #invs #a tr higher_layer_preds comm_keys_ids receiver msg_id =
+  reveal_opaque (`%receive_authenticated) (receive_authenticated #a);
+  match receive_authenticated #a comm_keys_ids receiver msg_id tr with
   | (None, tr_out) -> ()
   | (Some cm', tr_out) -> (
     let (Some msg_signed_bytes, tr) = recv_msg msg_id tr in
     let Some sender = get_sender msg_signed_bytes in
-    let (Some vk_sender, tr) = get_public_key receiver comm_keys_ids.pki (LongTermSigKey comm_layer_sign_tag) sender tr in
-    verify_message_proof #tag #invs.crypto_invs #a tr sender receiver msg_signed_bytes None vk_sender;
-    let (Some cm) = verify_message #a receiver msg_signed_bytes None vk_sender in
-    let ((), tr) = trigger_event receiver (CommAuthReceiveMsg sender receiver (serialize a cm.payload)) tr in
-    assert(tr_out == tr);
-    assert(trace_invariant tr_out);
+    let (Some vk_sender, tr) = get_public_key receiver comm_keys_ids.pki (LongTermSigKey (comm_layer_sign_tag a)) sender tr in
+    verify_message_proof #invs.crypto_invs #a tr sender receiver msg_signed_bytes None vk_sender;
+    match verify_message #a receiver msg_signed_bytes None vk_sender with
+    | None -> ()
+    | Some (Inl payload) -> (
+      let ((), tr) = trigger_event receiver (CommAuthReceiveMsg sender receiver payload <: communication_core_event a) tr in
+      assert(tr_out == tr);
+      assert(trace_invariant tr_out);
     ()
+    )
   )
 
 
 (**** Confidential and Authenticates Send and Receive Lemmas ****)
 
 val encrypt_and_sign_message_proof:
-  {|comm_layer_core_tag|} ->
   {|cinvs:crypto_invariants|} ->
-  #a:Type -> {| parseable_serializeable bytes a |} ->
+  #a:Type -> {|comm_layer_core_config a|} ->
   tr:trace ->
   sender:principal -> receiver:principal -> payload:a ->
   pk_receiver:bytes -> sk_sender:bytes -> enc_nonce:bytes -> sign_nonce:bytes ->
   Lemma
-  (requires (
-    let payload_bytes = serialize #bytes a payload in
-    has_communication_layer_crypto_predicates /\
+  (requires
+    has_communication_layer_crypto_predicates a /\
     is_secret (long_term_key_label sender) tr enc_nonce /\
     is_secret (long_term_key_label sender) tr sign_nonce /\
     enc_nonce `has_usage tr` PkeNonce /\
     sign_nonce `has_usage tr` SigNonce /\
-    is_public_key_for tr pk_receiver (LongTermPkeKey comm_layer_pkenc_tag) receiver /\
-    is_private_key_for tr sk_sender (LongTermSigKey comm_layer_sign_tag) sender /\
-    is_knowable_by (join (principal_label sender) (principal_label receiver)) tr payload_bytes /\
-    event_triggered tr sender (CommConfSendMsg sender receiver payload_bytes) /\
-    event_triggered tr sender (CommConfAuthSendMsg sender receiver payload_bytes)
-  ))
+    is_public_key_for tr pk_receiver (LongTermPkeKey (comm_layer_pkenc_tag a)) receiver /\
+    is_private_key_for tr sk_sender (LongTermSigKey (comm_layer_sign_tag a)) sender /\
+    is_well_formed a (is_knowable_by (comm_label sender receiver) tr) payload /\
+    event_triggered tr sender (CommConfSendMsg sender receiver payload <: communication_core_event a) /\
+    event_triggered tr sender (CommConfAuthSendMsg sender receiver payload <: communication_core_event a)
+  )
   (ensures
     is_publishable tr (encrypt_and_sign_message sender receiver payload pk_receiver sk_sender enc_nonce sign_nonce)
   )
-let encrypt_and_sign_message_proof #tag #cinvs #a tr sender receiver payload pk_receiver sk_sender enc_nonce sign_nonce =
+let encrypt_and_sign_message_proof #cinvs #a tr sender receiver payload pk_receiver sk_sender enc_nonce sign_nonce =
   reveal_opaque (`%encrypt_and_sign_message) (encrypt_and_sign_message #a);
   reveal_opaque (`%encrypt_message) (encrypt_message #a); // TODO: This should be removeable.
   encrypt_message_proof tr sender receiver pk_receiver enc_nonce payload;
   let enc_payload = encrypt_message pk_receiver enc_nonce payload in
-  sign_message_proof tr sender receiver {b=enc_payload} (Some pk_receiver) sk_sender sign_nonce;
+  sign_message_proof #cinvs #a tr sender receiver (Inr enc_payload) (Some pk_receiver) sk_sender sign_nonce;
   ()
 
 val send_confidential_authenticated_proof:
-  {|tag:comm_layer_core_tag|} ->
-  {|invs:protocol_invariants|} ->
-  #a:Type -> {| parseable_serializeable bytes a |} ->
+  {|protocol_invariants|} ->
+  #a:Type0 -> {|comm_layer_core_config a|}  ->
   tr:trace ->
   higher_layer_preds:comm_higher_layer_event_preds a ->
   comm_keys_ids:communication_keys_sess_ids ->
@@ -471,8 +455,8 @@ val send_confidential_authenticated_proof:
     trace_invariant tr /\
     has_private_keys_invariant /\
     has_pki_invariant /\
-    has_communication_layer_crypto_predicates /\
-    has_communication_layer_event_predicates higher_layer_preds /\
+    has_communication_layer_crypto_predicates a /\
+    has_communication_layer_event_predicates a higher_layer_preds /\
     higher_layer_preds.send_conf tr sender receiver payload /\
     higher_layer_preds.send_conf_auth tr sender receiver payload /\
     is_well_formed a (is_knowable_by (join (principal_label sender) (principal_label receiver)) tr) payload
@@ -481,27 +465,27 @@ val send_confidential_authenticated_proof:
     let (_, tr_out) = send_confidential_authenticated comm_keys_ids sender receiver payload tr in
     trace_invariant tr_out
   ))
-  [SMTPat (trace_invariant #invs tr);
-   SMTPat (send_confidential_authenticated #tag #a comm_keys_ids sender receiver payload tr);
+  [SMTPat (trace_invariant tr);
+   SMTPat (send_confidential_authenticated comm_keys_ids sender receiver payload tr);
    SMTPat (core_comm_layer_lemmas_enabled higher_layer_preds)]
-let send_confidential_authenticated_proof #tag #invs #a tr higher_layer_preds comm_keys_ids sender receiver payload =
-  reveal_opaque (`%send_confidential_authenticated) (send_confidential_authenticated #tag #a);
+let send_confidential_authenticated_proof #invs #a tr higher_layer_preds comm_keys_ids sender receiver payload =
+  reveal_opaque (`%send_confidential_authenticated) (send_confidential_authenticated #a);
   match send_confidential_authenticated comm_keys_ids sender receiver payload tr with
   | (None, tr_out) -> ()
   | (Some _, tr_out) -> (
-    let (Some pk_receiver, tr') = get_public_key sender comm_keys_ids.pki (LongTermPkeKey comm_layer_pkenc_tag) receiver tr in
-    let (Some sk_sender, tr') = get_private_key  sender comm_keys_ids.private_keys (LongTermSigKey comm_layer_sign_tag) tr' in
+    let (Some pk_receiver, tr') = get_public_key sender comm_keys_ids.pki (LongTermPkeKey (comm_layer_pkenc_tag a)) receiver tr in
+    let (Some sk_sender, tr') = get_private_key  sender comm_keys_ids.private_keys (LongTermSigKey (comm_layer_sign_tag a)) tr' in
     let (enc_nonce, tr') = mk_rand PkeNonce (long_term_key_label sender) 32 tr' in
     let (sign_nonce, tr') = mk_rand SigNonce (long_term_key_label sender) 32 tr' in
 
     let payload_bytes = serialize #bytes a payload in
     higher_layer_preds.send_conf_later tr tr' sender receiver payload;
-    let ((), tr') = trigger_event sender (CommConfSendMsg sender receiver payload_bytes) tr' in
-    assert(event_triggered tr' sender (CommConfSendMsg sender receiver payload_bytes));
+    let ((), tr') = trigger_event sender (CommConfSendMsg sender receiver payload <: communication_core_event a) tr' in
+    assert(event_triggered tr' sender (CommConfSendMsg sender receiver payload <: communication_core_event a));
 
     higher_layer_preds.send_conf_auth_later tr tr' sender receiver payload;
-    let ((), tr') = trigger_event sender (CommConfAuthSendMsg sender receiver payload_bytes) tr' in
-    assert(event_triggered tr' sender (CommConfAuthSendMsg sender receiver payload_bytes));
+    let ((), tr') = trigger_event sender (CommConfAuthSendMsg sender receiver payload <: communication_core_event a) tr' in
+    assert(event_triggered tr' sender (CommConfAuthSendMsg sender receiver payload <: communication_core_event a));
 
     encrypt_and_sign_message_proof tr' sender receiver payload pk_receiver sk_sender enc_nonce sign_nonce;
     let msg = encrypt_and_sign_message sender receiver payload pk_receiver sk_sender enc_nonce sign_nonce in
@@ -514,57 +498,56 @@ let send_confidential_authenticated_proof #tag #invs #a tr higher_layer_preds co
 
 #push-options "--ifuel 1 --z3rlimit 40"
 val verify_and_decrypt_message_proof:
-  {|comm_layer_core_tag|} ->
   {|cinvs:crypto_invariants|} ->
-  #a:Type -> {| parseable_serializeable bytes a |} ->
+  #a:Type -> {|comm_layer_core_config a|} ->
   tr:trace ->
   sender:principal -> receiver:principal -> msg_encrypted_signed:bytes ->
   sk_receiver:bytes -> vk_sender:bytes ->
   Lemma
   (requires
-    has_communication_layer_crypto_predicates /\
+    has_communication_layer_crypto_predicates a /\
     is_publishable tr msg_encrypted_signed /\
-    is_private_key_for tr sk_receiver (LongTermPkeKey comm_layer_pkenc_tag) receiver /\
-    is_public_key_for tr vk_sender (LongTermSigKey comm_layer_sign_tag) sender
+    is_private_key_for tr sk_receiver (LongTermPkeKey (comm_layer_pkenc_tag a)) receiver /\
+    is_public_key_for tr vk_sender (LongTermSigKey (comm_layer_sign_tag a)) sender
   )
   (ensures (
     match verify_and_decrypt_message #a receiver sk_receiver vk_sender msg_encrypted_signed with
     | None -> True
     | Some cm -> (
       is_well_formed a (is_knowable_by (principal_label receiver) tr) cm.payload /\
-      is_knowable_by (principal_label receiver) tr (serialize a cm.payload) /\
+      //is_knowable_by (principal_label receiver) tr (serialize a cm.payload) /\
       (
-        event_triggered tr sender (CommConfAuthSendMsg sender receiver (serialize a cm.payload)) \/
+        event_triggered tr sender (CommConfAuthSendMsg sender receiver cm.payload <: communication_core_event a) \/
         is_corrupt tr (long_term_key_label sender)
       )
     )
   ))
-let verify_and_decrypt_message_proof #tag #cinvs #a tr sender receiver msg_encrypted_signed sk_receiver vk_sender =
+let verify_and_decrypt_message_proof #cinvs #a tr sender receiver msg_encrypted_signed sk_receiver vk_sender =
   reveal_opaque (`%verify_and_decrypt_message) (verify_and_decrypt_message #a);
   reveal_opaque (`%decrypt_message) (decrypt_message #a);
   match verify_and_decrypt_message #a receiver sk_receiver vk_sender msg_encrypted_signed with
   | None -> ()
   | Some cm -> (
-    verify_message_proof #tag #cinvs #com_send_byte tr sender receiver msg_encrypted_signed (Some sk_receiver) vk_sender;
-    let Some cm' = verify_message #com_send_byte receiver msg_encrypted_signed (Some sk_receiver) vk_sender in
-
-    let Some msg_signed_t = parse com_message_t msg_encrypted_signed in
+    verify_message_proof #cinvs #a tr sender receiver msg_encrypted_signed (Some sk_receiver) vk_sender;
+    let Some (Inr payload_enc) = verify_message #a receiver msg_encrypted_signed (Some sk_receiver) vk_sender in
+    let Some msg_signed_t = parse comm_message_t msg_encrypted_signed in
     let SigMessage msg_signed = msg_signed_t in
     let Some sign_input = parse signature_input msg_signed.msg in
     let Encrypted _ _ _ pk_receiver = sign_input in
     assert(pk_receiver == pk sk_receiver);
 
-    let Some plaintext = pke_dec sk_receiver cm'.payload.b in
+    let Some plaintext = pke_dec sk_receiver payload_enc in
     serialize_parse_inv_lemma #bytes a plaintext;
 
     introduce (~(is_corrupt tr (long_term_key_label sender))) ==>  (
-        event_triggered tr sender (CommConfAuthSendMsg sender receiver (serialize a cm.payload))
+        event_triggered tr sender (CommConfAuthSendMsg sender receiver cm.payload <: communication_core_event a)
       )
     with _. (
       eliminate exists plain_payload nonce.
-          cm'.payload.b == pke_enc pk_receiver nonce plain_payload /\
-          event_triggered tr sender (CommConfAuthSendMsg sender receiver plain_payload)
-      returns event_triggered tr sender (CommConfAuthSendMsg sender receiver (serialize a cm.payload))
+          payload_enc == pke_enc pk_receiver nonce plain_payload /\
+          Some? (parse a plain_payload) /\
+          event_triggered tr sender (CommConfAuthSendMsg sender receiver (Some?.v (parse a plain_payload)) <: communication_core_event a)
+      returns event_triggered tr sender (CommConfAuthSendMsg sender receiver cm.payload <: communication_core_event a)
       with _. (
         pke_dec_enc sk_receiver nonce plain_payload;
         ()
@@ -574,9 +557,8 @@ let verify_and_decrypt_message_proof #tag #cinvs #a tr sender receiver msg_encry
 #pop-options
 
 val receive_confidential_authenticated_proof:
-  {|tag:comm_layer_core_tag|} ->
   {|invs:protocol_invariants|} ->
-  #a:Type -> {| parseable_serializeable bytes a |} ->
+  #a:Type -> {|comm_layer_core_config a|} ->
   tr:trace ->
   higher_layer_preds:comm_higher_layer_event_preds a ->
   comm_keys_ids:communication_keys_sess_ids ->
@@ -586,37 +568,37 @@ val receive_confidential_authenticated_proof:
     trace_invariant tr /\
     has_private_keys_invariant /\
     has_pki_invariant /\
-    has_communication_layer_crypto_predicates /\
-    has_communication_layer_event_predicates higher_layer_preds
+    has_communication_layer_crypto_predicates a /\
+    has_communication_layer_event_predicates a higher_layer_preds
   )
   (ensures
     (
-      match receive_confidential_authenticated #tag #a comm_keys_ids receiver msg_id tr with
+      match receive_confidential_authenticated #a comm_keys_ids receiver msg_id tr with
       | (None, tr_out) -> trace_invariant tr_out
       | (Some cm, tr_out) -> (
         trace_invariant tr_out /\
-        event_triggered tr_out receiver (CommConfAuthReceiveMsg cm.sender receiver (serialize a cm.payload)) /\
+        event_triggered tr_out receiver (CommConfAuthReceiveMsg cm.sender receiver cm.payload <: communication_core_event a) /\
         is_well_formed a (is_knowable_by (principal_label receiver) tr) cm.payload
       )
     )
   )
   [SMTPat (trace_invariant #invs tr);
-   SMTPat (receive_confidential_authenticated #tag #a comm_keys_ids receiver msg_id tr);
+   SMTPat (receive_confidential_authenticated #a comm_keys_ids receiver msg_id tr);
    SMTPat (core_comm_layer_lemmas_enabled higher_layer_preds)]
-let receive_confidential_authenticated_proof #tag #invs #a tr higher_layer_preds comm_keys_ids receiver msg_id =
-  reveal_opaque (`%receive_confidential_authenticated) (receive_confidential_authenticated #tag #a);
+let receive_confidential_authenticated_proof #invs #a tr higher_layer_preds comm_keys_ids receiver msg_id =
+  reveal_opaque (`%receive_confidential_authenticated) (receive_confidential_authenticated #a);
   reveal_opaque (`%verify_and_decrypt_message) (verify_and_decrypt_message #a); // TODO: These reveals should be removeable.
-  match receive_confidential_authenticated #tag #a comm_keys_ids receiver msg_id tr with
+  match receive_confidential_authenticated #a comm_keys_ids receiver msg_id tr with
   | (None, tr_out) -> ()
   | (Some cm, tr_out) -> (
     let (Some msg_encrypted_signed, tr) = recv_msg msg_id tr in
-    let (Some sk_receiver, tr) = get_private_key receiver comm_keys_ids.private_keys (LongTermPkeKey comm_layer_pkenc_tag) tr in
+    let (Some sk_receiver, tr) = get_private_key receiver comm_keys_ids.private_keys (LongTermPkeKey (comm_layer_pkenc_tag a)) tr in
     let Some sender = get_sender msg_encrypted_signed in
-    let (Some vk_sender, tr) = get_public_key receiver comm_keys_ids.pki (LongTermSigKey comm_layer_sign_tag) sender tr in
-    verify_and_decrypt_message_proof #tag #invs.crypto_invs #a tr sender receiver msg_encrypted_signed sk_receiver vk_sender;
+    let (Some vk_sender, tr) = get_public_key receiver comm_keys_ids.pki (LongTermSigKey (comm_layer_sign_tag a)) sender tr in
+    verify_and_decrypt_message_proof #invs.crypto_invs #a tr sender receiver msg_encrypted_signed sk_receiver vk_sender;
     let Some cm = verify_and_decrypt_message #a receiver sk_receiver vk_sender msg_encrypted_signed in
-    let ((), tr) = trigger_event receiver (CommConfAuthReceiveMsg sender receiver (serialize a cm.payload)) tr in
-    assert(event_triggered tr receiver (CommConfAuthReceiveMsg sender receiver (serialize a cm.payload)));
+    let ((), tr) = trigger_event receiver (CommConfAuthReceiveMsg sender receiver cm.payload <: communication_core_event a) tr in
+    assert(event_triggered tr receiver (CommConfAuthReceiveMsg sender receiver cm.payload <: communication_core_event a));
     assert(trace_invariant tr);
     assert(tr == tr_out);
     ()

--- a/src/lib/communication/DY.Lib.Communication.Core.Lemmas.fst
+++ b/src/lib/communication/DY.Lib.Communication.Core.Lemmas.fst
@@ -41,7 +41,7 @@ let enable_core_comm_layer_lemmas preds =
 (**** Initialization Satisfies the Trace Invariants ****)
 
 #push-options "--ifuel 2 --z3rlimit 25"
-val initialize_communication_proof:
+val initialize_communication_core_proof
   {|invs:protocol_invariants|} ->
   tr:trace ->
   a:Type -> {|comm_layer_core_config a|} ->

--- a/src/lib/communication/DY.Lib.Communication.Core.Lemmas.fst
+++ b/src/lib/communication/DY.Lib.Communication.Core.Lemmas.fst
@@ -65,6 +65,13 @@ let initialize_communication_core_proof tr a sender receiver =
 
 (**** Confidential Send and Receive Lemmas ****)
 
+val comm_conf_send_event_triggered:
+  #a:Type0 -> {|comm_layer_core_config a|} ->
+  trace -> principal -> principal -> a ->
+  prop
+let comm_conf_send_event_triggered #a tr sender receiver payload =
+  event_triggered tr sender (CommConfSendMsg sender receiver payload <: communication_core_event a)
+
 val encrypt_message_proof:
   {|cinvs:crypto_invariants|} ->
   #a:Type -> {|comm_layer_core_config a|} ->
@@ -77,11 +84,11 @@ val encrypt_message_proof:
     is_secret (long_term_key_label sender) tr nonce /\
     nonce `has_usage tr` PkeNonce /\
     is_public_key_for tr pk_receiver (LongTermPkeKey (comm_layer_pkenc_tag a)) receiver /\
-    is_well_formed a (is_knowable_by (join (principal_label sender) (principal_label receiver)) tr) payload /\
-    event_triggered tr sender (CommConfSendMsg sender receiver payload <: communication_core_event a)
+    is_well_formed a (is_knowable_by (comm_label sender receiver) tr) payload /\
+    comm_conf_send_event_triggered tr sender receiver payload
   ))
   (ensures
-    is_publishable tr (encrypt_message pk_receiver nonce payload)
+    is_publishable tr (encrypt_message pk_receiver nonce payload) 
   )
 let encrypt_message_proof #cinvs #a tr sender receiver pk_receiver nonce pkenc_in =
   reveal_opaque (`%encrypt_message) (encrypt_message #a)
@@ -97,8 +104,7 @@ val send_confidential_proof:
   (requires (
     trace_invariant tr /\
     has_pki_invariant /\
-    has_communication_layer_core_crypto_predicates a /\
-    has_communication_layer_core_event_predicates a higher_layer_preds /\
+    has_communication_layer_core_predicates higher_layer_preds /\
     higher_layer_preds.send_conf tr sender receiver payload /\
     // We only require the payload to flow to the sender and receiver to allow
     // the sender to send a payload readable by other principals. If you want
@@ -149,7 +155,7 @@ val decrypt_message_proof:
         is_well_formed a (is_knowable_by (comm_label sender receiver) tr) payload /\
         is_well_formed a (is_knowable_by (comm_label sender receiver) tr) payload /\
         (
-          event_triggered tr sender (CommConfSendMsg sender receiver payload <: communication_core_event a) \/
+          comm_conf_send_event_triggered tr sender receiver payload \/
           is_well_formed a (is_publishable tr) payload
         )
       )
@@ -176,8 +182,7 @@ val receive_confidential_proof:
   (requires
     trace_invariant tr /\
     has_private_keys_invariant /\
-    has_communication_layer_core_crypto_predicates a /\
-    has_communication_layer_core_event_predicates a higher_layer_preds
+    has_communication_layer_core_predicates higher_layer_preds
   )
   (ensures (
     match receive_confidential comm_keys_ids receiver msg_id tr with
@@ -208,54 +213,79 @@ let receive_confidential_proof #invs #a tr higher_layer_preds comm_keys_ids rece
 
 (**** Authenticated Send and Receive Lemmas ****)
 
+val comm_auth_send_event_triggered:
+  #a:Type0 -> {|comm_layer_core_config a|} ->
+  trace -> principal -> a ->
+  prop
+let comm_auth_send_event_triggered #a tr sender payload =
+  event_triggered tr sender (CommAuthSendMsg sender payload <: communication_core_event a)
+
+val comm_conf_auth_send_event_triggered:
+  #a:Type0 -> {|comm_layer_core_config a|} ->
+  trace -> principal -> principal -> a ->
+  prop
+let comm_conf_auth_send_event_triggered #a tr sender receiver payload =
+  event_triggered tr sender (CommConfAuthSendMsg sender receiver payload <: communication_core_event a)
+
+#push-options "--ifuel 1 --fuel 0 --z3rlimit 50"
 val sign_message_proof:
   {|cinvs:crypto_invariants|} ->
   #a:Type0 -> {|config:comm_layer_core_config a|} ->
   tr:trace ->
-  sender:principal -> receiver:principal -> payload:either a bytes -> pk_receiver:option bytes ->
+  sender:principal -> receiver:principal -> input:either a (bytes & bytes) ->
   sk_sender:bytes -> nonce:bytes ->
   Lemma
   (requires (
-    (Some? pk_receiver <==> Inr? payload) /\ 
-    (None? pk_receiver <==> Inl? payload) /\
     has_communication_layer_core_crypto_predicates a /\
     is_secret (long_term_key_label sender) tr nonce /\
     nonce `has_usage tr` SigNonce /\
     is_private_key_for tr sk_sender (LongTermSigKey (comm_layer_sign_tag a)) sender /\
     (
-      match pk_receiver with
-      | None -> (
-        is_well_formed a (is_publishable tr) (Inl?.v payload) /\
-        event_triggered tr sender (CommAuthSendMsg sender (Inl?.v payload) <: communication_core_event a)
+      match input with
+      | Inl payload -> (
+        is_well_formed a (is_publishable tr) payload /\
+        comm_auth_send_event_triggered #a tr sender payload
       )
-      | Some pk -> (
-        is_publishable tr (Inr?.v payload) /\
+      | Inr (payload, pk) -> (
+        is_publishable tr payload /\
         is_publishable tr pk /\
         (exists plain_payload nonce.
-          Inr?.v payload == pke_enc pk nonce plain_payload /\
-          (match parse a #(parseable_serializeable_bytes_a #a) plain_payload with
+          payload == pke_enc pk nonce plain_payload /\
+          (match parse a #(parseable_serializeable_bytes_a_core #a) plain_payload with
           | None -> False
-          | Some plain_payload_parsed -> event_triggered tr sender (CommConfAuthSendMsg sender receiver plain_payload_parsed <: communication_core_event a))
+          | Some plain_payload_parsed -> comm_conf_auth_send_event_triggered tr sender receiver plain_payload_parsed)
         )
       )
     )
   ))
   (ensures
-    is_publishable tr (sign_message sender receiver payload pk_receiver sk_sender nonce)
+    is_publishable tr (sign_message sender receiver input sk_sender nonce)
   )
-let sign_message_proof #cinvs #a #config tr sender receiver payload pk_receiver sk_sender nonce =
+let sign_message_proof #cinvs #a #config tr sender receiver input sk_sender nonce =
   reveal_opaque (`%sign_message) (sign_message #a);
-  let sig_input = match pk_receiver with
-    | None -> Plain sender receiver (serialize a (Inl?.v payload))
-    | Some pk -> Encrypted sender receiver (Inr?.v payload) pk
-  in 
-  let sig_input_bytes = serialize signature_input sig_input in
-  serialize_wf_lemma signature_input (is_publishable tr) sig_input;
-  let signature = sign sk_sender nonce sig_input_bytes in
-  let msg_signed = SigMessage {msg=sig_input_bytes; signature} in
-  assert(bytes_invariant tr signature);
-  serialize_wf_lemma comm_message_t (is_publishable tr) msg_signed;
-  ()
+  // The proof is duplicated here to improve the proof performance
+  match input with
+    | Inl payload -> (
+      let sig_input:signature_input a = Plain sender receiver payload in
+      let sig_input_bytes = serialize (signature_input a) sig_input in
+      serialize_wf_lemma (signature_input a) (is_publishable tr) sig_input;
+      let signature = sign sk_sender nonce sig_input_bytes in
+      assert(bytes_invariant tr signature); // Improves proof performance
+      let msg_signed = SigMessage {msg=sig_input_bytes; signature} in
+      serialize_wf_lemma comm_message_t (is_publishable tr) msg_signed;
+      ()
+    )
+    | Inr (payload, pk) -> (
+      let sig_input:signature_input a = Encrypted sender receiver payload pk in
+      let sig_input_bytes = serialize (signature_input a) sig_input in
+      serialize_wf_lemma (signature_input a) (is_publishable tr) sig_input;
+      let signature = sign sk_sender nonce sig_input_bytes in
+      assert(bytes_invariant tr signature); // Improves proof performance
+      let msg_signed = SigMessage {msg=sig_input_bytes; signature} in
+      serialize_wf_lemma comm_message_t (is_publishable tr) msg_signed;
+      ()
+    )
+#pop-options
 
 val send_authenticated_proof:
   {|invs:protocol_invariants|} ->
@@ -268,8 +298,7 @@ val send_authenticated_proof:
   (requires
     trace_invariant tr /\
     has_private_keys_invariant /\
-    has_communication_layer_core_crypto_predicates a /\
-    has_communication_layer_core_event_predicates a higher_layer_preds /\
+    has_communication_layer_core_predicates higher_layer_preds /\
     higher_layer_preds.send_auth tr sender payload /\
     is_well_formed a (is_publishable tr) payload
   )
@@ -289,9 +318,9 @@ let send_authenticated_proof #invs #a tr higher_layer_preds comm_keys_ids sender
       let (nonce,  tr') = mk_rand SigNonce (long_term_key_label sender) 32 tr' in
       higher_layer_preds.send_auth_later tr tr' sender payload;
       let ((), tr') = trigger_event sender (CommAuthSendMsg sender payload <: communication_core_event a) tr' in
-      assert(event_triggered tr' sender (CommAuthSendMsg sender payload <: communication_core_event a));
-      sign_message_proof #invs.crypto_invs #a tr' sender receiver (Inl payload) None sk_sender nonce;
-      let msg_signed = sign_message #a sender receiver (Inl payload) None sk_sender nonce in
+      assert(comm_auth_send_event_triggered tr' sender payload);
+      sign_message_proof #invs.crypto_invs #a tr' sender receiver (Inl payload) sk_sender nonce;
+      let msg_signed = sign_message #a sender receiver (Inl payload) sk_sender nonce in
       let (msg_id, tr') = send_msg msg_signed tr' in
       assert(tr_out == tr');
       assert(trace_invariant tr_out);
@@ -315,27 +344,30 @@ val verify_message_proof:
   (ensures (
     match verify_message #a receiver msg_bytes sk_receiver_opt vk_sender with
     | Some payload -> (
-      let Some msg_signed_t = parse comm_message_t msg_bytes in
-      let SigMessage msg_signed = msg_signed_t in
-      let Some sign_input = parse signature_input msg_signed.msg in
+      let Some (SigMessage msg_signed) = parse comm_message_t msg_bytes in
+      let Some sign_input = parse (signature_input a) msg_signed.msg in
       (
         match sign_input with
         | Plain sender' receiver' payload_bytes' -> (
           is_well_formed a (is_publishable tr) (Inl?.v payload) /\
           (
-            event_triggered tr sender (CommAuthSendMsg sender (Inl?.v payload) <: communication_core_event a) \/ 
+            sender == sender' /\
+            receiver == receiver' /\
+            comm_auth_send_event_triggered tr sender (Inl?.v payload) \/ 
             is_corrupt tr (long_term_key_label sender)
           )
         )
         | Encrypted sender' receiver' payload_bytes' pk_receiver -> (
           is_publishable tr (Inr?.v payload) /\
           (
+            sender == sender' /\
+            receiver == receiver' /\
             (
               exists plain_payload nonce.
                 (Inr?.v payload) == pke_enc pk_receiver nonce plain_payload /\
                 (match parse a plain_payload with
                 | None -> False
-                | Some plain_payload_parsed -> event_triggered tr sender (CommConfAuthSendMsg sender receiver plain_payload_parsed <: communication_core_event a))
+                | Some plain_payload_parsed -> comm_conf_auth_send_event_triggered tr sender receiver plain_payload_parsed)
             ) \/ (
               is_corrupt tr (long_term_key_label sender)
             )
@@ -353,11 +385,10 @@ let verify_message_proof #cinvs #a #config tr sender receiver msg_bytes sk_recei
     parse_wf_lemma comm_message_t (is_publishable tr) msg_bytes;
     let Some msg_signed_t = parse comm_message_t msg_bytes in
     let SigMessage msg_signed = msg_signed_t in
-    parse_wf_lemma signature_input (is_publishable tr) msg_signed.msg;
-    let Some sign_input = parse signature_input msg_signed.msg in
+    parse_wf_lemma (signature_input a) (is_publishable tr) msg_signed.msg;
+    let Some sign_input = parse (signature_input a) msg_signed.msg in
     match sign_input with
     | Plain sender' receiver' payload_bytes' -> (
-      serialize_parse_inv_lemma a payload_bytes';
       ()
     )
     | Encrypted sender' receiver' payload_bytes' pk_receiver -> (
@@ -376,8 +407,7 @@ val receive_authenticated_proof:
   (requires
     trace_invariant tr /\
     has_pki_invariant /\
-    has_communication_layer_core_crypto_predicates a /\
-    has_communication_layer_core_event_predicates a higher_layer_preds
+    has_communication_layer_core_predicates higher_layer_preds
   )
   (ensures (
     match receive_authenticated comm_keys_ids receiver msg_id tr with
@@ -397,7 +427,7 @@ let receive_authenticated_proof #invs #a tr higher_layer_preds comm_keys_ids rec
   | (None, tr_out) -> ()
   | (Some cm', tr_out) -> (
     let (Some msg_signed_bytes, tr) = recv_msg msg_id tr in
-    let Some sender = get_sender msg_signed_bytes in
+    let Some sender = get_sender #a msg_signed_bytes in
     let (Some vk_sender, tr) = get_public_key receiver comm_keys_ids.pki (LongTermSigKey (comm_layer_sign_tag a)) sender tr in
     verify_message_proof #invs.crypto_invs #a tr sender receiver msg_signed_bytes None vk_sender;
     match verify_message #a receiver msg_signed_bytes None vk_sender with
@@ -429,8 +459,8 @@ val encrypt_and_sign_message_proof:
     is_public_key_for tr pk_receiver (LongTermPkeKey (comm_layer_pkenc_tag a)) receiver /\
     is_private_key_for tr sk_sender (LongTermSigKey (comm_layer_sign_tag a)) sender /\
     is_well_formed a (is_knowable_by (comm_label sender receiver) tr) payload /\
-    event_triggered tr sender (CommConfSendMsg sender receiver payload <: communication_core_event a) /\
-    event_triggered tr sender (CommConfAuthSendMsg sender receiver payload <: communication_core_event a)
+    comm_conf_send_event_triggered tr sender receiver payload /\
+    comm_conf_auth_send_event_triggered tr sender receiver payload
   )
   (ensures
     is_publishable tr (encrypt_and_sign_message sender receiver payload pk_receiver sk_sender enc_nonce sign_nonce)
@@ -440,7 +470,7 @@ let encrypt_and_sign_message_proof #cinvs #a tr sender receiver payload pk_recei
   reveal_opaque (`%encrypt_message) (encrypt_message #a); // TODO: This should be removeable.
   encrypt_message_proof tr sender receiver pk_receiver enc_nonce payload;
   let enc_payload = encrypt_message pk_receiver enc_nonce payload in
-  sign_message_proof #cinvs #a tr sender receiver (Inr enc_payload) (Some pk_receiver) sk_sender sign_nonce;
+  sign_message_proof #cinvs #a tr sender receiver (Inr (enc_payload, pk_receiver)) sk_sender sign_nonce;
   ()
 
 val send_confidential_authenticated_proof:
@@ -455,8 +485,7 @@ val send_confidential_authenticated_proof:
     trace_invariant tr /\
     has_private_keys_invariant /\
     has_pki_invariant /\
-    has_communication_layer_core_crypto_predicates a /\
-    has_communication_layer_core_event_predicates a higher_layer_preds /\
+    has_communication_layer_core_predicates higher_layer_preds /\
     higher_layer_preds.send_conf tr sender receiver payload /\
     higher_layer_preds.send_conf_auth tr sender receiver payload /\
     is_well_formed a (is_knowable_by (join (principal_label sender) (principal_label receiver)) tr) payload
@@ -481,11 +510,11 @@ let send_confidential_authenticated_proof #invs #a tr higher_layer_preds comm_ke
     let payload_bytes = serialize #bytes a payload in
     higher_layer_preds.send_conf_later tr tr' sender receiver payload;
     let ((), tr') = trigger_event sender (CommConfSendMsg sender receiver payload <: communication_core_event a) tr' in
-    assert(event_triggered tr' sender (CommConfSendMsg sender receiver payload <: communication_core_event a));
+    assert(comm_conf_send_event_triggered tr' sender receiver payload);
 
     higher_layer_preds.send_conf_auth_later tr tr' sender receiver payload;
     let ((), tr') = trigger_event sender (CommConfAuthSendMsg sender receiver payload <: communication_core_event a) tr' in
-    assert(event_triggered tr' sender (CommConfAuthSendMsg sender receiver payload <: communication_core_event a));
+    assert(comm_conf_auth_send_event_triggered tr' sender receiver payload);
 
     encrypt_and_sign_message_proof tr' sender receiver payload pk_receiver sk_sender enc_nonce sign_nonce;
     let msg = encrypt_and_sign_message sender receiver payload pk_receiver sk_sender enc_nonce sign_nonce in
@@ -517,7 +546,7 @@ val verify_and_decrypt_message_proof:
       is_well_formed a (is_knowable_by (principal_label receiver) tr) cm.payload /\
       //is_knowable_by (principal_label receiver) tr (serialize a cm.payload) /\
       (
-        event_triggered tr sender (CommConfAuthSendMsg sender receiver cm.payload <: communication_core_event a) \/
+        comm_conf_auth_send_event_triggered tr sender receiver cm.payload \/
         is_corrupt tr (long_term_key_label sender)
       )
     )
@@ -532,7 +561,7 @@ let verify_and_decrypt_message_proof #cinvs #a tr sender receiver msg_encrypted_
     let Some (Inr payload_enc) = verify_message #a receiver msg_encrypted_signed (Some sk_receiver) vk_sender in
     let Some msg_signed_t = parse comm_message_t msg_encrypted_signed in
     let SigMessage msg_signed = msg_signed_t in
-    let Some sign_input = parse signature_input msg_signed.msg in
+    let Some sign_input = parse (signature_input a) msg_signed.msg in
     let Encrypted _ _ _ pk_receiver = sign_input in
     assert(pk_receiver == pk sk_receiver);
 
@@ -540,14 +569,14 @@ let verify_and_decrypt_message_proof #cinvs #a tr sender receiver msg_encrypted_
     serialize_parse_inv_lemma #bytes a plaintext;
 
     introduce (~(is_corrupt tr (long_term_key_label sender))) ==>  (
-        event_triggered tr sender (CommConfAuthSendMsg sender receiver cm.payload <: communication_core_event a)
+        comm_conf_auth_send_event_triggered tr sender receiver cm.payload
       )
     with _. (
       eliminate exists plain_payload nonce.
           payload_enc == pke_enc pk_receiver nonce plain_payload /\
           Some? (parse a plain_payload) /\
-          event_triggered tr sender (CommConfAuthSendMsg sender receiver (Some?.v (parse a plain_payload)) <: communication_core_event a)
-      returns event_triggered tr sender (CommConfAuthSendMsg sender receiver cm.payload <: communication_core_event a)
+          comm_conf_auth_send_event_triggered tr sender receiver (Some?.v (parse a plain_payload))
+      returns comm_conf_auth_send_event_triggered tr sender receiver cm.payload
       with _. (
         pke_dec_enc sk_receiver nonce plain_payload;
         ()
@@ -568,8 +597,7 @@ val receive_confidential_authenticated_proof:
     trace_invariant tr /\
     has_private_keys_invariant /\
     has_pki_invariant /\
-    has_communication_layer_core_crypto_predicates a /\
-    has_communication_layer_core_event_predicates a higher_layer_preds
+    has_communication_layer_core_predicates higher_layer_preds
   )
   (ensures
     (
@@ -593,7 +621,7 @@ let receive_confidential_authenticated_proof #invs #a tr higher_layer_preds comm
   | (Some cm, tr_out) -> (
     let (Some msg_encrypted_signed, tr) = recv_msg msg_id tr in
     let (Some sk_receiver, tr) = get_private_key receiver comm_keys_ids.private_keys (LongTermPkeKey (comm_layer_pkenc_tag a)) tr in
-    let Some sender = get_sender msg_encrypted_signed in
+    let Some sender = get_sender #a msg_encrypted_signed in
     let (Some vk_sender, tr) = get_public_key receiver comm_keys_ids.pki (LongTermSigKey (comm_layer_sign_tag a)) sender tr in
     verify_and_decrypt_message_proof #invs.crypto_invs #a tr sender receiver msg_encrypted_signed sk_receiver vk_sender;
     let Some cm = verify_and_decrypt_message #a receiver sk_receiver vk_sender msg_encrypted_signed in

--- a/src/lib/communication/DY.Lib.Communication.Core.Lemmas.fst
+++ b/src/lib/communication/DY.Lib.Communication.Core.Lemmas.fst
@@ -21,19 +21,19 @@ open DY.Lib.Communication.Core.Invariants
 /// To enable these core lemmas for an analysis, which requires specifying which
 /// predicates they shouild be used for, one can use the line
 /// `enable_core_comm_layer_lemmas preds`, where `preds` is the relevant
-/// `comm_higher_layer_event_preds` for the protocol.
+/// `comm_core_higher_layer_event_preds` for the protocol.
 /// See https://github.com/FStarLang/FStar/wiki/Quantifiers-and-patterns
 /// for more information on this technique.
 
 [@@"opaque_to_smt"]
 val core_comm_layer_lemmas_enabled:
   #a:Type -> {|comm_layer_core_config a|} ->
-  comm_higher_layer_event_preds a -> prop
+  comm_core_higher_layer_event_preds a -> prop
 let core_comm_layer_lemmas_enabled _ = True
 
 val enable_core_comm_layer_lemmas:
   #a:Type -> {|comm_layer_core_config a|} ->
-  preds:comm_higher_layer_event_preds a ->
+  preds:comm_core_higher_layer_event_preds a ->
   Lemma (core_comm_layer_lemmas_enabled preds)
 let enable_core_comm_layer_lemmas preds =
   normalize_term_spec (core_comm_layer_lemmas_enabled preds)
@@ -41,7 +41,7 @@ let enable_core_comm_layer_lemmas preds =
 (**** Initialization Satisfies the Trace Invariants ****)
 
 #push-options "--ifuel 2"
-val initialize_communication_proof:
+val initialize_communication_core_proof:
   {|invs:protocol_invariants|} ->
   tr:trace ->
   a:Type -> {|comm_layer_core_config a|} ->
@@ -53,14 +53,14 @@ val initialize_communication_proof:
     has_pki_invariant
   )
   (ensures (
-    let (_, tr_out) = initialize_communication a sender receiver tr in
+    let (_, tr_out) = initialize_communication_core a sender receiver tr in
     trace_invariant tr_out
   ))
   [SMTPat (trace_invariant #invs tr);
-   SMTPat (initialize_communication a sender receiver tr);
+   SMTPat (initialize_communication_core a sender receiver tr);
   ]
-let initialize_communication_proof tr a sender receiver =
-  reveal_opaque (`%initialize_communication) (initialize_communication a sender receiver)
+let initialize_communication_core_proof tr a sender receiver =
+  reveal_opaque (`%initialize_communication_core) (initialize_communication_core a sender receiver)
 #pop-options
 
 (**** Confidential Send and Receive Lemmas ****)
@@ -73,7 +73,7 @@ val encrypt_message_proof:
   pk_receiver:bytes -> nonce:bytes -> payload:a ->
   Lemma
   (requires (
-    has_communication_layer_crypto_predicates a /\
+    has_communication_layer_core_crypto_predicates a /\
     is_secret (long_term_key_label sender) tr nonce /\
     nonce `has_usage tr` PkeNonce /\
     is_public_key_for tr pk_receiver (LongTermPkeKey (comm_layer_pkenc_tag a)) receiver /\
@@ -90,20 +90,20 @@ val send_confidential_proof:
   {|invs:protocol_invariants|} ->
   #a:Type0 -> {|comm_layer_core_config a|} ->
   tr:trace ->
-  higher_layer_preds:comm_higher_layer_event_preds a ->
+  higher_layer_preds:comm_core_higher_layer_event_preds a ->
   keys_sess_ids:communication_keys_sess_ids ->
   sender:principal -> receiver:principal -> payload:a ->
   Lemma
   (requires (
     trace_invariant tr /\
     has_pki_invariant /\
-    has_communication_layer_crypto_predicates a /\
-    has_communication_layer_event_predicates a higher_layer_preds /\
+    has_communication_layer_core_crypto_predicates a /\
+    has_communication_layer_core_event_predicates a higher_layer_preds /\
     higher_layer_preds.send_conf tr sender receiver payload /\
     // We only require the payload to flow to the sender and receiver to allow
     // the sender to send a payload readable by other principals. If you want
     // the payload to be only readable by the sender and receiver, you can use
-    // the `comm_higher_layer_event_preds` on the protocol level to enforce
+    // the `comm_core_higher_layer_event_preds` on the protocol level to enforce
     // this. Look into the usage examples of this layer to see how it works.
     is_well_formed a (is_knowable_by (comm_label sender receiver) tr) payload
   ))
@@ -137,7 +137,7 @@ val decrypt_message_proof:
   receiver:principal -> sk_receiver:bytes -> msg_encrypted:bytes ->
   Lemma
   (requires
-    has_communication_layer_crypto_predicates a /\
+    has_communication_layer_core_crypto_predicates a /\
     is_private_key_for tr sk_receiver (LongTermPkeKey (comm_layer_pkenc_tag a)) receiver /\
     bytes_invariant tr msg_encrypted
   )
@@ -169,15 +169,15 @@ val receive_confidential_proof:
   {|invs:protocol_invariants|} ->
   #a:Type0 -> {|comm_layer_core_config a|} ->
   tr:trace ->
-  higher_layer_preds:comm_higher_layer_event_preds a ->
+  higher_layer_preds:comm_core_higher_layer_event_preds a ->
   comm_keys_ids:communication_keys_sess_ids ->
   receiver:principal -> msg_id:timestamp ->
   Lemma
   (requires
     trace_invariant tr /\
     has_private_keys_invariant /\
-    has_communication_layer_crypto_predicates a /\
-    has_communication_layer_event_predicates a higher_layer_preds
+    has_communication_layer_core_crypto_predicates a /\
+    has_communication_layer_core_event_predicates a higher_layer_preds
   )
   (ensures (
     match receive_confidential comm_keys_ids receiver msg_id tr with
@@ -218,7 +218,7 @@ val sign_message_proof:
   (requires (
     (Some? pk_receiver <==> Inr? payload) /\ 
     (None? pk_receiver <==> Inl? payload) /\
-    has_communication_layer_crypto_predicates a /\
+    has_communication_layer_core_crypto_predicates a /\
     is_secret (long_term_key_label sender) tr nonce /\
     nonce `has_usage tr` SigNonce /\
     is_private_key_for tr sk_sender (LongTermSigKey (comm_layer_sign_tag a)) sender /\
@@ -261,15 +261,15 @@ val send_authenticated_proof:
   {|invs:protocol_invariants|} ->
   #a:Type -> {|comm_layer_core_config a|} ->
   tr:trace ->
-  higher_layer_preds:comm_higher_layer_event_preds a ->
+  higher_layer_preds:comm_core_higher_layer_event_preds a ->
   comm_keys_ids:communication_keys_sess_ids ->
   sender:principal -> receiver:principal -> payload:a ->
   Lemma
   (requires
     trace_invariant tr /\
     has_private_keys_invariant /\
-    has_communication_layer_crypto_predicates a /\
-    has_communication_layer_event_predicates a higher_layer_preds /\
+    has_communication_layer_core_crypto_predicates a /\
+    has_communication_layer_core_event_predicates a higher_layer_preds /\
     higher_layer_preds.send_auth tr sender payload /\
     is_well_formed a (is_publishable tr) payload
   )
@@ -308,7 +308,7 @@ val verify_message_proof:
   vk_sender:bytes ->
   Lemma
   (requires
-    has_communication_layer_crypto_predicates a /\
+    has_communication_layer_core_crypto_predicates a /\
     is_publishable tr msg_bytes /\
     is_public_key_for tr vk_sender (LongTermSigKey (comm_layer_sign_tag a)) sender
   )
@@ -369,15 +369,15 @@ val receive_authenticated_proof:
   {|invs:protocol_invariants|} ->
   #a:Type -> {|config:comm_layer_core_config a|} ->
   tr:trace ->
-  higher_layer_preds:comm_higher_layer_event_preds a ->
+  higher_layer_preds:comm_core_higher_layer_event_preds a ->
   comm_keys_ids:communication_keys_sess_ids ->
   receiver:principal -> msg_id:timestamp ->
   Lemma
   (requires
     trace_invariant tr /\
     has_pki_invariant /\
-    has_communication_layer_crypto_predicates a /\
-    has_communication_layer_event_predicates a higher_layer_preds
+    has_communication_layer_core_crypto_predicates a /\
+    has_communication_layer_core_event_predicates a higher_layer_preds
   )
   (ensures (
     match receive_authenticated comm_keys_ids receiver msg_id tr with
@@ -421,7 +421,7 @@ val encrypt_and_sign_message_proof:
   pk_receiver:bytes -> sk_sender:bytes -> enc_nonce:bytes -> sign_nonce:bytes ->
   Lemma
   (requires
-    has_communication_layer_crypto_predicates a /\
+    has_communication_layer_core_crypto_predicates a /\
     is_secret (long_term_key_label sender) tr enc_nonce /\
     is_secret (long_term_key_label sender) tr sign_nonce /\
     enc_nonce `has_usage tr` PkeNonce /\
@@ -447,7 +447,7 @@ val send_confidential_authenticated_proof:
   {|protocol_invariants|} ->
   #a:Type0 -> {|comm_layer_core_config a|}  ->
   tr:trace ->
-  higher_layer_preds:comm_higher_layer_event_preds a ->
+  higher_layer_preds:comm_core_higher_layer_event_preds a ->
   comm_keys_ids:communication_keys_sess_ids ->
   sender:principal -> receiver:principal -> payload:a ->
   Lemma
@@ -455,8 +455,8 @@ val send_confidential_authenticated_proof:
     trace_invariant tr /\
     has_private_keys_invariant /\
     has_pki_invariant /\
-    has_communication_layer_crypto_predicates a /\
-    has_communication_layer_event_predicates a higher_layer_preds /\
+    has_communication_layer_core_crypto_predicates a /\
+    has_communication_layer_core_event_predicates a higher_layer_preds /\
     higher_layer_preds.send_conf tr sender receiver payload /\
     higher_layer_preds.send_conf_auth tr sender receiver payload /\
     is_well_formed a (is_knowable_by (join (principal_label sender) (principal_label receiver)) tr) payload
@@ -505,7 +505,7 @@ val verify_and_decrypt_message_proof:
   sk_receiver:bytes -> vk_sender:bytes ->
   Lemma
   (requires
-    has_communication_layer_crypto_predicates a /\
+    has_communication_layer_core_crypto_predicates a /\
     is_publishable tr msg_encrypted_signed /\
     is_private_key_for tr sk_receiver (LongTermPkeKey (comm_layer_pkenc_tag a)) receiver /\
     is_public_key_for tr vk_sender (LongTermSigKey (comm_layer_sign_tag a)) sender
@@ -560,7 +560,7 @@ val receive_confidential_authenticated_proof:
   {|invs:protocol_invariants|} ->
   #a:Type -> {|comm_layer_core_config a|} ->
   tr:trace ->
-  higher_layer_preds:comm_higher_layer_event_preds a ->
+  higher_layer_preds:comm_core_higher_layer_event_preds a ->
   comm_keys_ids:communication_keys_sess_ids ->
   receiver:principal -> msg_id:timestamp ->
   Lemma
@@ -568,8 +568,8 @@ val receive_confidential_authenticated_proof:
     trace_invariant tr /\
     has_private_keys_invariant /\
     has_pki_invariant /\
-    has_communication_layer_crypto_predicates a /\
-    has_communication_layer_event_predicates a higher_layer_preds
+    has_communication_layer_core_crypto_predicates a /\
+    has_communication_layer_core_event_predicates a higher_layer_preds
   )
   (ensures
     (

--- a/src/lib/communication/DY.Lib.Communication.Core.Properties.fst
+++ b/src/lib/communication/DY.Lib.Communication.Core.Properties.fst
@@ -22,7 +22,7 @@ open DY.Lib.Communication.Core.Lemmas
 (*** Confidential Messages Properties ***)
 
 val conf_message_secrecy:
-  {|comm_layer_event_core_tag|} ->
+  {|comm_layer_core_tag|} ->
   {|protocol_invariants|} ->
   #a:Type -> {| parseable_serializeable bytes a |} ->
   tr:trace -> i:timestamp ->
@@ -43,7 +43,7 @@ val conf_message_secrecy:
       is_well_formed a (is_publishable (prefix tr i)) payload_parsed
     ) payload
   )
-let conf_message_secrecy #event_tag #invs #a tr i higher_layer_preds receiver payload =
+let conf_message_secrecy #tag #invs #a tr i higher_layer_preds receiver payload =
   let send_event sender = CommConfSendMsg sender receiver payload in
   let tr_i = prefix tr i in
   eliminate (exists sender. event_triggered tr_i sender (send_event sender)) \/
@@ -69,7 +69,7 @@ let conf_message_secrecy #event_tag #invs #a tr i higher_layer_preds receiver pa
 (*** Authenticated Messages Properties ***)
 
 val sender_authentication:
-  {|comm_layer_event_core_tag|} ->
+  {|comm_layer_core_tag|} ->
   {|protocol_invariants|} ->
   #a:Type -> {| parseable_serializeable bytes a |} ->
   tr:trace -> i:timestamp ->
@@ -86,13 +86,13 @@ val sender_authentication:
     event_triggered (prefix tr i) sender (CommAuthSendMsg sender payload) \/
     is_corrupt (prefix tr i) (long_term_key_label sender)
   )
-let sender_authentication #event_tag #invs #a tr i higher_layer_preds sender receiver secret = ()
+let sender_authentication #tag #invs #a tr i higher_layer_preds sender receiver secret = ()
 
 
 (*** Confidential and Authenticated Messages Properties ***)
 
 val sender_confauth_authentication:
-  {|comm_layer_event_core_tag|} ->
+  {|comm_layer_core_tag|} ->
   {|protocol_invariants|} ->
   #a:Type -> {| parseable_serializeable bytes a |} ->
   tr:trace -> i:timestamp ->
@@ -109,4 +109,4 @@ val sender_confauth_authentication:
     event_triggered (prefix tr i) sender (CommConfAuthSendMsg sender receiver payload) \/
     is_corrupt (prefix tr i) (long_term_key_label sender)
   )
-let sender_confauth_authentication #event_tag #invs #a tr i higher_layer_preds sender receiver secret = ()
+let sender_confauth_authentication #tag #invs #a tr i higher_layer_preds sender receiver secret = ()

--- a/src/lib/communication/DY.Lib.Communication.Core.Properties.fst
+++ b/src/lib/communication/DY.Lib.Communication.Core.Properties.fst
@@ -22,6 +22,7 @@ open DY.Lib.Communication.Core.Lemmas
 (*** Confidential Messages Properties ***)
 
 val conf_message_secrecy:
+  {|comm_layer_event_core_tag|} ->
   {|protocol_invariants|} ->
   #a:Type -> {| parseable_serializeable bytes a |} ->
   tr:trace -> i:timestamp ->
@@ -42,7 +43,7 @@ val conf_message_secrecy:
       is_well_formed a (is_publishable (prefix tr i)) payload_parsed
     ) payload
   )
-let conf_message_secrecy #invs #a tr i higher_layer_preds receiver payload =
+let conf_message_secrecy #event_tag #invs #a tr i higher_layer_preds receiver payload =
   let send_event sender = CommConfSendMsg sender receiver payload in
   let tr_i = prefix tr i in
   eliminate (exists sender. event_triggered tr_i sender (send_event sender)) \/
@@ -68,6 +69,7 @@ let conf_message_secrecy #invs #a tr i higher_layer_preds receiver payload =
 (*** Authenticated Messages Properties ***)
 
 val sender_authentication:
+  {|comm_layer_event_core_tag|} ->
   {|protocol_invariants|} ->
   #a:Type -> {| parseable_serializeable bytes a |} ->
   tr:trace -> i:timestamp ->
@@ -84,12 +86,13 @@ val sender_authentication:
     event_triggered (prefix tr i) sender (CommAuthSendMsg sender payload) \/
     is_corrupt (prefix tr i) (long_term_key_label sender)
   )
-let sender_authentication #invs #a tr i higher_layer_preds sender receiver secret = ()
+let sender_authentication #event_tag #invs #a tr i higher_layer_preds sender receiver secret = ()
 
 
 (*** Confidential and Authenticated Messages Properties ***)
 
 val sender_confauth_authentication:
+  {|comm_layer_event_core_tag|} ->
   {|protocol_invariants|} ->
   #a:Type -> {| parseable_serializeable bytes a |} ->
   tr:trace -> i:timestamp ->
@@ -106,4 +109,4 @@ val sender_confauth_authentication:
     event_triggered (prefix tr i) sender (CommConfAuthSendMsg sender receiver payload) \/
     is_corrupt (prefix tr i) (long_term_key_label sender)
   )
-let sender_confauth_authentication #invs #a tr i higher_layer_preds sender receiver secret = ()
+let sender_confauth_authentication #event_tag #invs #a tr i higher_layer_preds sender receiver secret = ()

--- a/src/lib/communication/DY.Lib.Communication.Core.Properties.fst
+++ b/src/lib/communication/DY.Lib.Communication.Core.Properties.fst
@@ -10,6 +10,7 @@ open DY.Lib.State.PrivateKeys
 open DY.Lib.State.Typed
 open DY.Lib.Comparse.DYUtils
 
+open DY.Lib.Communication.Data
 open DY.Lib.Communication.Core
 open DY.Lib.Communication.Core.Invariants
 open DY.Lib.Communication.Core.Lemmas
@@ -31,7 +32,7 @@ val conf_message_secrecy:
   Lemma
   (requires
     trace_invariant tr /\
-    has_communication_layer_core_event_predicates a higher_layer_preds /\
+    has_communication_layer_core_predicates higher_layer_preds /\
     event_triggered_at tr i receiver (CommConfReceiveMsg receiver payload <: communication_core_event a)
   )
   (ensures
@@ -72,7 +73,7 @@ val sender_authentication:
   Lemma
   (requires
     trace_invariant tr /\
-    has_communication_layer_core_event_predicates a higher_layer_preds /\
+    has_communication_layer_core_predicates higher_layer_preds /\
     event_triggered_at tr i receiver (CommAuthReceiveMsg sender receiver payload <: communication_core_event a)
   )
   (ensures
@@ -94,7 +95,7 @@ val sender_confauth_authentication:
   Lemma
   (requires
     trace_invariant tr /\
-    has_communication_layer_core_event_predicates a higher_layer_preds /\
+    has_communication_layer_core_predicates higher_layer_preds /\
     event_triggered_at tr i receiver (CommConfAuthReceiveMsg sender receiver payload <: communication_core_event a)
   )
   (ensures

--- a/src/lib/communication/DY.Lib.Communication.Core.Properties.fst
+++ b/src/lib/communication/DY.Lib.Communication.Core.Properties.fst
@@ -25,7 +25,7 @@ open DY.Lib.Communication.Core.Lemmas
 val conf_message_secrecy:
   {|protocol_invariants|} ->
   #a:Type -> {|comm_layer_core_config a|} ->
-  tr:trace -> i:timestamp ->
+  tr:trace ->
   higher_layer_preds:comm_core_higher_layer_event_preds a ->
   receiver:principal ->
   payload:a ->
@@ -33,29 +33,30 @@ val conf_message_secrecy:
   (requires
     trace_invariant tr /\
     has_communication_layer_core_predicates higher_layer_preds /\
-    event_triggered_at tr i receiver (CommConfReceiveMsg receiver payload <: communication_core_event a)
+    event_triggered tr receiver (CommConfReceiveMsg receiver payload <: communication_core_event a)
   )
   (ensures
-    is_well_formed a (is_knowable_by (principal_label receiver) (prefix tr i)) payload /\
-    ((exists sender. higher_layer_preds.send_conf (prefix tr i) sender receiver payload) \/
-    is_well_formed a (is_publishable (prefix tr i)) payload)
+    is_well_formed a (is_knowable_by (principal_label receiver) tr) payload /\
+    ((exists sender. higher_layer_preds.send_conf tr sender receiver payload) \/
+    is_well_formed a (is_publishable tr) payload)
   )
-let conf_message_secrecy #invs #a tr i higher_layer_preds receiver payload =
+let conf_message_secrecy #invs #a tr higher_layer_preds receiver payload =
   let send_event sender:communication_core_event a = CommConfSendMsg sender receiver payload in
+  let i = find_event_triggered_at_timestamp tr receiver (CommConfReceiveMsg receiver payload <: communication_core_event a) in
   let tr_i = prefix tr i in
   eliminate (exists sender. event_triggered tr_i sender (send_event sender)) \/
             is_well_formed a (is_publishable tr_i) payload
   returns
-    is_well_formed a (is_knowable_by (principal_label receiver) tr_i) payload /\
-    ((exists sender. higher_layer_preds.send_conf (prefix tr i) sender receiver payload) \/
-    is_well_formed a (is_publishable (prefix tr i)) payload)
+    is_well_formed a (is_knowable_by (principal_label receiver) tr) payload /\
+    ((exists sender. higher_layer_preds.send_conf tr sender receiver payload) \/
+    is_well_formed a (is_publishable tr) payload)
   with _. eliminate exists sender. event_triggered tr_i sender (send_event sender)
     returns _
     with _. (
       let j = find_event_triggered_at_timestamp tr sender (send_event sender) in
       find_event_triggered_at_timestamp_later tr_i tr sender (send_event sender);
 
-      higher_layer_preds.send_conf_later (prefix tr j) tr_i sender receiver payload;
+      higher_layer_preds.send_conf_later (prefix tr j) tr sender receiver payload;
       ()
     )
   and _. ()

--- a/src/lib/communication/DY.Lib.Communication.Core.Properties.fst
+++ b/src/lib/communication/DY.Lib.Communication.Core.Properties.fst
@@ -22,68 +22,61 @@ open DY.Lib.Communication.Core.Lemmas
 (*** Confidential Messages Properties ***)
 
 val conf_message_secrecy:
-  {|comm_layer_core_tag|} ->
   {|protocol_invariants|} ->
-  #a:Type -> {| parseable_serializeable bytes a |} ->
+  #a:Type -> {|comm_layer_core_config a|} ->
   tr:trace -> i:timestamp ->
   higher_layer_preds:comm_higher_layer_event_preds a ->
   receiver:principal ->
-  payload:bytes ->
+  payload:a ->
   Lemma
   (requires
     trace_invariant tr /\
-    has_communication_layer_event_predicates higher_layer_preds /\
-    event_triggered_at tr i receiver (CommConfReceiveMsg receiver payload)
+    has_communication_layer_event_predicates a higher_layer_preds /\
+    event_triggered_at tr i receiver (CommConfReceiveMsg receiver payload <: communication_core_event a)
   )
   (ensures
-    is_knowable_by (principal_label receiver) (prefix tr i) payload /\
-
-    parse_and_pred (fun payload_parsed ->
-      (exists sender. higher_layer_preds.send_conf (prefix tr i) sender receiver payload_parsed) \/
-      is_well_formed a (is_publishable (prefix tr i)) payload_parsed
-    ) payload
+    is_well_formed a (is_knowable_by (principal_label receiver) (prefix tr i)) payload /\
+    ((exists sender. higher_layer_preds.send_conf (prefix tr i) sender receiver payload) \/
+    is_well_formed a (is_publishable (prefix tr i)) payload)
   )
-let conf_message_secrecy #tag #invs #a tr i higher_layer_preds receiver payload =
-  let send_event sender = CommConfSendMsg sender receiver payload in
+let conf_message_secrecy #invs #a tr i higher_layer_preds receiver payload =
+  let send_event sender:communication_core_event a = CommConfSendMsg sender receiver payload in
   let tr_i = prefix tr i in
   eliminate (exists sender. event_triggered tr_i sender (send_event sender)) \/
-            is_publishable tr_i payload
+            is_well_formed a (is_publishable tr_i) payload
   returns
-    is_knowable_by (principal_label receiver) tr_i payload /\
-    parse_and_pred (fun payload_parsed ->
-      (exists sender. higher_layer_preds.send_conf (prefix tr i) sender receiver payload_parsed) \/
-      is_well_formed a (is_publishable (prefix tr i)) payload_parsed
-    ) payload
+    is_well_formed a (is_knowable_by (principal_label receiver) tr_i) payload /\
+    ((exists sender. higher_layer_preds.send_conf (prefix tr i) sender receiver payload) \/
+    is_well_formed a (is_publishable (prefix tr i)) payload)
   with _. eliminate exists sender. event_triggered tr_i sender (send_event sender)
     returns _
     with _. (
       let j = find_event_triggered_at_timestamp tr sender (send_event sender) in
       find_event_triggered_at_timestamp_later tr_i tr sender (send_event sender);
 
-      serialize_parse_inv_lemma a payload;
-      higher_layer_preds.send_conf_later (prefix tr j) tr_i sender receiver (Some?.v (parse a payload))
+      higher_layer_preds.send_conf_later (prefix tr j) tr_i sender receiver payload;
+      ()
     )
-  and _. parse_wf_lemma a (is_publishable (prefix tr i)) payload
+  and _. ()
 
 
 (*** Authenticated Messages Properties ***)
 
 val sender_authentication:
-  {|comm_layer_core_tag|} ->
   {|protocol_invariants|} ->
-  #a:Type -> {| parseable_serializeable bytes a |} ->
+  #a:Type -> {|comm_layer_core_config a|} ->
   tr:trace -> i:timestamp ->
   higher_layer_preds:comm_higher_layer_event_preds a ->
   sender:principal -> receiver:principal ->
-  payload:bytes ->
+  payload:a ->
   Lemma
   (requires
     trace_invariant tr /\
-    has_communication_layer_event_predicates higher_layer_preds /\
-    event_triggered_at tr i receiver (CommAuthReceiveMsg sender receiver payload)
+    has_communication_layer_event_predicates a higher_layer_preds /\
+    event_triggered_at tr i receiver (CommAuthReceiveMsg sender receiver payload <: communication_core_event a)
   )
   (ensures
-    event_triggered (prefix tr i) sender (CommAuthSendMsg sender payload) \/
+    event_triggered (prefix tr i) sender (CommAuthSendMsg sender payload <: communication_core_event a) \/
     is_corrupt (prefix tr i) (long_term_key_label sender)
   )
 let sender_authentication #tag #invs #a tr i higher_layer_preds sender receiver secret = ()
@@ -92,21 +85,20 @@ let sender_authentication #tag #invs #a tr i higher_layer_preds sender receiver 
 (*** Confidential and Authenticated Messages Properties ***)
 
 val sender_confauth_authentication:
-  {|comm_layer_core_tag|} ->
   {|protocol_invariants|} ->
-  #a:Type -> {| parseable_serializeable bytes a |} ->
+  #a:Type -> {|comm_layer_core_config a|} ->
   tr:trace -> i:timestamp ->
   higher_layer_preds:comm_higher_layer_event_preds a ->
   sender:principal -> receiver:principal ->
-  payload:bytes ->
+  payload:a ->
   Lemma
   (requires
     trace_invariant tr /\
-    has_communication_layer_event_predicates higher_layer_preds /\
-    event_triggered_at tr i receiver (CommConfAuthReceiveMsg sender receiver payload)
+    has_communication_layer_event_predicates a higher_layer_preds /\
+    event_triggered_at tr i receiver (CommConfAuthReceiveMsg sender receiver payload <: communication_core_event a)
   )
   (ensures
-    event_triggered (prefix tr i) sender (CommConfAuthSendMsg sender receiver payload) \/
+    event_triggered (prefix tr i) sender (CommConfAuthSendMsg sender receiver payload <: communication_core_event a) \/
     is_corrupt (prefix tr i) (long_term_key_label sender)
   )
 let sender_confauth_authentication #tag #invs #a tr i higher_layer_preds sender receiver secret = ()

--- a/src/lib/communication/DY.Lib.Communication.Core.Properties.fst
+++ b/src/lib/communication/DY.Lib.Communication.Core.Properties.fst
@@ -77,7 +77,7 @@ val sender_authentication:
     event_triggered_at tr i receiver (CommAuthReceiveMsg sender receiver payload <: communication_core_event a)
   )
   (ensures
-    event_triggered (prefix tr i) sender (CommAuthSendMsg sender payload <: communication_core_event a) \/
+    comm_auth_send_event_triggered #a (prefix tr i) sender payload \/
     is_corrupt (prefix tr i) (long_term_key_label sender)
   )
 let sender_authentication #tag #invs #a tr i higher_layer_preds sender receiver secret = ()
@@ -99,7 +99,7 @@ val sender_confauth_authentication:
     event_triggered_at tr i receiver (CommConfAuthReceiveMsg sender receiver payload <: communication_core_event a)
   )
   (ensures
-    event_triggered (prefix tr i) sender (CommConfAuthSendMsg sender receiver payload <: communication_core_event a) \/
+    comm_conf_auth_send_event_triggered #a (prefix tr i) sender receiver payload \/
     is_corrupt (prefix tr i) (long_term_key_label sender)
   )
 let sender_confauth_authentication #tag #invs #a tr i higher_layer_preds sender receiver secret = ()

--- a/src/lib/communication/DY.Lib.Communication.Core.Properties.fst
+++ b/src/lib/communication/DY.Lib.Communication.Core.Properties.fst
@@ -25,13 +25,13 @@ val conf_message_secrecy:
   {|protocol_invariants|} ->
   #a:Type -> {|comm_layer_core_config a|} ->
   tr:trace -> i:timestamp ->
-  higher_layer_preds:comm_higher_layer_event_preds a ->
+  higher_layer_preds:comm_core_higher_layer_event_preds a ->
   receiver:principal ->
   payload:a ->
   Lemma
   (requires
     trace_invariant tr /\
-    has_communication_layer_event_predicates a higher_layer_preds /\
+    has_communication_layer_core_event_predicates a higher_layer_preds /\
     event_triggered_at tr i receiver (CommConfReceiveMsg receiver payload <: communication_core_event a)
   )
   (ensures
@@ -66,13 +66,13 @@ val sender_authentication:
   {|protocol_invariants|} ->
   #a:Type -> {|comm_layer_core_config a|} ->
   tr:trace -> i:timestamp ->
-  higher_layer_preds:comm_higher_layer_event_preds a ->
+  higher_layer_preds:comm_core_higher_layer_event_preds a ->
   sender:principal -> receiver:principal ->
   payload:a ->
   Lemma
   (requires
     trace_invariant tr /\
-    has_communication_layer_event_predicates a higher_layer_preds /\
+    has_communication_layer_core_event_predicates a higher_layer_preds /\
     event_triggered_at tr i receiver (CommAuthReceiveMsg sender receiver payload <: communication_core_event a)
   )
   (ensures
@@ -88,13 +88,13 @@ val sender_confauth_authentication:
   {|protocol_invariants|} ->
   #a:Type -> {|comm_layer_core_config a|} ->
   tr:trace -> i:timestamp ->
-  higher_layer_preds:comm_higher_layer_event_preds a ->
+  higher_layer_preds:comm_core_higher_layer_event_preds a ->
   sender:principal -> receiver:principal ->
   payload:a ->
   Lemma
   (requires
     trace_invariant tr /\
-    has_communication_layer_event_predicates a higher_layer_preds /\
+    has_communication_layer_core_event_predicates a higher_layer_preds /\
     event_triggered_at tr i receiver (CommConfAuthReceiveMsg sender receiver payload <: communication_core_event a)
   )
   (ensures

--- a/src/lib/communication/DY.Lib.Communication.Core.fst
+++ b/src/lib/communication/DY.Lib.Communication.Core.fst
@@ -13,11 +13,15 @@ open DY.Lib.Communication.Data
 
 (*** Layer Setup ***)
 
-val comm_layer_pkenc_tag: string
-let comm_layer_pkenc_tag = "DY.Lib.Communication.PkEnc.PublicKey"
+class comm_layer_core_tag = {
+  tag: string;
+}
 
-val comm_layer_sign_tag: string
-let comm_layer_sign_tag = "DY.Lib.Communication.Sign.PublicKey"
+val comm_layer_pkenc_tag: {|comm_layer_core_tag|} -> string
+let comm_layer_pkenc_tag #tag = tag.tag ^ ".PkEnc.PublicKey"
+
+val comm_layer_sign_tag: {|comm_layer_core_tag|} -> string
+let comm_layer_sign_tag #tag = tag.tag ^ ".Sign.PublicKey"
 
 type communication_keys_sess_ids = {
   pki: state_id;
@@ -45,11 +49,7 @@ type communication_event =
 %splice [ps_communication_event_is_well_formed] (gen_is_well_formed_lemma (`communication_event))
 #pop-options
 
-class comm_layer_event_core_tag = {
-  tag: string;
-}
-
-instance event_communication_event {|t:comm_layer_event_core_tag|}: event communication_event = {
+instance event_communication_event {|t:comm_layer_core_tag|}: event communication_event = {
   tag = t.tag;
   format = mk_parseable_serializeable ps_communication_event;
 }
@@ -68,12 +68,12 @@ let encrypt_message #a pk_receiver nonce payload =
 
 [@@ "opaque_to_smt"]
 val send_confidential:
-  {|comm_layer_event_core_tag|} ->
+  {|comm_layer_core_tag|} ->
   #a:Type0 -> {| parseable_serializeable bytes a |} ->
   communication_keys_sess_ids ->
   principal -> principal -> a ->
   traceful (option timestamp)
-let send_confidential #event_tag #a comm_keys_ids sender receiver payload =
+let send_confidential #tag #a comm_keys_ids sender receiver payload =
   let*? pk_receiver = get_public_key sender comm_keys_ids.pki (LongTermPkeKey comm_layer_pkenc_tag) receiver in
   let* nonce = mk_rand PkeNonce (long_term_key_label sender) 32 in
   trigger_event sender (CommConfSendMsg sender receiver (serialize a payload));*
@@ -91,12 +91,12 @@ let decrypt_message #a sk_receiver msg_encrypted =
 
 [@@ "opaque_to_smt"]
 val receive_confidential:
-  {|comm_layer_event_core_tag|} ->
+  {|comm_layer_core_tag|} ->
   #a:Type -> {| parseable_serializeable bytes a |} ->
   communication_keys_sess_ids ->
   principal -> timestamp ->
   traceful (option a)
-let receive_confidential #event_tag #a comm_keys_ids receiver msg_id =
+let receive_confidential #tag #a comm_keys_ids receiver msg_id =
   let*? sk_receiver = get_private_key receiver comm_keys_ids.private_keys (LongTermPkeKey comm_layer_pkenc_tag) in
   let*? msg_encrypted = recv_msg msg_id in
   let*? payload = return (decrypt_message #a sk_receiver msg_encrypted) in
@@ -126,12 +126,12 @@ let sign_message #a sender receiver payload pk_receiver sk nonce =
 
 [@@ "opaque_to_smt"]
 val send_authenticated:
-  {|comm_layer_event_core_tag|} ->
+  {|comm_layer_core_tag|} ->
   #a:Type -> {| parseable_serializeable bytes a |} ->
   communication_keys_sess_ids ->
   principal -> principal -> a ->
   traceful (option timestamp)
-let send_authenticated #event_tag #a comm_keys_ids sender receiver payload =
+let send_authenticated #tag #a comm_keys_ids sender receiver payload =
   let*? sk_sender = get_private_key sender comm_keys_ids.private_keys (LongTermSigKey comm_layer_sign_tag) in
   let* nonce = mk_rand SigNonce (long_term_key_label sender) 32 in
   let payload_bytes = serialize a payload in
@@ -178,12 +178,12 @@ let get_sender sign_msg_bytes =
 
 [@@ "opaque_to_smt"]
 val receive_authenticated:
-  {|comm_layer_event_core_tag|} ->
+  {|comm_layer_core_tag|} ->
   #a:Type -> {| parseable_serializeable bytes a |} ->
   communication_keys_sess_ids ->
   principal -> timestamp ->
   traceful (option (communication_message a))
-let receive_authenticated #event_tag #a comm_keys_ids receiver msg_id =
+let receive_authenticated #tag #a comm_keys_ids receiver msg_id =
   let*? msg_signed_bytes = recv_msg msg_id in
   let*? sender = return (get_sender msg_signed_bytes) in
   let*? vk_sender = get_public_key receiver comm_keys_ids.pki (LongTermSigKey comm_layer_sign_tag) sender in
@@ -208,12 +208,12 @@ let encrypt_and_sign_message #a sender receiver payload pk_receiver sk_sender en
 // to create and parse confidential and authenticated messages.
 [@@ "opaque_to_smt"]
 val send_confidential_authenticated:
-  {|comm_layer_event_core_tag|} ->
+  {|comm_layer_core_tag|} ->
   #a:Type -> {| parseable_serializeable bytes a |} ->
   communication_keys_sess_ids ->
   principal -> principal -> a ->
   traceful (option timestamp)
-let send_confidential_authenticated #event_tag #a comm_keys_ids sender receiver payload =
+let send_confidential_authenticated #tag #a comm_keys_ids sender receiver payload =
   let*? pk_receiver = get_public_key sender comm_keys_ids.pki (LongTermPkeKey comm_layer_pkenc_tag) receiver in
   let*? sk_sender = get_private_key sender comm_keys_ids.private_keys (LongTermSigKey comm_layer_sign_tag) in
   let* enc_nonce = mk_rand PkeNonce (long_term_key_label sender) 32 in
@@ -235,12 +235,12 @@ let verify_and_decrypt_message #a #ps receiver sk_receiver vk_sender msg_encrypt
 
 [@@ "opaque_to_smt"]
 val receive_confidential_authenticated:
-  {|comm_layer_event_core_tag|} ->
+  {|comm_layer_core_tag|} ->
   #a:Type -> {| parseable_serializeable bytes a |} ->
   communication_keys_sess_ids ->
   principal -> timestamp ->
   traceful (option (communication_message a))
-let receive_confidential_authenticated #event_tag #a comm_keys_ids receiver msg_id =
+let receive_confidential_authenticated #tag #a comm_keys_ids receiver msg_id =
   let*? msg_encrypted_signed = recv_msg msg_id in
   let*? sk_receiver = get_private_key receiver comm_keys_ids.private_keys (LongTermPkeKey comm_layer_pkenc_tag) in
   let*? sender = return (get_sender msg_encrypted_signed) in
@@ -253,8 +253,8 @@ let receive_confidential_authenticated #event_tag #a comm_keys_ids receiver msg_
 (**** Layer Initialization ****)
 
 [@@ "opaque_to_smt"]
-val initialize_communication: principal -> principal -> traceful (option (communication_keys_sess_ids & communication_keys_sess_ids))
-let initialize_communication sender receiver =
+val initialize_communication: {|comm_layer_core_tag|} -> principal -> principal -> traceful (option (communication_keys_sess_ids & communication_keys_sess_ids))
+let initialize_communication #tag sender receiver =
   // Initialize keys for public key encryption
   let* client_global_session_priv_key_id = initialize_private_keys sender in
   generate_private_key sender client_global_session_priv_key_id (LongTermPkeKey comm_layer_pkenc_tag);*

--- a/src/lib/communication/DY.Lib.Communication.Core.fst
+++ b/src/lib/communication/DY.Lib.Communication.Core.fst
@@ -13,15 +13,19 @@ open DY.Lib.Communication.Data
 
 (*** Layer Setup ***)
 
-class comm_layer_core_tag = {
+class comm_layer_core_config (a:Type) = {
   tag: string;
+  ps_a: parser_serializer bytes a;
 }
 
-val comm_layer_pkenc_tag: {|comm_layer_core_tag|} -> string
-let comm_layer_pkenc_tag #tag = tag.tag ^ ".PkEnc.PublicKey"
+instance parseable_serializeable_bytes_a (#a:Type) {|c:comm_layer_core_config a|}: parseable_serializeable bytes a =
+  mk_parseable_serializeable c.ps_a
 
-val comm_layer_sign_tag: {|comm_layer_core_tag|} -> string
-let comm_layer_sign_tag #tag = tag.tag ^ ".Sign.PublicKey"
+val comm_layer_pkenc_tag: (a:Type) -> {|comm_layer_core_config a|} -> string
+let comm_layer_pkenc_tag a #config = config.tag ^ ".PkEnc.PublicKey"
+
+val comm_layer_sign_tag: (a:Type) -> {|comm_layer_core_config a|} -> string
+let comm_layer_sign_tag a #config = config.tag ^ ".Sign.PublicKey"
 
 type communication_keys_sess_ids = {
   pki: state_id;
@@ -35,23 +39,23 @@ let comm_label sender receiver = join (principal_label sender) (principal_label 
 (*** Events ***)
 
 [@@with_bytes bytes]
-type communication_event =
-  | CommConfSendMsg: sender:principal -> receiver:principal -> payload:bytes -> communication_event
-  | CommConfReceiveMsg: receiver:principal -> payload:bytes -> communication_event
-  | CommAuthSendMsg: sender:principal -> payload:bytes -> communication_event
-  | CommAuthReceiveMsg: sender:principal -> receiver:principal -> payload:bytes -> communication_event
-  | CommConfAuthSendMsg: sender:principal -> receiver:principal -> payload:bytes -> communication_event
-  | CommConfAuthReceiveMsg: sender:principal -> receiver:principal -> payload:bytes -> communication_event
+type communication_core_event (a:Type) {|config:comm_layer_core_config a|} =
+  | CommConfSendMsg: sender:principal -> receiver:principal -> [@@@ with_parser #bytes config.ps_a] payload:a -> communication_core_event a
+  | CommConfReceiveMsg: receiver:principal -> [@@@ with_parser #bytes config.ps_a] payload:a -> communication_core_event a
+  | CommAuthSendMsg: sender:principal -> [@@@ with_parser #bytes config.ps_a] payload:a -> communication_core_event a
+  | CommAuthReceiveMsg: sender:principal -> receiver:principal -> [@@@ with_parser #bytes config.ps_a] payload:a -> communication_core_event a
+  | CommConfAuthSendMsg: sender:principal -> receiver:principal -> [@@@ with_parser #bytes config.ps_a] payload:a -> communication_core_event a
+  | CommConfAuthReceiveMsg: sender:principal -> receiver:principal -> [@@@ with_parser #bytes config.ps_a] payload:a -> communication_core_event a
   
 
 #push-options "--ifuel 1 --fuel 0"
-%splice [ps_communication_event] (gen_parser (`communication_event))
-%splice [ps_communication_event_is_well_formed] (gen_is_well_formed_lemma (`communication_event))
+%splice [ps_communication_core_event] (gen_parser (`communication_core_event))
+%splice [ps_communication_core_event_is_well_formed] (gen_is_well_formed_lemma (`communication_core_event))
 #pop-options
 
-instance event_communication_event {|t:comm_layer_core_tag|}: event communication_event = {
-  tag = t.tag;
-  format = mk_parseable_serializeable ps_communication_event;
+instance event_communication_core_event (a:Type) {|config:comm_layer_core_config a|}: event (communication_core_event a) = {
+  tag = config.tag ^ ".Event";
+  format = mk_parseable_serializeable (ps_communication_core_event a);
 }
 
 
@@ -61,29 +65,28 @@ instance event_communication_event {|t:comm_layer_core_tag|}: event communicatio
 
 [@@ "opaque_to_smt"]
 val encrypt_message:
-  #a:Type -> {| parseable_serializeable bytes a |} ->
+  #a:Type -> {|comm_layer_core_config a|} ->
   bytes -> bytes -> a -> bytes
 let encrypt_message #a pk_receiver nonce payload =
   pke_enc pk_receiver nonce (serialize a payload)
 
 [@@ "opaque_to_smt"]
 val send_confidential:
-  {|comm_layer_core_tag|} ->
-  #a:Type0 -> {| parseable_serializeable bytes a |} ->
+  #a:Type0 -> {|comm_layer_core_config a|} ->
   communication_keys_sess_ids ->
   principal -> principal -> a ->
   traceful (option timestamp)
-let send_confidential #tag #a comm_keys_ids sender receiver payload =
-  let*? pk_receiver = get_public_key sender comm_keys_ids.pki (LongTermPkeKey comm_layer_pkenc_tag) receiver in
+let send_confidential #a comm_keys_ids sender receiver payload =
+  let*? pk_receiver = get_public_key sender comm_keys_ids.pki (LongTermPkeKey (comm_layer_pkenc_tag a)) receiver in
   let* nonce = mk_rand PkeNonce (long_term_key_label sender) 32 in
-  trigger_event sender (CommConfSendMsg sender receiver (serialize a payload));*
+  trigger_event sender (CommConfSendMsg sender receiver payload <: communication_core_event a);*
   let msg_encrypted = encrypt_message pk_receiver nonce payload in
   let* msg_id = send_msg msg_encrypted in
   return (Some msg_id)
 
 [@@ "opaque_to_smt"]
 val decrypt_message:
-  #a:Type -> {| parseable_serializeable bytes a |} ->
+  #a:Type0 -> {|comm_layer_core_config a|}  ->
   bytes -> bytes -> option a
 let decrypt_message #a sk_receiver msg_encrypted =
   let? plaintext = pke_dec sk_receiver msg_encrypted in
@@ -91,83 +94,76 @@ let decrypt_message #a sk_receiver msg_encrypted =
 
 [@@ "opaque_to_smt"]
 val receive_confidential:
-  {|comm_layer_core_tag|} ->
-  #a:Type -> {| parseable_serializeable bytes a |} ->
+  #a:Type0 -> {|comm_layer_core_config a|}  ->
   communication_keys_sess_ids ->
   principal -> timestamp ->
   traceful (option a)
-let receive_confidential #tag #a comm_keys_ids receiver msg_id =
-  let*? sk_receiver = get_private_key receiver comm_keys_ids.private_keys (LongTermPkeKey comm_layer_pkenc_tag) in
+let receive_confidential #a comm_keys_ids receiver msg_id =
+  let*? sk_receiver = get_private_key receiver comm_keys_ids.private_keys (LongTermPkeKey (comm_layer_pkenc_tag a)) in
   let*? msg_encrypted = recv_msg msg_id in
-  let*? payload = return (decrypt_message #a sk_receiver msg_encrypted) in
-  trigger_event receiver (CommConfReceiveMsg receiver (serialize a payload));*
+  let*? payload = return (decrypt_message sk_receiver msg_encrypted) in
+  trigger_event receiver (CommConfReceiveMsg receiver payload <: communication_core_event a);*
   return (Some payload)
 
 
 (**** Authenticated Send and Receive Functions ****)
 
-#push-options "--ifuel 1"
 [@@ "opaque_to_smt"]
 val sign_message:
-  #a:Type -> {| parseable_serializeable bytes a |} ->
-  principal -> principal -> a -> option bytes -> bytes -> bytes -> bytes
+  #a:Type -> {|comm_layer_core_config a|} ->
+  principal -> principal -> payload:either a bytes -> pk_receiver:option bytes{(Some? pk_receiver <==> Inr? payload) /\ (None? pk_receiver <==> Inl? payload)} -> bytes -> bytes -> bytes
 let sign_message #a sender receiver payload pk_receiver sk nonce =
-  let payload_bytes = serialize a payload in
   let sig_input = (
     match pk_receiver with
-    | None -> Plain sender receiver payload_bytes
-    | Some pk -> Encrypted sender receiver payload_bytes pk
+    | None -> Plain sender receiver (serialize a (Inl?.v payload))
+    | Some pk -> Encrypted sender receiver (Inr?.v payload) pk
   ) in
   let sig_input_bytes = serialize signature_input sig_input in
   let signature = sign sk nonce sig_input_bytes in
   let signed_msg = SigMessage {msg=sig_input_bytes; signature} in
-  serialize com_message_t signed_msg
-#pop-options
+  serialize comm_message_t signed_msg
 
 [@@ "opaque_to_smt"]
 val send_authenticated:
-  {|comm_layer_core_tag|} ->
-  #a:Type -> {| parseable_serializeable bytes a |} ->
+  #a:Type0 -> {|comm_layer_core_config a|} ->
   communication_keys_sess_ids ->
   principal -> principal -> a ->
   traceful (option timestamp)
-let send_authenticated #tag #a comm_keys_ids sender receiver payload =
-  let*? sk_sender = get_private_key sender comm_keys_ids.private_keys (LongTermSigKey comm_layer_sign_tag) in
+let send_authenticated #a comm_keys_ids sender receiver payload =
+  let*? sk_sender = get_private_key sender comm_keys_ids.private_keys (LongTermSigKey (comm_layer_sign_tag a)) in
   let* nonce = mk_rand SigNonce (long_term_key_label sender) 32 in
-  let payload_bytes = serialize a payload in
-  trigger_event sender (CommAuthSendMsg sender payload_bytes);*
-  let msg_signed = sign_message sender receiver payload None sk_sender nonce in
+  trigger_event sender (CommAuthSendMsg sender payload <: communication_core_event a);*
+  let msg_signed = sign_message sender receiver (Inl payload) None sk_sender nonce in
   let* msg_id = send_msg msg_signed in
   return (Some msg_id)
 
 #push-options "--ifuel 1 --fuel 0"
 //[@@ "opaque_to_smt"]
 val verify_message:
-  #a:Type -> {| parseable_serializeable bytes a |} ->
-  principal -> bytes -> option bytes -> bytes -> option (communication_message a)
+  #a:Type -> {|comm_layer_core_config a|} ->
+  principal -> bytes -> option bytes -> bytes -> option (either a bytes)
 let verify_message #a receiver sign_msg_bytes sk_receiver_opt vk_sender =
-  let? msg_sign_t = parse com_message_t sign_msg_bytes in
+  let? msg_sign_t = parse comm_message_t sign_msg_bytes in
   guard (SigMessage? msg_sign_t);?
   let SigMessage msg_sign = msg_sign_t in
   let? sign_input = parse signature_input msg_sign.msg in
   guard (verify vk_sender msg_sign.msg msg_sign.signature);?
-  let? (pk_receiver_opt, cm) = match sign_input with
+  let? (pk_receiver_opt, receiver', payload) = match sign_input with
     | Plain sender receiver payload_bytes -> (
       let? payload = parse a payload_bytes in
-      Some (None, {sender; receiver; payload})
+      Some (None, receiver, (Inl payload))
     )
     | Encrypted sender receiver payload_bytes pk_receiver -> (
-      let? payload = parse a payload_bytes in
-      Some (Some pk_receiver, {sender; receiver; payload})
+      Some (Some pk_receiver, receiver, (Inr payload_bytes))
     )
   in
-  guard (cm.receiver = receiver);?
+  guard (receiver' = receiver);?
   guard (pk_receiver_opt = FStar.Option.mapTot pk sk_receiver_opt);?
-  Some cm
+  Some payload
 
 val get_sender: bytes -> option principal
 let get_sender sign_msg_bytes =
-  let? msg_sign_t = parse com_message_t sign_msg_bytes in
+  let? msg_sign_t = parse comm_message_t sign_msg_bytes in
   guard (SigMessage? msg_sign_t);?
   let SigMessage msg_sign = msg_sign_t in
   let? sign_input = parse signature_input msg_sign.msg in
@@ -178,29 +174,31 @@ let get_sender sign_msg_bytes =
 
 [@@ "opaque_to_smt"]
 val receive_authenticated:
-  {|comm_layer_core_tag|} ->
-  #a:Type -> {| parseable_serializeable bytes a |} ->
+  #a:Type0 -> {|comm_layer_core_config a|} ->
   communication_keys_sess_ids ->
   principal -> timestamp ->
   traceful (option (communication_message a))
-let receive_authenticated #tag #a comm_keys_ids receiver msg_id =
+let receive_authenticated #a comm_keys_ids receiver msg_id =
   let*? msg_signed_bytes = recv_msg msg_id in
   let*? sender = return (get_sender msg_signed_bytes) in
-  let*? vk_sender = get_public_key receiver comm_keys_ids.pki (LongTermSigKey comm_layer_sign_tag) sender in
-  let*? cm:communication_message a = return (verify_message receiver msg_signed_bytes None vk_sender) in
-  trigger_event receiver (CommAuthReceiveMsg sender receiver (serialize a cm.payload));*
-  return (Some cm)
+  let*? vk_sender = get_public_key receiver comm_keys_ids.pki (LongTermSigKey (comm_layer_sign_tag a)) sender in
+  match verify_message #a receiver msg_signed_bytes None vk_sender with
+  | None -> return None
+  | Some (Inl payload) -> (
+    trigger_event receiver (CommAuthReceiveMsg sender receiver payload <: communication_core_event a);*
+    return (Some {sender; receiver; payload})
+  )
 
 
 (**** Confidential and Authenticates Send and Receive Functions ****)
 
 [@@ "opaque_to_smt"]
 val encrypt_and_sign_message:
-  #a:Type -> {| parseable_serializeable bytes a |} ->
+  #a:Type -> {|comm_layer_core_config a|} ->
   principal -> principal -> a -> bytes -> bytes -> bytes -> bytes -> bytes
 let encrypt_and_sign_message #a sender receiver payload pk_receiver sk_sender enc_nonce sign_nonce =
   let enc_payload = encrypt_message #a pk_receiver enc_nonce payload in
-  sign_message #com_send_byte sender receiver {b=enc_payload} (Some pk_receiver) sk_sender sign_nonce
+  sign_message #a sender receiver (Inr enc_payload) (Some pk_receiver) sk_sender sign_nonce
 
 // We do not encrypt the sender and receiver because, in real-world settings,
 // they can also be identified by the IP addresses or certificates they use.
@@ -208,81 +206,80 @@ let encrypt_and_sign_message #a sender receiver payload pk_receiver sk_sender en
 // to create and parse confidential and authenticated messages.
 [@@ "opaque_to_smt"]
 val send_confidential_authenticated:
-  {|comm_layer_core_tag|} ->
-  #a:Type -> {| parseable_serializeable bytes a |} ->
+  #a:Type0 -> {|comm_layer_core_config a|} ->
   communication_keys_sess_ids ->
   principal -> principal -> a ->
   traceful (option timestamp)
-let send_confidential_authenticated #tag #a comm_keys_ids sender receiver payload =
-  let*? pk_receiver = get_public_key sender comm_keys_ids.pki (LongTermPkeKey comm_layer_pkenc_tag) receiver in
-  let*? sk_sender = get_private_key sender comm_keys_ids.private_keys (LongTermSigKey comm_layer_sign_tag) in
+let send_confidential_authenticated #a comm_keys_ids sender receiver payload =
+  let*? pk_receiver = get_public_key sender comm_keys_ids.pki (LongTermPkeKey (comm_layer_pkenc_tag a)) receiver in
+  let*? sk_sender = get_private_key sender comm_keys_ids.private_keys (LongTermSigKey (comm_layer_sign_tag a)) in
   let* enc_nonce = mk_rand PkeNonce (long_term_key_label sender) 32 in
   let* sign_nonce = mk_rand SigNonce (long_term_key_label sender) 32 in
-  trigger_event sender (CommConfSendMsg sender receiver (serialize a payload));*
-  trigger_event sender (CommConfAuthSendMsg sender receiver (serialize a payload));*
+  trigger_event sender (CommConfSendMsg sender receiver payload <: communication_core_event a);*
+  trigger_event sender (CommConfAuthSendMsg sender receiver payload <: communication_core_event a);*
   let msg_encrypted_signed_bytes = encrypt_and_sign_message sender receiver payload pk_receiver sk_sender enc_nonce sign_nonce in
   let* msg_id = send_msg msg_encrypted_signed_bytes in
   return (Some msg_id)
 
 [@@ "opaque_to_smt"]
 val verify_and_decrypt_message:
-  #a:Type -> {| parseable_serializeable bytes a |} ->
+  #a:Type0 -> {|comm_layer_core_config a|} ->
   principal -> bytes -> bytes -> bytes -> option (communication_message a)
-let verify_and_decrypt_message #a #ps receiver sk_receiver vk_sender msg_encrypted_signed =
-  let? cm:communication_message com_send_byte = verify_message #com_send_byte receiver msg_encrypted_signed (Some sk_receiver) vk_sender in
-  let? payload:a = decrypt_message #a sk_receiver cm.payload.b in
-  Some {sender=cm.sender; receiver=cm.receiver; payload}
+let verify_and_decrypt_message #a receiver sk_receiver vk_sender msg_encrypted_signed =
+  let? Inr payload_enc = verify_message #a receiver msg_encrypted_signed (Some sk_receiver) vk_sender in
+  let? payload:a = decrypt_message #a sk_receiver payload_enc in
+  let? sender = get_sender msg_encrypted_signed in
+  Some {sender; receiver; payload}
 
 [@@ "opaque_to_smt"]
 val receive_confidential_authenticated:
-  {|comm_layer_core_tag|} ->
-  #a:Type -> {| parseable_serializeable bytes a |} ->
+  #a:Type0 -> {|comm_layer_core_config a|} ->
   communication_keys_sess_ids ->
   principal -> timestamp ->
   traceful (option (communication_message a))
-let receive_confidential_authenticated #tag #a comm_keys_ids receiver msg_id =
+let receive_confidential_authenticated #a comm_keys_ids receiver msg_id =
   let*? msg_encrypted_signed = recv_msg msg_id in
-  let*? sk_receiver = get_private_key receiver comm_keys_ids.private_keys (LongTermPkeKey comm_layer_pkenc_tag) in
+  let*? sk_receiver = get_private_key receiver comm_keys_ids.private_keys (LongTermPkeKey (comm_layer_pkenc_tag a)) in
   let*? sender = return (get_sender msg_encrypted_signed) in
-  let*? vk_sender = get_public_key receiver comm_keys_ids.pki (LongTermSigKey comm_layer_sign_tag) sender in 
+  let*? vk_sender = get_public_key receiver comm_keys_ids.pki (LongTermSigKey (comm_layer_sign_tag a)) sender in 
   let*? cm:communication_message a = return (verify_and_decrypt_message #a receiver sk_receiver vk_sender msg_encrypted_signed) in 
-  trigger_event receiver (CommConfAuthReceiveMsg sender receiver (serialize a cm.payload));*
+  trigger_event receiver (CommConfAuthReceiveMsg sender receiver cm.payload <: communication_core_event a);*
   return (Some cm)
 
 
 (**** Layer Initialization ****)
 
 [@@ "opaque_to_smt"]
-val initialize_communication: {|comm_layer_core_tag|} -> principal -> principal -> traceful (option (communication_keys_sess_ids & communication_keys_sess_ids))
-let initialize_communication #tag sender receiver =
+val initialize_communication: a:Type -> {|comm_layer_core_config a|} -> principal -> principal -> traceful (option (communication_keys_sess_ids & communication_keys_sess_ids))
+let initialize_communication a sender receiver =
   // Initialize keys for public key encryption
   let* client_global_session_priv_key_id = initialize_private_keys sender in
-  generate_private_key sender client_global_session_priv_key_id (LongTermPkeKey comm_layer_pkenc_tag);*
+  generate_private_key sender client_global_session_priv_key_id (LongTermPkeKey (comm_layer_pkenc_tag a));*
 
   let* receiver_global_session_priv_key_id = initialize_private_keys receiver in
-  generate_private_key receiver receiver_global_session_priv_key_id (LongTermPkeKey comm_layer_pkenc_tag);*
+  generate_private_key receiver receiver_global_session_priv_key_id (LongTermPkeKey (comm_layer_pkenc_tag a));*
 
-  let*? priv_key_receiver = get_private_key receiver receiver_global_session_priv_key_id (LongTermPkeKey comm_layer_pkenc_tag) in
+  let*? priv_key_receiver = get_private_key receiver receiver_global_session_priv_key_id (LongTermPkeKey (comm_layer_pkenc_tag a)) in
   let pub_key_receiver = pk priv_key_receiver in
   let* client_global_session_pub_key_id = initialize_pki sender in
-  install_public_key sender client_global_session_pub_key_id (LongTermPkeKey comm_layer_pkenc_tag) receiver pub_key_receiver;*
+  install_public_key sender client_global_session_pub_key_id (LongTermPkeKey (comm_layer_pkenc_tag a)) receiver pub_key_receiver;*
 
-  let*? priv_key_client = get_private_key sender client_global_session_priv_key_id (LongTermPkeKey comm_layer_pkenc_tag) in
+  let*? priv_key_client = get_private_key sender client_global_session_priv_key_id (LongTermPkeKey (comm_layer_pkenc_tag a)) in
   let pub_key_client = pk priv_key_client in
   let* receiver_global_session_pub_key_id = initialize_pki receiver in
-  install_public_key receiver receiver_global_session_pub_key_id (LongTermPkeKey comm_layer_pkenc_tag) sender pub_key_client;*
+  install_public_key receiver receiver_global_session_pub_key_id (LongTermPkeKey (comm_layer_pkenc_tag a)) sender pub_key_client;*
 
   // Initialize signing keys
-  generate_private_key sender client_global_session_priv_key_id (LongTermSigKey comm_layer_sign_tag);*
-  generate_private_key receiver receiver_global_session_priv_key_id (LongTermSigKey comm_layer_sign_tag);*
+  generate_private_key sender client_global_session_priv_key_id (LongTermSigKey (comm_layer_sign_tag a));*
+  generate_private_key receiver receiver_global_session_priv_key_id (LongTermSigKey (comm_layer_sign_tag a));*
 
-  let*? priv_key_receiver = get_private_key receiver receiver_global_session_priv_key_id (LongTermSigKey comm_layer_sign_tag) in
+  let*? priv_key_receiver = get_private_key receiver receiver_global_session_priv_key_id (LongTermSigKey (comm_layer_sign_tag a)) in
   let pub_key_receiver = vk priv_key_receiver in
-  install_public_key sender client_global_session_pub_key_id (LongTermSigKey comm_layer_sign_tag) receiver pub_key_receiver;*
+  install_public_key sender client_global_session_pub_key_id (LongTermSigKey (comm_layer_sign_tag a)) receiver pub_key_receiver;*
 
-  let*? priv_key_client = get_private_key sender client_global_session_priv_key_id (LongTermSigKey comm_layer_sign_tag) in
+  let*? priv_key_client = get_private_key sender client_global_session_priv_key_id (LongTermSigKey (comm_layer_sign_tag a)) in
   let pub_key_client = vk priv_key_client in
-  install_public_key receiver receiver_global_session_pub_key_id (LongTermSigKey comm_layer_sign_tag) sender pub_key_client;*
+  install_public_key receiver receiver_global_session_pub_key_id (LongTermSigKey (comm_layer_sign_tag a)) sender pub_key_client;*
 
   let client_comm_keys_sess_ids = {pki=client_global_session_pub_key_id; private_keys=client_global_session_priv_key_id} in
   let receiver_comm_keys_sess_ids = {pki=receiver_global_session_pub_key_id; private_keys=receiver_global_session_priv_key_id} in

--- a/src/lib/communication/DY.Lib.Communication.Core.fst
+++ b/src/lib/communication/DY.Lib.Communication.Core.fst
@@ -38,7 +38,7 @@ type communication_core_event (a:Type) {|config:comm_layer_core_config a|} =
   | CommAuthReceiveMsg: sender:principal -> receiver:principal -> [@@@ with_parser #bytes config.core_ps_a] payload:a -> communication_core_event a
   | CommConfAuthSendMsg: sender:principal -> receiver:principal -> [@@@ with_parser #bytes config.core_ps_a] payload:a -> communication_core_event a
   | CommConfAuthReceiveMsg: sender:principal -> receiver:principal -> [@@@ with_parser #bytes config.core_ps_a] payload:a -> communication_core_event a
-  
+
 
 #push-options "--ifuel 1 --fuel 0"
 %splice [ps_communication_core_event] (gen_parser (`communication_core_event))
@@ -237,8 +237,8 @@ let receive_confidential_authenticated #a comm_keys_ids receiver msg_id =
   let*? msg_encrypted_signed = recv_msg msg_id in
   let*? sk_receiver = get_private_key receiver comm_keys_ids.private_keys (LongTermPkeKey (comm_layer_pkenc_tag a)) in
   let*? sender = return (get_sender #a msg_encrypted_signed) in
-  let*? vk_sender = get_public_key receiver comm_keys_ids.pki (LongTermSigKey (comm_layer_sign_tag a)) sender in 
-  let*? cm:communication_message a = return (verify_and_decrypt_message #a receiver sk_receiver vk_sender msg_encrypted_signed) in 
+  let*? vk_sender = get_public_key receiver comm_keys_ids.pki (LongTermSigKey (comm_layer_sign_tag a)) sender in
+  let*? cm:communication_message a = return (verify_and_decrypt_message #a receiver sk_receiver vk_sender msg_encrypted_signed) in
   trigger_event receiver (CommConfAuthReceiveMsg sender receiver cm.payload <: communication_core_event a);*
   return (Some cm)
 

--- a/src/lib/communication/DY.Lib.Communication.Core.fst
+++ b/src/lib/communication/DY.Lib.Communication.Core.fst
@@ -18,8 +18,8 @@ class comm_layer_core_config (a:Type) = {
   ps_a: parser_serializer bytes a;
 }
 
-instance parseable_serializeable_bytes_a (#a:Type) {|c:comm_layer_core_config a|}: parseable_serializeable bytes a =
-  mk_parseable_serializeable c.ps_a
+instance parseable_serializeable_bytes_a (#a:Type) {|config:comm_layer_core_config a|}: parseable_serializeable bytes a =
+  mk_parseable_serializeable config.ps_a
 
 val comm_layer_pkenc_tag: (a:Type) -> {|comm_layer_core_config a|} -> string
 let comm_layer_pkenc_tag a #config = config.tag ^ ".PkEnc.PublicKey"
@@ -250,8 +250,8 @@ let receive_confidential_authenticated #a comm_keys_ids receiver msg_id =
 (**** Layer Initialization ****)
 
 [@@ "opaque_to_smt"]
-val initialize_communication: a:Type -> {|comm_layer_core_config a|} -> principal -> principal -> traceful (option (communication_keys_sess_ids & communication_keys_sess_ids))
-let initialize_communication a sender receiver =
+val initialize_communication_core: a:Type -> {|comm_layer_core_config a|} -> principal -> principal -> traceful (option (communication_keys_sess_ids & communication_keys_sess_ids))
+let initialize_communication_core a sender receiver =
   // Initialize keys for public key encryption
   let* client_global_session_priv_key_id = initialize_private_keys sender in
   generate_private_key sender client_global_session_priv_key_id (LongTermPkeKey (comm_layer_pkenc_tag a));*

--- a/src/lib/communication/DY.Lib.Communication.Core.fst
+++ b/src/lib/communication/DY.Lib.Communication.Core.fst
@@ -13,19 +13,11 @@ open DY.Lib.Communication.Data
 
 (*** Layer Setup ***)
 
-class comm_layer_core_config (a:Type) = {
-  tag: string;
-  ps_a: parser_serializer bytes a;
-}
-
-instance parseable_serializeable_bytes_a (#a:Type) {|config:comm_layer_core_config a|}: parseable_serializeable bytes a =
-  mk_parseable_serializeable config.ps_a
-
 val comm_layer_pkenc_tag: (a:Type) -> {|comm_layer_core_config a|} -> string
-let comm_layer_pkenc_tag a #config = config.tag ^ ".PkEnc.PublicKey"
+let comm_layer_pkenc_tag a #config = config.core_tag ^ ".PkEnc.PublicKey"
 
 val comm_layer_sign_tag: (a:Type) -> {|comm_layer_core_config a|} -> string
-let comm_layer_sign_tag a #config = config.tag ^ ".Sign.PublicKey"
+let comm_layer_sign_tag a #config = config.core_tag ^ ".Sign.PublicKey"
 
 type communication_keys_sess_ids = {
   pki: state_id;
@@ -40,12 +32,12 @@ let comm_label sender receiver = join (principal_label sender) (principal_label 
 
 [@@with_bytes bytes]
 type communication_core_event (a:Type) {|config:comm_layer_core_config a|} =
-  | CommConfSendMsg: sender:principal -> receiver:principal -> [@@@ with_parser #bytes config.ps_a] payload:a -> communication_core_event a
-  | CommConfReceiveMsg: receiver:principal -> [@@@ with_parser #bytes config.ps_a] payload:a -> communication_core_event a
-  | CommAuthSendMsg: sender:principal -> [@@@ with_parser #bytes config.ps_a] payload:a -> communication_core_event a
-  | CommAuthReceiveMsg: sender:principal -> receiver:principal -> [@@@ with_parser #bytes config.ps_a] payload:a -> communication_core_event a
-  | CommConfAuthSendMsg: sender:principal -> receiver:principal -> [@@@ with_parser #bytes config.ps_a] payload:a -> communication_core_event a
-  | CommConfAuthReceiveMsg: sender:principal -> receiver:principal -> [@@@ with_parser #bytes config.ps_a] payload:a -> communication_core_event a
+  | CommConfSendMsg: sender:principal -> receiver:principal -> [@@@ with_parser #bytes config.core_ps_a] payload:a -> communication_core_event a
+  | CommConfReceiveMsg: receiver:principal -> [@@@ with_parser #bytes config.core_ps_a] payload:a -> communication_core_event a
+  | CommAuthSendMsg: sender:principal -> [@@@ with_parser #bytes config.core_ps_a] payload:a -> communication_core_event a
+  | CommAuthReceiveMsg: sender:principal -> receiver:principal -> [@@@ with_parser #bytes config.core_ps_a] payload:a -> communication_core_event a
+  | CommConfAuthSendMsg: sender:principal -> receiver:principal -> [@@@ with_parser #bytes config.core_ps_a] payload:a -> communication_core_event a
+  | CommConfAuthReceiveMsg: sender:principal -> receiver:principal -> [@@@ with_parser #bytes config.core_ps_a] payload:a -> communication_core_event a
   
 
 #push-options "--ifuel 1 --fuel 0"
@@ -54,7 +46,7 @@ type communication_core_event (a:Type) {|config:comm_layer_core_config a|} =
 #pop-options
 
 instance event_communication_core_event (a:Type) {|config:comm_layer_core_config a|}: event (communication_core_event a) = {
-  tag = config.tag ^ ".Event";
+  tag = config.core_tag ^ ".Event";
   format = mk_parseable_serializeable (ps_communication_core_event a);
 }
 
@@ -108,20 +100,22 @@ let receive_confidential #a comm_keys_ids receiver msg_id =
 
 (**** Authenticated Send and Receive Functions ****)
 
+#push-options "--ifuel 1"
 [@@ "opaque_to_smt"]
 val sign_message:
-  #a:Type -> {|comm_layer_core_config a|} ->
-  principal -> principal -> payload:either a bytes -> pk_receiver:option bytes{(Some? pk_receiver <==> Inr? payload) /\ (None? pk_receiver <==> Inl? payload)} -> bytes -> bytes -> bytes
-let sign_message #a sender receiver payload pk_receiver sk nonce =
+  #a:Type0 -> {|comm_layer_core_config a|} ->
+  principal -> principal -> input:either a (bytes & bytes) -> bytes -> bytes -> bytes
+let sign_message #a sender receiver input sk nonce =
   let sig_input = (
-    match pk_receiver with
-    | None -> Plain sender receiver (serialize a (Inl?.v payload))
-    | Some pk -> Encrypted sender receiver (Inr?.v payload) pk
+    match input with
+    | Inl payload -> Plain sender receiver payload
+    | Inr (payload, pk) -> Encrypted sender receiver payload pk
   ) in
-  let sig_input_bytes = serialize signature_input sig_input in
+  let sig_input_bytes = serialize (signature_input a) sig_input in
   let signature = sign sk nonce sig_input_bytes in
   let signed_msg = SigMessage {msg=sig_input_bytes; signature} in
   serialize comm_message_t signed_msg
+#pop-options
 
 [@@ "opaque_to_smt"]
 val send_authenticated:
@@ -133,24 +127,23 @@ let send_authenticated #a comm_keys_ids sender receiver payload =
   let*? sk_sender = get_private_key sender comm_keys_ids.private_keys (LongTermSigKey (comm_layer_sign_tag a)) in
   let* nonce = mk_rand SigNonce (long_term_key_label sender) 32 in
   trigger_event sender (CommAuthSendMsg sender payload <: communication_core_event a);*
-  let msg_signed = sign_message sender receiver (Inl payload) None sk_sender nonce in
+  let msg_signed = sign_message sender receiver (Inl payload) sk_sender nonce in
   let* msg_id = send_msg msg_signed in
   return (Some msg_id)
 
 #push-options "--ifuel 1 --fuel 0"
 //[@@ "opaque_to_smt"]
 val verify_message:
-  #a:Type -> {|comm_layer_core_config a|} ->
+  #a:Type0 -> {|comm_layer_core_config a|} ->
   principal -> bytes -> option bytes -> bytes -> option (either a bytes)
 let verify_message #a receiver sign_msg_bytes sk_receiver_opt vk_sender =
   let? msg_sign_t = parse comm_message_t sign_msg_bytes in
   guard (SigMessage? msg_sign_t);?
   let SigMessage msg_sign = msg_sign_t in
-  let? sign_input = parse signature_input msg_sign.msg in
+  let? sign_input = parse (signature_input a) msg_sign.msg in
   guard (verify vk_sender msg_sign.msg msg_sign.signature);?
   let? (pk_receiver_opt, receiver', payload) = match sign_input with
-    | Plain sender receiver payload_bytes -> (
-      let? payload = parse a payload_bytes in
+    | Plain sender receiver payload -> (
       Some (None, receiver, (Inl payload))
     )
     | Encrypted sender receiver payload_bytes pk_receiver -> (
@@ -161,14 +154,17 @@ let verify_message #a receiver sign_msg_bytes sk_receiver_opt vk_sender =
   guard (pk_receiver_opt = FStar.Option.mapTot pk sk_receiver_opt);?
   Some payload
 
-val get_sender: bytes -> option principal
-let get_sender sign_msg_bytes =
+val get_sender:
+  #a:Type0 -> {|comm_layer_core_config a|} ->
+  bytes ->
+  option principal
+let get_sender #a sign_msg_bytes =
   let? msg_sign_t = parse comm_message_t sign_msg_bytes in
   guard (SigMessage? msg_sign_t);?
   let SigMessage msg_sign = msg_sign_t in
-  let? sign_input = parse signature_input msg_sign.msg in
+  let? sign_input = parse (signature_input a) msg_sign.msg in
   match sign_input with
-  | Plain sender receiver payload_bytes -> Some sender
+  | Plain sender receiver payload -> Some sender
   | Encrypted sender receiver payload_bytes pk_receiver -> Some sender
 #pop-options
 
@@ -180,7 +176,7 @@ val receive_authenticated:
   traceful (option (communication_message a))
 let receive_authenticated #a comm_keys_ids receiver msg_id =
   let*? msg_signed_bytes = recv_msg msg_id in
-  let*? sender = return (get_sender msg_signed_bytes) in
+  let*? sender = return (get_sender #a msg_signed_bytes) in
   let*? vk_sender = get_public_key receiver comm_keys_ids.pki (LongTermSigKey (comm_layer_sign_tag a)) sender in
   match verify_message #a receiver msg_signed_bytes None vk_sender with
   | None -> return None
@@ -194,11 +190,11 @@ let receive_authenticated #a comm_keys_ids receiver msg_id =
 
 [@@ "opaque_to_smt"]
 val encrypt_and_sign_message:
-  #a:Type -> {|comm_layer_core_config a|} ->
+  #a:Type0 -> {|comm_layer_core_config a|} ->
   principal -> principal -> a -> bytes -> bytes -> bytes -> bytes -> bytes
 let encrypt_and_sign_message #a sender receiver payload pk_receiver sk_sender enc_nonce sign_nonce =
   let enc_payload = encrypt_message #a pk_receiver enc_nonce payload in
-  sign_message #a sender receiver (Inr enc_payload) (Some pk_receiver) sk_sender sign_nonce
+  sign_message #a sender receiver (Inr (enc_payload, pk_receiver)) sk_sender sign_nonce
 
 // We do not encrypt the sender and receiver because, in real-world settings,
 // they can also be identified by the IP addresses or certificates they use.
@@ -228,7 +224,7 @@ val verify_and_decrypt_message:
 let verify_and_decrypt_message #a receiver sk_receiver vk_sender msg_encrypted_signed =
   let? Inr payload_enc = verify_message #a receiver msg_encrypted_signed (Some sk_receiver) vk_sender in
   let? payload:a = decrypt_message #a sk_receiver payload_enc in
-  let? sender = get_sender msg_encrypted_signed in
+  let? sender = get_sender #a msg_encrypted_signed in
   Some {sender; receiver; payload}
 
 [@@ "opaque_to_smt"]
@@ -240,7 +236,7 @@ val receive_confidential_authenticated:
 let receive_confidential_authenticated #a comm_keys_ids receiver msg_id =
   let*? msg_encrypted_signed = recv_msg msg_id in
   let*? sk_receiver = get_private_key receiver comm_keys_ids.private_keys (LongTermPkeKey (comm_layer_pkenc_tag a)) in
-  let*? sender = return (get_sender msg_encrypted_signed) in
+  let*? sender = return (get_sender #a msg_encrypted_signed) in
   let*? vk_sender = get_public_key receiver comm_keys_ids.pki (LongTermSigKey (comm_layer_sign_tag a)) sender in 
   let*? cm:communication_message a = return (verify_and_decrypt_message #a receiver sk_receiver vk_sender msg_encrypted_signed) in 
   trigger_event receiver (CommConfAuthReceiveMsg sender receiver cm.payload <: communication_core_event a);*

--- a/src/lib/communication/DY.Lib.Communication.Data.fst
+++ b/src/lib/communication/DY.Lib.Communication.Data.fst
@@ -11,19 +11,21 @@ open DY.Lib.Comparse.Parsers
 
 (**** Core ****)
 
+(*)
 /// The following type is meant to be used to send a single byte with a function
 /// of the communication layer. Since the communication layer always takes a
 /// serializable data object we need to encapsulate the byte in a data object.
 [@@with_bytes bytes]
-type com_send_byte = {
+type comm_send_byte = {
   b:bytes;
 }
 
-%splice [ps_com_send_byte] (gen_parser (`com_send_byte))
-%splice [ps_com_send_byte_is_well_formed] (gen_is_well_formed_lemma (`com_send_byte))
+%splice [ps_comm_send_byte] (gen_parser (`comm_send_byte))
+%splice [ps_comm_send_byte_is_well_formed] (gen_is_well_formed_lemma (`comm_send_byte))
 
-instance parseable_serializeable_bytes_com_send_byte: parseable_serializeable bytes com_send_byte
-  = mk_parseable_serializeable ps_com_send_byte
+instance parseable_serializeable_bytes_comm_send_byte: parseable_serializeable bytes comm_send_byte
+  = mk_parseable_serializeable ps_comm_send_byte
+  *)
 
 /// Data structure to return data from communication layer functions
 type communication_message (a:Type) = {
@@ -89,15 +91,15 @@ instance parseable_serializeable_bytes_authenticated_data: parseable_serializeab
 (**** Message Type for all Messages on the Wire ****)
 
 [@@with_bytes bytes]
-type com_message_t =
-  | SigMessage: signed_communication_message -> com_message_t
-  | RequestMessage: request_message -> com_message_t
-  | ResponseMessage: response_envelope -> com_message_t
+type comm_message_t =
+  | SigMessage: signed_communication_message -> comm_message_t
+  | RequestMessage: request_message -> comm_message_t
+  | ResponseMessage: response_envelope -> comm_message_t
 
 #push-options "--ifuel 1"
-%splice [ps_com_message_t] (gen_parser (`com_message_t))
-%splice [ps_com_message_t_is_well_formed] (gen_is_well_formed_lemma (`com_message_t))
+%splice [ps_comm_message_t] (gen_parser (`comm_message_t))
+%splice [ps_comm_message_t_is_well_formed] (gen_is_well_formed_lemma (`comm_message_t))
 #pop-options
 
-instance parseable_serializeable_bytes_com_message_t: parseable_serializeable bytes com_message_t
-  = mk_parseable_serializeable ps_com_message_t
+instance parseable_serializeable_bytes_comm_message_t: parseable_serializeable bytes comm_message_t
+  = mk_parseable_serializeable ps_comm_message_t

--- a/src/lib/communication/DY.Lib.Communication.Data.fst
+++ b/src/lib/communication/DY.Lib.Communication.Data.fst
@@ -11,21 +11,14 @@ open DY.Lib.Comparse.Parsers
 
 (**** Core ****)
 
-(*)
-/// The following type is meant to be used to send a single byte with a function
-/// of the communication layer. Since the communication layer always takes a
-/// serializable data object we need to encapsulate the byte in a data object.
-[@@with_bytes bytes]
-type comm_send_byte = {
-  b:bytes;
+/// Communication layer core configuration
+class comm_layer_core_config (a:Type) = {
+  core_tag: string;
+  core_ps_a: parser_serializer bytes a;
 }
 
-%splice [ps_comm_send_byte] (gen_parser (`comm_send_byte))
-%splice [ps_comm_send_byte_is_well_formed] (gen_is_well_formed_lemma (`comm_send_byte))
-
-instance parseable_serializeable_bytes_comm_send_byte: parseable_serializeable bytes comm_send_byte
-  = mk_parseable_serializeable ps_comm_send_byte
-  *)
+instance parseable_serializeable_bytes_a_core (#a:Type) {|config:comm_layer_core_config a|}: parseable_serializeable bytes a =
+  mk_parseable_serializeable config.core_ps_a
 
 /// Data structure to return data from communication layer functions
 type communication_message (a:Type) = {
@@ -35,17 +28,17 @@ type communication_message (a:Type) = {
 }
 
 [@@with_bytes bytes]
-type signature_input = 
-  | Plain: sender:principal -> receiver:principal -> payload:bytes -> signature_input
-  | Encrypted: sender:principal -> receiver:principal -> payload:bytes -> pk:bytes -> signature_input
+type signature_input (a:Type) {|config:comm_layer_core_config a|} = 
+  | Plain: sender:principal -> receiver:principal -> [@@@ with_parser #bytes config.core_ps_a] payload:a -> signature_input a
+  | Encrypted: sender:principal -> receiver:principal -> payload:bytes -> pk:bytes -> signature_input a
 
 #push-options "--ifuel 1 --fuel 0"
 %splice [ps_signature_input] (gen_parser (`signature_input))
 %splice [ps_signature_input_is_well_formed] (gen_is_well_formed_lemma (`signature_input))
 #pop-options
 
-instance parseable_serializeable_bytes_signature_input: parseable_serializeable bytes signature_input
-  = mk_parseable_serializeable ps_signature_input
+instance parseable_serializeable_bytes_signature_input (#a:Type) {|config:comm_layer_core_config a|}: parseable_serializeable bytes (signature_input a)
+  = mk_parseable_serializeable (ps_signature_input a)
 
 [@@with_bytes bytes]
 type signed_communication_message = {
@@ -57,6 +50,15 @@ type signed_communication_message = {
 %splice [ps_signed_communication_message_is_well_formed] (gen_is_well_formed_lemma (`signed_communication_message))
 
 (**** Request/Response ****)
+
+/// Communication layer reqres configuration
+class comm_layer_reqres_config (a:Type) = {
+  reqres_tag: string;
+  reqres_ps_a: parser_serializer bytes a;
+}
+
+instance parseable_serializeable_bytes_a_reqres (#a:Type) {|config:comm_layer_reqres_config a|}: parseable_serializeable bytes a =
+  mk_parseable_serializeable config.reqres_ps_a
 
 [@@with_bytes bytes]
 type request_message = {

--- a/src/lib/communication/DY.Lib.Communication.Printing.fst
+++ b/src/lib/communication/DY.Lib.Communication.Printing.fst
@@ -78,8 +78,8 @@ let com_core_event_to_string payload_to_string =
         sender receiver (option_to_string payload_to_string payload))
   )))
 
-val com_reqres_event_to_string: (bytes -> option string) -> (string & (bytes -> option string))
-let com_reqres_event_to_string payload_to_string =
+val com_reqres_event_to_string: {|comm_layer_event_reqres_tag|} -> (bytes -> option string) -> (string & (bytes -> option string))
+let com_reqres_event_to_string #event_tag payload_to_string =
   (event_communication_reqres_event.tag, (fun b -> (
     let? cre = parse communication_reqres_event b in
     match cre with
@@ -98,9 +98,10 @@ let com_reqres_event_to_string payload_to_string =
   )))
 
 val com_event_to_string:
+  {|comm_layer_event_reqres_tag|} ->
   (bytes -> option string) -> (bytes -> option string) ->
   list (string & (bytes -> option string))
-let com_event_to_string core_payload_to_string reqres_payload_to_string =
+let com_event_to_string #event_tag core_payload_to_string reqres_payload_to_string =
   [com_core_event_to_string core_payload_to_string;
     com_reqres_event_to_string reqres_payload_to_string]
 

--- a/src/lib/communication/DY.Lib.Communication.Printing.fst
+++ b/src/lib/communication/DY.Lib.Communication.Printing.fst
@@ -10,13 +10,19 @@ open DY.Lib.Communication.RequestResponse
 
 #set-options "--fuel 0 --ifuel 1 --z3cliopt 'smt.qi.eager_threshold=100'"
 
-val com_message_to_string: (bytes -> option string) -> (bytes -> option string) -> bytes -> option string
-let com_message_to_string msg_to_string reqres_payload_to_string b =
+val com_message_to_string:
+  #reqres_type:Type -> {|parseable_serializeable bytes reqres_type|} -> 
+  (bytes -> option string) -> (reqres_type -> string) -> bytes ->
+  option string
+let com_message_to_string #reqres_type msg_to_string reqres_payload_to_string b =
   match b with
   | PkeEnc pk nonce msg -> (
     match parse com_message_t msg with
     | Some (SigMessage _) -> Some "Error: SigMessage cannot be inside a PkeEnc encryption"
-    | Some (RequestMessage {request; key}) -> reqres_payload_to_string request
+    | Some (RequestMessage {request; key}) -> (
+      let? request_parsed = parse reqres_type request in 
+      Some (reqres_payload_to_string request_parsed)
+    )
     | Some (ResponseMessage _) -> Some "Error: ResponseMessage cannot be inside a PkeEnc encryption"
     | None -> Some (option_to_string msg_to_string b)
   )
@@ -47,7 +53,10 @@ let com_message_to_string msg_to_string reqres_payload_to_string b =
     | Some (RequestMessage _) -> Some "Error: RequestMessage cannot be send in plaintext"
     | Some (ResponseMessage {nonce; ciphertext}) -> (
       match ciphertext with
-      | AeadEnc key nonce msg ad -> reqres_payload_to_string msg
+      | AeadEnc key nonce response ad -> (
+        let? response_parsed = parse reqres_type response in 
+        Some (reqres_payload_to_string response_parsed)
+      )
       | _ -> Some "Error: response_envelope does not contain an AEAD ciphertext"
     )
     | None -> Some (option_to_string msg_to_string b)
@@ -78,45 +87,59 @@ let com_core_event_to_string payload_to_string =
         sender receiver (option_to_string payload_to_string payload))
   )))
 
-val com_reqres_event_to_string: {|comm_layer_reqres_tag|} -> (bytes -> option string) -> (string & (bytes -> option string))
-let com_reqres_event_to_string #tag payload_to_string =
+val com_reqres_event_to_string:
+  {|comm_layer_reqres_tag|} ->
+  #reqres_type:Type -> {|parseable_serializeable bytes reqres_type|} ->
+  (reqres_type -> string) -> 
+  (string & (bytes -> option string))
+let com_reqres_event_to_string #tag #reqres_type payload_to_string =
   (event_communication_reqres_event.tag, (fun b -> (
     let? cre = parse communication_reqres_event b in
     match cre with
-    | CommClientSendRequest client server request key -> 
+    | CommClientSendRequest client server request key -> (
+      let? request_parsed = parse reqres_type request in
       Some (Printf.sprintf "CommClientSendRequest client = %s, server = %s, request = (%s)"
-        client server (option_to_string payload_to_string request))
-    | CommServerReceiveRequest server request key -> 
+        client server (payload_to_string request_parsed))
+    )
+    | CommServerReceiveRequest server request key -> (
+      let? request_parsed = parse reqres_type request in
       Some (Printf.sprintf "CommServerReceiveRequest server = %s, request = (%s), key = %s"
-        server (option_to_string payload_to_string request) (bytes_to_string key))
-    | CommServerSendResponse server request response -> 
+        server (payload_to_string request_parsed) (bytes_to_string key))
+    )
+    | CommServerSendResponse server request response -> (
+      let? request_parsed = parse reqres_type request in
+      let? response_parsed = parse reqres_type response in
       Some (Printf.sprintf "CommServerSendResponse server = %s, request = %s, response = (%s)"
-        server (option_to_string payload_to_string request) (option_to_string payload_to_string response))
-    | CommClientReceiveResponse client server response key -> 
+        server (payload_to_string request_parsed) (payload_to_string response_parsed))
+    )
+    | CommClientReceiveResponse client server response key -> (
+      let? response_parsed = parse reqres_type response in
       Some (Printf.sprintf "CommClientReceiveResponse client = %s, server = %s, response = (%s), key = %s" 
-        client server (option_to_string payload_to_string response) (bytes_to_string key))
+        client server (payload_to_string response_parsed) (bytes_to_string key))
+    )
   )))
 
 val com_event_to_string:
   {|comm_layer_reqres_tag|} ->
-  (bytes -> option string) -> (bytes -> option string) ->
+  #reqres_type:Type -> {|parseable_serializeable bytes reqres_type|} ->
+  (bytes -> option string) -> (reqres_type -> string) ->
   list (string & (bytes -> option string))
-let com_event_to_string #tag core_payload_to_string reqres_payload_to_string =
+let com_event_to_string #tag #reqres_type core_payload_to_string reqres_payload_to_string =
   [com_core_event_to_string core_payload_to_string;
-    com_reqres_event_to_string reqres_payload_to_string]
+    com_reqres_event_to_string #tag #reqres_type reqres_payload_to_string]
 
-val com_state_to_string: (bytes -> option string) -> (string & (bytes -> option string))
-let com_state_to_string payload_to_string =
-  (local_state_communication_layer_session.tag, (fun b -> (
-    let? cs = parse communication_states b in
+val com_state_to_string: {|t:comm_layer_reqres_tag|} -> (#a:Type0) -> {|comparse_parser_serializer a|} -> (a -> string) -> (string & (bytes -> option string))
+let com_state_to_string #tag #a #ps payload_to_string =
+  ((local_state_communication_layer_session a).tag, (fun b -> (
+    let? cs = parse (communication_states a) b in
     match cs with
     | ClientSendRequest {server; request; key} -> 
       Some (Printf.sprintf "ClientSendRequest server = %s, payload = (%s), key = %s" 
-        server (option_to_string payload_to_string request) (bytes_to_string key))
+        server (payload_to_string request) (bytes_to_string key))
     | ServerReceiveRequest {request; key} -> 
       Some (Printf.sprintf "ServerReceiveRequest payload = (%s), key = %s"
-        (option_to_string payload_to_string request) (bytes_to_string key)) 
+        (payload_to_string request) (bytes_to_string key)) 
     | ClientReceiveResponse {server; response; key} -> 
       Some (Printf.sprintf "ClientReceiveResponse server = %s, payload = (%s), key = %s"
-        server (option_to_string payload_to_string response) (bytes_to_string key))
+        server (payload_to_string response) (bytes_to_string key))
   )))

--- a/src/lib/communication/DY.Lib.Communication.Printing.fst
+++ b/src/lib/communication/DY.Lib.Communication.Printing.fst
@@ -78,8 +78,8 @@ let com_core_event_to_string payload_to_string =
         sender receiver (option_to_string payload_to_string payload))
   )))
 
-val com_reqres_event_to_string: {|comm_layer_event_reqres_tag|} -> (bytes -> option string) -> (string & (bytes -> option string))
-let com_reqres_event_to_string #event_tag payload_to_string =
+val com_reqres_event_to_string: {|comm_layer_reqres_tag|} -> (bytes -> option string) -> (string & (bytes -> option string))
+let com_reqres_event_to_string #tag payload_to_string =
   (event_communication_reqres_event.tag, (fun b -> (
     let? cre = parse communication_reqres_event b in
     match cre with
@@ -98,10 +98,10 @@ let com_reqres_event_to_string #event_tag payload_to_string =
   )))
 
 val com_event_to_string:
-  {|comm_layer_event_reqres_tag|} ->
+  {|comm_layer_reqres_tag|} ->
   (bytes -> option string) -> (bytes -> option string) ->
   list (string & (bytes -> option string))
-let com_event_to_string #event_tag core_payload_to_string reqres_payload_to_string =
+let com_event_to_string #tag core_payload_to_string reqres_payload_to_string =
   [com_core_event_to_string core_payload_to_string;
     com_reqres_event_to_string reqres_payload_to_string]
 

--- a/src/lib/communication/DY.Lib.Communication.Printing.fst
+++ b/src/lib/communication/DY.Lib.Communication.Printing.fst
@@ -33,14 +33,12 @@ let comm_message_to_string #core_type #core_config #reqres_type #reqres_config m
   | _ -> (
     match parse comm_message_t b with
     | Some (SigMessage {msg; signature}) -> (
-      match parse signature_input msg with
+      match parse (signature_input core_type) msg with
       | Some si -> (
         let sender, receiver, payload = (
           match si with
           | Plain sender receiver payload -> (
-            sender, receiver, (match parse core_type payload with
-            | None -> "Error: signature_input payload could not be parsed"
-            | Some payload_parsed -> msg_to_string payload_parsed))
+            sender, receiver, msg_to_string payload)
           | Encrypted sender receiver payload _ -> sender, receiver, (
             match payload with
             | PkeEnc pk nonce msg -> (

--- a/src/lib/communication/DY.Lib.Communication.Printing.fst
+++ b/src/lib/communication/DY.Lib.Communication.Printing.fst
@@ -10,40 +10,45 @@ open DY.Lib.Communication.RequestResponse
 
 #set-options "--fuel 0 --ifuel 1 --z3cliopt 'smt.qi.eager_threshold=100'"
 
-val com_message_to_string:
-  #reqres_type:Type -> {|parseable_serializeable bytes reqres_type|} -> 
-  (bytes -> option string) -> (reqres_type -> string) -> bytes ->
+val comm_message_to_string:
+  #core_type:Type0 -> {|comm_layer_core_config core_type|} ->
+  #reqres_type:Type -> {|comm_layer_reqres_config reqres_type|} -> 
+  (core_type -> string) -> (reqres_type -> string) -> bytes ->
   option string
-let com_message_to_string #reqres_type msg_to_string reqres_payload_to_string b =
+let comm_message_to_string #core_type #core_config #reqres_type #reqres_config msg_to_string reqres_payload_to_string b =
   match b with
   | PkeEnc pk nonce msg -> (
-    match parse com_message_t msg with
+    match parse comm_message_t msg with
     | Some (SigMessage _) -> Some "Error: SigMessage cannot be inside a PkeEnc encryption"
     | Some (RequestMessage {request; key}) -> (
       let? request_parsed = parse reqres_type request in 
       Some (reqres_payload_to_string request_parsed)
     )
     | Some (ResponseMessage _) -> Some "Error: ResponseMessage cannot be inside a PkeEnc encryption"
-    | None -> Some (option_to_string msg_to_string b)
+    | None -> (
+      let? b_parsed = parse core_type b in
+      Some (msg_to_string b_parsed)
+    )
   )
   | _ -> (
-    match parse com_message_t b with
+    match parse comm_message_t b with
     | Some (SigMessage {msg; signature}) -> (
       match parse signature_input msg with
       | Some si -> (
         let sender, receiver, payload = (
           match si with
-          | Plain sender receiver payload -> sender, receiver, (option_to_string msg_to_string payload)
+          | Plain sender receiver payload -> (
+            sender, receiver, (match parse core_type payload with
+            | None -> "Error: signature_input payload could not be parsed"
+            | Some payload_parsed -> msg_to_string payload_parsed))
           | Encrypted sender receiver payload _ -> sender, receiver, (
-            match parse com_send_byte payload with
-            | Some {b} -> (
-              match b with
-              | PkeEnc pk nonce msg -> (
-                Printf.sprintf "pk_enc (pk = %s, msg = (%s))"
-                  (bytes_to_string pk) (option_to_string msg_to_string msg))
-              | _ -> "Error: com_send_byte message does not contain a PkeEnc encrypted message"
-            )
-            | None -> "Error: encrypted signature input does not contain a com_send_byte message"
+            match payload with
+            | PkeEnc pk nonce msg -> (
+              match parse core_type msg with
+              | None -> "Error: pk_enc message could not be parsed"
+              | Some msg_parsed -> Printf.sprintf "pk_enc (pk = %s, msg = (%s))"
+                (bytes_to_string pk) (msg_to_string msg_parsed))
+            | _ -> "Error: com_send_byte message does not contain a PkeEnc encrypted message"
           )
         ) in
         Some (Printf.sprintf "msg = (<BREAK>\tsender = %s,<BREAK>\treceiver = %s,<BREAK>\tpayload = (%s<BREAK>\t)<BREAK>),<BREAK>signature = sig(sk_{%s}, msg)" sender receiver payload sender)
@@ -59,77 +64,77 @@ let com_message_to_string #reqres_type msg_to_string reqres_payload_to_string b 
       )
       | _ -> Some "Error: response_envelope does not contain an AEAD ciphertext"
     )
-    | None -> Some (option_to_string msg_to_string b)
+    | None -> (
+      let? b_parsed = parse core_type b in
+      Some (msg_to_string b_parsed)
+    )
   )
 
-val com_core_event_to_string: (bytes -> option string) -> (string & (bytes -> option string))
-let com_core_event_to_string payload_to_string =
-  (event_communication_event.tag, (fun b -> (
-    let? ce = parse communication_event b in
+val com_core_event_to_string:
+  #a:Type0 -> {|comm_layer_core_config a|} ->
+  (a -> string) ->
+  (string & (bytes -> option string))
+let com_core_event_to_string #a payload_to_string =
+  ((event_communication_core_event a).tag, (fun b -> (
+    let? ce = parse (communication_core_event a) b in
     match ce with
     | CommConfSendMsg sender receiver payload ->
       Some (Printf.sprintf "CommConfSendMsg sender = %s, receiver = %s, payload = (%s)"
-        sender receiver (option_to_string payload_to_string payload))
+        sender receiver (payload_to_string payload))
     | CommConfReceiveMsg receiver payload ->
       Some (Printf.sprintf "CommConfReceiveMsg receiver = %s, payload = (%s)"
-        receiver (option_to_string payload_to_string payload))
+        receiver (payload_to_string payload))
     | CommAuthSendMsg sender payload ->
       Some (Printf.sprintf "CommAuthSendMsg sender = %s, payload = (%s)"
-        sender (option_to_string payload_to_string payload))
+        sender (payload_to_string payload))
     | CommAuthReceiveMsg sender receiver payload -> 
       Some (Printf.sprintf "CommAuthReceiveMsg sender = %s, receiver = %s, payload = (%s)"
-        sender receiver (option_to_string payload_to_string payload))
+        sender receiver (payload_to_string payload))
     | CommConfAuthSendMsg sender receiver payload -> 
       Some (Printf.sprintf "CommConfAuthSendMsg sender = %s, receiver = %s, payload = (%s)"
-        sender receiver (option_to_string payload_to_string payload))
+        sender receiver (payload_to_string payload))
     | CommConfAuthReceiveMsg sender receiver payload ->
       Some (Printf.sprintf "CommConfAuthReceiveMsg sender = %s, receiver = %s, payload = (%s)"
-        sender receiver (option_to_string payload_to_string payload))
+        sender receiver (payload_to_string payload))
   )))
 
 val com_reqres_event_to_string:
-  {|comm_layer_reqres_tag|} ->
-  #reqres_type:Type -> {|parseable_serializeable bytes reqres_type|} ->
-  (reqres_type -> string) -> 
+  #a:Type0 -> {|comm_layer_reqres_config a|} ->
+  (a -> string) -> 
   (string & (bytes -> option string))
-let com_reqres_event_to_string #tag #reqres_type payload_to_string =
-  (event_communication_reqres_event.tag, (fun b -> (
-    let? cre = parse communication_reqres_event b in
+let com_reqres_event_to_string #a payload_to_string =
+  ((event_communication_reqres_event #a).tag, (fun b -> (
+    let? cre = parse (communication_reqres_event a) b in
     match cre with
     | CommClientSendRequest client server request key -> (
-      let? request_parsed = parse reqres_type request in
       Some (Printf.sprintf "CommClientSendRequest client = %s, server = %s, request = (%s)"
-        client server (payload_to_string request_parsed))
+        client server (payload_to_string request))
     )
     | CommServerReceiveRequest server request key -> (
-      let? request_parsed = parse reqres_type request in
       Some (Printf.sprintf "CommServerReceiveRequest server = %s, request = (%s), key = %s"
-        server (payload_to_string request_parsed) (bytes_to_string key))
+        server (payload_to_string request) (bytes_to_string key))
     )
     | CommServerSendResponse server request response -> (
-      let? request_parsed = parse reqres_type request in
-      let? response_parsed = parse reqres_type response in
       Some (Printf.sprintf "CommServerSendResponse server = %s, request = %s, response = (%s)"
-        server (payload_to_string request_parsed) (payload_to_string response_parsed))
+        server (payload_to_string request) (payload_to_string response))
     )
     | CommClientReceiveResponse client server response key -> (
-      let? response_parsed = parse reqres_type response in
       Some (Printf.sprintf "CommClientReceiveResponse client = %s, server = %s, response = (%s), key = %s" 
-        client server (payload_to_string response_parsed) (bytes_to_string key))
+        client server (payload_to_string response) (bytes_to_string key))
     )
   )))
 
 val com_event_to_string:
-  {|comm_layer_reqres_tag|} ->
-  #reqres_type:Type -> {|parseable_serializeable bytes reqres_type|} ->
-  (bytes -> option string) -> (reqres_type -> string) ->
+  #core_type:Type0 -> {|comm_layer_core_config core_type|} ->
+  #reqres_type:Type0 -> {|comm_layer_reqres_config reqres_type|} ->
+  (core_type -> string) -> (reqres_type -> string) ->
   list (string & (bytes -> option string))
-let com_event_to_string #tag #reqres_type core_payload_to_string reqres_payload_to_string =
+let com_event_to_string #core_type #reqres_type core_payload_to_string reqres_payload_to_string =
   [com_core_event_to_string core_payload_to_string;
-    com_reqres_event_to_string #tag #reqres_type reqres_payload_to_string]
+    com_reqres_event_to_string reqres_payload_to_string]
 
-val com_state_to_string: {|t:comm_layer_reqres_tag|} -> (#a:Type0) -> {|comparse_parser_serializer a|} -> (a -> string) -> (string & (bytes -> option string))
-let com_state_to_string #tag #a #ps payload_to_string =
+val com_state_to_string: (#a:Type0) -> {|comm_layer_reqres_config a|} -> (a -> string) -> (string & (bytes -> option string))
+let com_state_to_string #a payload_to_string =
   ((local_state_communication_layer_session a).tag, (fun b -> (
     let? cs = parse (communication_states a) b in
     match cs with

--- a/src/lib/communication/DY.Lib.Communication.Printing.fst
+++ b/src/lib/communication/DY.Lib.Communication.Printing.fst
@@ -26,8 +26,9 @@ let comm_message_to_string #core_type #core_config #reqres_type #reqres_config m
     )
     | Some (ResponseMessage _) -> Some "Error: ResponseMessage cannot be inside a PkeEnc encryption"
     | None -> (
-      let? b_parsed = parse core_type b in
-      Some (msg_to_string b_parsed)
+      let? b_parsed = parse core_type msg in
+      Some (Printf.sprintf "pk_enc (pk = %s, msg = (%s))"
+              (bytes_to_string pk) (msg_to_string b_parsed))
     )
   )
   | _ -> (

--- a/src/lib/communication/DY.Lib.Communication.RequestResponse.Invariants.fst
+++ b/src/lib/communication/DY.Lib.Communication.RequestResponse.Invariants.fst
@@ -101,8 +101,7 @@ val has_communication_layer_state_predicates:
   {|protocol_invariants|} ->
   prop
 let has_communication_layer_state_predicates #tag #invs =
-  has_local_state_predicate state_predicates_communication_layer /\
-  has_local_state_update_predicate (default_local_state_update_pred communication_states)
+  has_local_state_predicate state_predicates_communication_layer
 
 (*** Event Predicates ***)
 

--- a/src/lib/communication/DY.Lib.Communication.RequestResponse.Invariants.fst
+++ b/src/lib/communication/DY.Lib.Communication.RequestResponse.Invariants.fst
@@ -44,12 +44,29 @@ let aead_crypto_predicate_communication_layer #cusages a #config = {
 }
 #pop-options
 
-val aead_crypto_predicates_communication_layer_and_tag:
+val aead_crypto_predicates_communication_layer_reqres_and_tag:
   {|cusages:crypto_usages|} ->
   a:Type0 -> {|comm_layer_reqres_config a|} ->
   (string & aead_crypto_predicate)
-let aead_crypto_predicates_communication_layer_and_tag #cusages a #config =
+let aead_crypto_predicates_communication_layer_reqres_and_tag #cusages a #config =
   (comm_layer_aead_tag a, aead_crypto_predicate_communication_layer a)
+
+
+(*** Core Crypto Predicates ***)
+
+val pke_crypto_predicates_communication_layer_reqres_and_tag:
+  {|cusages:crypto_usages|} ->
+  a:Type0 -> {|comm_layer_reqres_config a|} ->
+  (string & pke_crypto_predicate)
+let pke_crypto_predicates_communication_layer_reqres_and_tag #cusages a #config =
+  pke_crypto_predicates_communication_layer_core_and_tag comm_message_t #(comm_layer_tag_core_config_reqres a)
+
+val sign_crypto_predicates_communication_layer_reqres_and_tag:
+  {|cusages:crypto_usages|} ->
+  a:Type0 -> {|comm_layer_reqres_config a|} ->
+  (string & sign_crypto_predicate)
+let sign_crypto_predicates_communication_layer_reqres_and_tag #cusages a #config =
+  sign_crypto_predicates_communication_layer_core_and_tag comm_message_t #(comm_layer_tag_core_config_reqres a)
 
 val has_communication_layer_reqres_crypto_predicates:
   {|cinvs:crypto_invariants|} ->
@@ -58,14 +75,14 @@ val has_communication_layer_reqres_crypto_predicates:
 let has_communication_layer_reqres_crypto_predicates #cinvs a #config =
   // Fix for the get_label function in the model code
   cinvs.usages == default_crypto_usages /\
-  has_pke_predicate (pke_crypto_predicates_communication_layer_and_tag comm_message_t) /\
-  has_sign_predicate (sign_crypto_predicates_communication_layer_and_tag comm_message_t) /\
-  has_aead_predicate (aead_crypto_predicates_communication_layer_and_tag a)
+  has_pke_predicate (pke_crypto_predicates_communication_layer_reqres_and_tag a) /\
+  has_sign_predicate (sign_crypto_predicates_communication_layer_reqres_and_tag a) /\
+  has_aead_predicate (aead_crypto_predicates_communication_layer_reqres_and_tag a)
 
 
 (*** State Predicates ***)
 
-#push-options "--ifuel 5 --fuel 5 --z3rlimit 25"
+#push-options "--ifuel 2 --z3rlimit 10"
 let state_predicates_communication_layer {|crypto_invariants|} (a:Type) {|comm_layer_reqres_config a|}: local_state_predicate (communication_states a) = {
   pred = (fun tr prin sess_id st ->
     match st with
@@ -100,18 +117,18 @@ let state_predicates_communication_layer {|crypto_invariants|} (a:Type) {|comm_l
 }
 #pop-options
 
-val state_predicates_communication_layer_and_tag:
+val state_predicates_communication_layer_reqres_and_tag:
   {|crypto_invariants|} ->
   (a:Type0) -> {|comm_layer_reqres_config a|} ->
   dtuple2 string local_bytes_state_predicate
-let state_predicates_communication_layer_and_tag #cinvs a #config =
+let state_predicates_communication_layer_reqres_and_tag #cinvs a #config =
   mk_local_state_tag_and_pred (state_predicates_communication_layer a)
 
-val has_communication_layer_state_predicates:
+val has_communication_layer_reqres_state_predicates:
   {|protocol_invariants|} ->
   (a:Type0) -> {|comm_layer_reqres_config a|} ->
   prop
-let has_communication_layer_state_predicates #invs a #config =
+let has_communication_layer_reqres_state_predicates #invs a #config =
   has_local_state_predicate (state_predicates_communication_layer a)
 
 (*** Event Predicates ***)
@@ -188,12 +205,12 @@ let event_predicate_communication_layer_reqres
 
 // Additional event preconditions for the events from the core communication layer
 #push-options "--fuel 0 --ifuel 2"
-val request_response_event_preconditions:
+val comm_core_higher_layer_event_preds_reqres:
   {|cinvs:crypto_invariants|} ->
   (a:Type0) -> {|comm_layer_reqres_config a|} ->
-  comm_higher_layer_event_preds comm_message_t
-let request_response_event_preconditions #cinvs a #config = {
-  (default_comm_higher_layer_event_preds comm_message_t) with
+  comm_core_higher_layer_event_preds comm_message_t #(comm_layer_tag_core_config_reqres a)
+let comm_core_higher_layer_event_preds_reqres #cinvs a #config = {
+  (default_comm_core_higher_layer_event_preds comm_message_t #(comm_layer_tag_core_config_reqres a)) with
   send_conf = (fun tr client server (com_msg_t:comm_message_t) ->
     match com_msg_t with
     | RequestMessage {request; key} -> (
@@ -215,7 +232,7 @@ val event_predicate_communication_layer_reqres_and_tag:
   list (string & compiled_event_predicate)
 let event_predicate_communication_layer_reqres_and_tag #cinvs #a higher_layer_resreq_preds =
   [
-    event_predicate_communication_layer_and_tag (request_response_event_preconditions a);
+    event_predicate_communication_layer_core_and_tag (comm_core_higher_layer_event_preds_reqres a);
     mk_event_tag_and_pred (event_predicate_communication_layer_reqres higher_layer_resreq_preds)
   ]
 
@@ -225,5 +242,5 @@ val has_communication_layer_reqres_event_predicates:
   comm_reqres_higher_layer_event_preds a ->
   prop
 let has_communication_layer_reqres_event_predicates #invs #a #config higher_layer_resreq_preds =
-  has_event_pred (event_predicate_communication_layer (request_response_event_preconditions a)) /\
+  has_event_pred (event_predicate_communication_layer_core (comm_core_higher_layer_event_preds_reqres a)) /\
   has_event_pred (event_predicate_communication_layer_reqres higher_layer_resreq_preds)

--- a/src/lib/communication/DY.Lib.Communication.RequestResponse.Invariants.fst
+++ b/src/lib/communication/DY.Lib.Communication.RequestResponse.Invariants.fst
@@ -43,6 +43,7 @@ let aead_crypto_predicate_communication_layer_reqres #cusages a #config = {
     | Some {server} -> ()
   ))
 }
+#pop-options
 
 val aead_crypto_predicate_and_tag_communication_layer_reqres:
   {|cusages:crypto_usages|} ->

--- a/src/lib/communication/DY.Lib.Communication.RequestResponse.Invariants.fst
+++ b/src/lib/communication/DY.Lib.Communication.RequestResponse.Invariants.fst
@@ -21,11 +21,11 @@ open DY.Lib.Communication.Core.Invariants
 (*** AEAD Predicate ***)
 
 #push-options "--ifuel 1"
-val aead_crypto_predicate_communication_layer:
+val aead_crypto_predicate_communication_layer_reqres:
   {|cusages:crypto_usages|} ->
   a:Type0 -> {|comm_layer_reqres_config a|} ->
   aead_crypto_predicate
-let aead_crypto_predicate_communication_layer #cusages a #config = {
+let aead_crypto_predicate_communication_layer_reqres #cusages a #config = {
   pred = (fun tr key_usage key nonce msg ad ->
       (match parse authenticated_data ad with
       | None -> False
@@ -44,29 +44,29 @@ let aead_crypto_predicate_communication_layer #cusages a #config = {
 }
 #pop-options
 
-val aead_crypto_predicates_communication_layer_reqres_and_tag:
+val aead_crypto_predicate_and_tag_communication_layer_reqres:
   {|cusages:crypto_usages|} ->
   a:Type0 -> {|comm_layer_reqres_config a|} ->
   (string & aead_crypto_predicate)
-let aead_crypto_predicates_communication_layer_reqres_and_tag #cusages a #config =
-  (comm_layer_aead_tag a, aead_crypto_predicate_communication_layer a)
+let aead_crypto_predicate_and_tag_communication_layer_reqres #cusages a #config =
+  (comm_layer_aead_tag a, aead_crypto_predicate_communication_layer_reqres a)
 
 
 (*** Core Crypto Predicates ***)
 
-val pke_crypto_predicates_communication_layer_reqres_and_tag:
+val pke_crypto_predicate_and_tag_communication_layer_reqres:
   {|cusages:crypto_usages|} ->
   a:Type0 -> {|comm_layer_reqres_config a|} ->
   (string & pke_crypto_predicate)
-let pke_crypto_predicates_communication_layer_reqres_and_tag #cusages a #config =
-  pke_crypto_predicates_communication_layer_core_and_tag comm_message_t #(comm_layer_tag_core_config_reqres a)
+let pke_crypto_predicate_and_tag_communication_layer_reqres #cusages a #config =
+  pke_crypto_predicates_and_tag_communication_layer_core comm_message_t #(comm_layer_tag_core_config_reqres a)
 
-val sign_crypto_predicates_communication_layer_reqres_and_tag:
+val sign_crypto_predicate_and_tag_communication_layer_reqres:
   {|cusages:crypto_usages|} ->
   a:Type0 -> {|comm_layer_reqres_config a|} ->
   (string & sign_crypto_predicate)
-let sign_crypto_predicates_communication_layer_reqres_and_tag #cusages a #config =
-  sign_crypto_predicates_communication_layer_core_and_tag comm_message_t #(comm_layer_tag_core_config_reqres a)
+let sign_crypto_predicate_and_tag_communication_layer_reqres #cusages a #config =
+  sign_crypto_predicate_and_tag_communication_layer_core comm_message_t #(comm_layer_tag_core_config_reqres a)
 
 val has_communication_layer_reqres_crypto_predicates:
   {|cinvs:crypto_invariants|} ->
@@ -75,15 +75,15 @@ val has_communication_layer_reqres_crypto_predicates:
 let has_communication_layer_reqres_crypto_predicates #cinvs a #config =
   // Fix for the get_label function in the model code
   cinvs.usages == default_crypto_usages /\
-  has_pke_predicate (pke_crypto_predicates_communication_layer_reqres_and_tag a) /\
-  has_sign_predicate (sign_crypto_predicates_communication_layer_reqres_and_tag a) /\
-  has_aead_predicate (aead_crypto_predicates_communication_layer_reqres_and_tag a)
+  has_pke_predicate (pke_crypto_predicate_and_tag_communication_layer_reqres a) /\
+  has_sign_predicate (sign_crypto_predicate_and_tag_communication_layer_reqres a) /\
+  has_aead_predicate (aead_crypto_predicate_and_tag_communication_layer_reqres a)
 
 
 (*** State Predicates ***)
 
 #push-options "--ifuel 2 --z3rlimit 10"
-let state_predicates_communication_layer {|crypto_invariants|} (a:Type) {|comm_layer_reqres_config a|}: local_state_predicate (communication_states a) = {
+let state_predicate_communication_layer_reqres {|crypto_invariants|} (a:Type) {|comm_layer_reqres_config a|}: local_state_predicate (communication_states a) = {
   pred = (fun tr prin sess_id st ->
     match st with
     | ClientSendRequest {server; request; key} -> (
@@ -107,29 +107,27 @@ let state_predicates_communication_layer {|crypto_invariants|} (a:Type) {|comm_l
   pred_later = (fun tr1 tr2 prin sess_id st -> ());
   pred_knowable = (fun tr prin sess_id st -> (
     match st with
-    | ClientSendRequest {server; request; key} ->
-      assert(is_well_formed a (is_knowable_by (principal_typed_state_content_label prin (DY.Lib.State.Typed.tag #(communication_states a)) sess_id st) tr) request)
-    | ServerReceiveRequest {request; key} ->
-      assert(is_well_formed a (is_knowable_by (principal_typed_state_content_label prin (DY.Lib.State.Typed.tag #(communication_states a)) sess_id st) tr) request)
-    | ClientReceiveResponse {server; response; key} ->
-      assert(is_well_formed a (is_knowable_by (principal_typed_state_content_label prin (DY.Lib.State.Typed.tag #(communication_states a)) sess_id st) tr) response)
+    | ClientSendRequest {server=_; request=payload; key}
+    | ServerReceiveRequest {request=payload; key}
+    | ClientReceiveResponse {server=_; response=payload; key} ->
+      assert(is_well_formed a (is_knowable_by (principal_typed_state_content_label prin (DY.Lib.State.Typed.tag #(communication_states a)) sess_id st) tr) payload)
   ));
 }
 #pop-options
 
-val state_predicates_communication_layer_reqres_and_tag:
+val state_predicate_and_tag_communication_layer_reqres:
   {|crypto_invariants|} ->
   (a:Type0) -> {|comm_layer_reqres_config a|} ->
   dtuple2 string local_bytes_state_predicate
-let state_predicates_communication_layer_reqres_and_tag #cinvs a #config =
-  mk_local_state_tag_and_pred (state_predicates_communication_layer a)
+let state_predicate_and_tag_communication_layer_reqres #cinvs a #config =
+  mk_local_state_tag_and_pred (state_predicate_communication_layer_reqres a)
 
-val has_communication_layer_reqres_state_predicates:
+val has_communication_layer_reqres_state_predicate:
   {|protocol_invariants|} ->
   (a:Type0) -> {|comm_layer_reqres_config a|} ->
   prop
-let has_communication_layer_reqres_state_predicates #invs a #config =
-  has_local_state_predicate (state_predicates_communication_layer a)
+let has_communication_layer_reqres_state_predicate #invs a #config =
+  has_local_state_predicate (state_predicate_communication_layer_reqres a)
 
 (*** Event Predicates ***)
 
@@ -214,9 +212,7 @@ let comm_core_higher_layer_event_preds_reqres #cinvs a #config = {
   send_conf = (fun tr client server (com_msg_t:comm_message_t) ->
     match com_msg_t with
     | RequestMessage {request; key} -> (
-      match parse a request with
-      | None -> False
-      | Some request_parsed -> event_triggered tr client (CommClientSendRequest client server request_parsed key <: communication_reqres_event a)
+      parse_and_pred (fun request_parsed -> event_triggered tr client (CommClientSendRequest client server request_parsed key <: communication_reqres_event a)) request
     )
     | _ -> False
   );
@@ -232,7 +228,7 @@ val event_predicate_communication_layer_reqres_and_tag:
   list (string & compiled_event_predicate)
 let event_predicate_communication_layer_reqres_and_tag #cinvs #a higher_layer_resreq_preds =
   [
-    event_predicate_communication_layer_core_and_tag (comm_core_higher_layer_event_preds_reqres a);
+    event_predicate_and_tag_communication_layer_core (comm_core_higher_layer_event_preds_reqres a);
     mk_event_tag_and_pred (event_predicate_communication_layer_reqres higher_layer_resreq_preds)
   ]
 
@@ -244,3 +240,16 @@ val has_communication_layer_reqres_event_predicates:
 let has_communication_layer_reqres_event_predicates #invs #a #config higher_layer_resreq_preds =
   has_event_pred (event_predicate_communication_layer_core (comm_core_higher_layer_event_preds_reqres a)) /\
   has_event_pred (event_predicate_communication_layer_reqres higher_layer_resreq_preds)
+
+
+(*** All Communication Layer ReqRes Predicates ***)
+
+val has_communication_layer_reqres_predicates:
+  {|protocol_invariants|} ->
+  #a:Type0 -> {| comm_layer_reqres_config a |} ->
+  comm_reqres_higher_layer_event_preds a ->
+  prop
+let has_communication_layer_reqres_predicates #invs #a #config higher_layer_resreq_preds =
+  has_communication_layer_reqres_crypto_predicates a /\
+  has_communication_layer_reqres_event_predicates higher_layer_resreq_preds /\
+  has_communication_layer_reqres_state_predicate a

--- a/src/lib/communication/DY.Lib.Communication.RequestResponse.Invariants.fst
+++ b/src/lib/communication/DY.Lib.Communication.RequestResponse.Invariants.fst
@@ -22,15 +22,18 @@ open DY.Lib.Communication.Core.Invariants
 
 #push-options "--ifuel 1"
 val aead_crypto_predicate_communication_layer:
-  {|comm_layer_reqres_tag|} ->
   {|cusages:crypto_usages|} ->
+  a:Type0 -> {|comm_layer_reqres_config a|} ->
   aead_crypto_predicate
-let aead_crypto_predicate_communication_layer #tag #cusages = {
+let aead_crypto_predicate_communication_layer #cusages a #config = {
   pred = (fun tr key_usage key nonce msg ad ->
       (match parse authenticated_data ad with
       | None -> False
       | Some {server} -> (exists request.
-        event_triggered tr server (CommServerSendResponse server request msg)
+        match parse a msg with
+        | None -> False
+        | Some response ->
+          event_triggered tr server (CommServerSendResponse server request response <: communication_reqres_event a)
       )
     )
   );
@@ -42,45 +45,45 @@ let aead_crypto_predicate_communication_layer #tag #cusages = {
 #pop-options
 
 val aead_crypto_predicates_communication_layer_and_tag:
-  {|comm_layer_reqres_tag|} ->
   {|cusages:crypto_usages|} ->
+  a:Type0 -> {|comm_layer_reqres_config a|} ->
   (string & aead_crypto_predicate)
-let aead_crypto_predicates_communication_layer_and_tag #tag #cusages =
-  (comm_layer_aead_tag, aead_crypto_predicate_communication_layer)
+let aead_crypto_predicates_communication_layer_and_tag #cusages a #config =
+  (comm_layer_aead_tag a, aead_crypto_predicate_communication_layer a)
 
 val has_communication_layer_reqres_crypto_predicates:
-  {|comm_layer_reqres_tag|} ->
   {|cinvs:crypto_invariants|} ->
+  a:Type0 -> {|comm_layer_reqres_config a|} ->
   prop
-let has_communication_layer_reqres_crypto_predicates #tag #cinvs =
+let has_communication_layer_reqres_crypto_predicates #cinvs a #config =
   // Fix for the get_label function in the model code
   cinvs.usages == default_crypto_usages /\
-  has_pke_predicate pke_crypto_predicates_communication_layer_and_tag /\
-  has_sign_predicate sign_crypto_predicates_communication_layer_and_tag /\
-  has_aead_predicate aead_crypto_predicates_communication_layer_and_tag
+  has_pke_predicate (pke_crypto_predicates_communication_layer_and_tag comm_message_t) /\
+  has_sign_predicate (sign_crypto_predicates_communication_layer_and_tag comm_message_t) /\
+  has_aead_predicate (aead_crypto_predicates_communication_layer_and_tag a)
 
 
 (*** State Predicates ***)
 
 #push-options "--ifuel 5 --fuel 5 --z3rlimit 25"
-let state_predicates_communication_layer {|comm_layer_reqres_tag|} {|crypto_invariants|} (a:Type) {|comparse_parser_serializer a|}: local_state_predicate (communication_states a) = {
+let state_predicates_communication_layer {|crypto_invariants|} (a:Type) {|comm_layer_reqres_config a|}: local_state_predicate (communication_states a) = {
   pred = (fun tr prin sess_id st ->
     match st with
     | ClientSendRequest {server; request; key} -> (
       let client = prin in
-      is_well_formed a #ps_able (is_knowable_by (comm_label client server) tr) request /\
+      is_well_formed a (is_knowable_by (comm_label client server) tr) request /\
       is_secret (comm_label client server) tr key /\
-      key `has_usage tr` (AeadKey comm_layer_aead_tag empty)
+      key `has_usage tr` (AeadKey (comm_layer_aead_tag a) empty)
     )
     | ServerReceiveRequest {request; key} -> (
       let server = prin in
       is_knowable_by (principal_label server) tr key /\
-      is_well_formed a #ps_able (is_knowable_by (principal_label server) tr) request /\
-      key `has_usage tr` (AeadKey comm_layer_aead_tag empty)
+      is_well_formed a (is_knowable_by (principal_label server) tr) request /\
+      key `has_usage tr` (AeadKey (comm_layer_aead_tag a) empty)
     )
     | ClientReceiveResponse {server; response; key} -> (
       let client = prin in
-      is_well_formed a #ps_able (is_knowable_by (comm_label client server) tr) response /\
+      is_well_formed a (is_knowable_by (comm_label client server) tr) response /\
       is_secret (comm_label client server) tr key
     )
   );
@@ -88,35 +91,33 @@ let state_predicates_communication_layer {|comm_layer_reqres_tag|} {|crypto_inva
   pred_knowable = (fun tr prin sess_id st -> (
     match st with
     | ClientSendRequest {server; request; key} ->
-      assert(is_well_formed a #ps_able (is_knowable_by (principal_typed_state_content_label prin (DY.Lib.State.Typed.tag #(communication_states a)) sess_id st) tr) request)
+      assert(is_well_formed a (is_knowable_by (principal_typed_state_content_label prin (DY.Lib.State.Typed.tag #(communication_states a)) sess_id st) tr) request)
     | ServerReceiveRequest {request; key} ->
-      assert(is_well_formed a #ps_able (is_knowable_by (principal_typed_state_content_label prin (DY.Lib.State.Typed.tag #(communication_states a)) sess_id st) tr) request)
+      assert(is_well_formed a (is_knowable_by (principal_typed_state_content_label prin (DY.Lib.State.Typed.tag #(communication_states a)) sess_id st) tr) request)
     | ClientReceiveResponse {server; response; key} ->
-      assert(is_well_formed a #ps_able (is_knowable_by (principal_typed_state_content_label prin (DY.Lib.State.Typed.tag #(communication_states a)) sess_id st) tr) response)
+      assert(is_well_formed a (is_knowable_by (principal_typed_state_content_label prin (DY.Lib.State.Typed.tag #(communication_states a)) sess_id st) tr) response)
   ));
 }
 #pop-options
 
 val state_predicates_communication_layer_and_tag:
-  {|comm_layer_reqres_tag|} ->
   {|crypto_invariants|} ->
-  (a:Type0) -> {|comparse_parser_serializer a|} ->
+  (a:Type0) -> {|comm_layer_reqres_config a|} ->
   dtuple2 string local_bytes_state_predicate
-let state_predicates_communication_layer_and_tag #tag #cinvs a #ps =
+let state_predicates_communication_layer_and_tag #cinvs a #config =
   mk_local_state_tag_and_pred (state_predicates_communication_layer a)
 
 val has_communication_layer_state_predicates:
-  {|comm_layer_reqres_tag|} ->
   {|protocol_invariants|} ->
-  (a:Type0) -> {|comparse_parser_serializer a|} ->
+  (a:Type0) -> {|comm_layer_reqres_config a|} ->
   prop
-let has_communication_layer_state_predicates #tag #invs a #ps =
+let has_communication_layer_state_predicates #invs a #config =
   has_local_state_predicate (state_predicates_communication_layer a)
 
 (*** Event Predicates ***)
 
 noeq
-type comm_reqres_higher_layer_event_preds (a:Type) {| parseable_serializeable bytes a |} = {
+type comm_reqres_higher_layer_event_preds (a:Type) {| comm_layer_reqres_config a |} = {
   send_request: tr:trace -> client:principal -> server:principal -> request:a -> key_label:label -> prop;
   send_request_later:
     tr1:trace -> tr2:trace ->
@@ -147,7 +148,7 @@ type comm_reqres_higher_layer_event_preds (a:Type) {| parseable_serializeable by
     )
 }
 
-let default_comm_reqres_higher_layer_event_preds (a:Type) {| parseable_serializeable bytes a |} : comm_reqres_higher_layer_event_preds a = {
+let default_comm_reqres_higher_layer_event_preds (a:Type) {| comm_layer_reqres_config a |} : comm_reqres_higher_layer_event_preds a = {
   send_request = (fun tr client server request key_label -> True);
   send_request_later = (fun tr1 tr2 client server request key_label -> ());
   send_response = (fun tr server request response -> True);
@@ -156,35 +157,30 @@ let default_comm_reqres_higher_layer_event_preds (a:Type) {| parseable_serialize
 
 #push-options "--ifuel 1 --fuel 0"
 let event_predicate_communication_layer_reqres
-  {|comm_layer_reqres_tag|}
   {|crypto_invariants|}
-  (#a:Type) {| parseable_serializeable bytes a |}
+  (#a:Type) {| comm_layer_reqres_config a |}
   (higher_layer_resreq_preds:comm_reqres_higher_layer_event_preds a) :
-  event_predicate communication_reqres_event =
+  event_predicate (communication_reqres_event a) =
   fun tr prin e ->
     (match e with
     | CommClientSendRequest client server request key -> (
-      is_knowable_by (get_label tr key) tr request /\
+      is_well_formed a (is_knowable_by (get_label tr key) tr) request /\
       is_secret (comm_label client server) tr key /\
-      key `has_usage tr` (AeadKey comm_layer_aead_tag empty) /\
-      parse_and_pred (fun request -> higher_layer_resreq_preds.send_request tr client server request (get_label tr key)) request
+      key `has_usage tr` (AeadKey (comm_layer_aead_tag a) empty) /\
+      higher_layer_resreq_preds.send_request tr client server request (get_label tr key)
     )
     | CommServerReceiveRequest server request key -> (
       is_knowable_by (principal_label server) tr key /\
-      is_knowable_by (get_label tr key) tr request /\
-      key `has_usage tr` (AeadKey comm_layer_aead_tag empty) /\
+      is_well_formed a (is_knowable_by (get_label tr key) tr) request /\
+      key `has_usage tr` (AeadKey (comm_layer_aead_tag a) empty) /\
       (
-        (exists client. event_triggered tr client (CommClientSendRequest client server request key)) \/
+        (exists client. event_triggered tr client (CommClientSendRequest client server request key <: communication_reqres_event a)) \/
         is_publishable tr key
       )
     )
-    | CommServerSendResponse server request response -> (
-      match parse a request, parse a response with
-      | Some request, Some response -> higher_layer_resreq_preds.send_response tr server request response
-      | _ -> False
-    )
+    | CommServerSendResponse server request response -> higher_layer_resreq_preds.send_response tr server request response
     | CommClientReceiveResponse client server response key -> (
-      (exists request. event_triggered tr server (CommServerSendResponse server request response)) \/
+      (exists request. event_triggered tr server (CommServerSendResponse server request response <: communication_reqres_event a)) \/
       is_corrupt tr (principal_label client) \/ is_corrupt tr (principal_label server)
     )
     )
@@ -193,15 +189,17 @@ let event_predicate_communication_layer_reqres
 // Additional event preconditions for the events from the core communication layer
 #push-options "--fuel 0 --ifuel 2"
 val request_response_event_preconditions:
-  {|comm_layer_reqres_tag|} ->
   {|cinvs:crypto_invariants|} ->
-  comm_higher_layer_event_preds com_message_t
-let request_response_event_preconditions #tag #cinvs = {
-  (default_comm_higher_layer_event_preds com_message_t) with
-  send_conf = (fun tr client server (com_msg_t:com_message_t) ->
+  (a:Type0) -> {|comm_layer_reqres_config a|} ->
+  comm_higher_layer_event_preds comm_message_t
+let request_response_event_preconditions #cinvs a #config = {
+  (default_comm_higher_layer_event_preds comm_message_t) with
+  send_conf = (fun tr client server (com_msg_t:comm_message_t) ->
     match com_msg_t with
     | RequestMessage {request; key} -> (
-      event_triggered tr client (CommClientSendRequest client server request key)
+      match parse a request with
+      | None -> False
+      | Some request_parsed -> event_triggered tr client (CommClientSendRequest client server request_parsed key <: communication_reqres_event a)
     )
     | _ -> False
   );
@@ -211,24 +209,21 @@ let request_response_event_preconditions #tag #cinvs = {
 #pop-options
 
 val event_predicate_communication_layer_reqres_and_tag:
-  {|comm_layer_reqres_tag|} ->
   {|cinvs:crypto_invariants|} ->
-  #a:Type -> {| parseable_serializeable bytes a |} ->
+  #a:Type0 -> {| comm_layer_reqres_config a |} ->
   comm_reqres_higher_layer_event_preds a ->
   list (string & compiled_event_predicate)
 let event_predicate_communication_layer_reqres_and_tag #cinvs #a higher_layer_resreq_preds =
   [
-    event_predicate_communication_layer_and_tag request_response_event_preconditions;
+    event_predicate_communication_layer_and_tag (request_response_event_preconditions a);
     mk_event_tag_and_pred (event_predicate_communication_layer_reqres higher_layer_resreq_preds)
   ]
 
 val has_communication_layer_reqres_event_predicates:
-  {|comm_layer_reqres_tag|} ->
   {|protocol_invariants|} ->
-  #a:Type -> {| parseable_serializeable bytes a |} ->
-  comm_higher_layer_event_preds com_message_t ->
+  #a:Type0 -> {| comm_layer_reqres_config a |} ->
   comm_reqres_higher_layer_event_preds a ->
   prop
-let has_communication_layer_reqres_event_predicates #invs #a higher_layer_preds higher_layer_resreq_preds =
-  has_event_pred (event_predicate_communication_layer higher_layer_preds) /\
+let has_communication_layer_reqres_event_predicates #invs #a #config higher_layer_resreq_preds =
+  has_event_pred (event_predicate_communication_layer (request_response_event_preconditions a)) /\
   has_event_pred (event_predicate_communication_layer_reqres higher_layer_resreq_preds)

--- a/src/lib/communication/DY.Lib.Communication.RequestResponse.Lemmas.fst
+++ b/src/lib/communication/DY.Lib.Communication.RequestResponse.Lemmas.fst
@@ -21,20 +21,25 @@ open DY.Lib.Communication.RequestResponse.Invariants
 
 (*** Lemmas ***)
 
-val get_response_label: tr:trace -> comm_meta_data -> label
-let get_response_label tr req_meta_data = get_label #default_crypto_usages tr req_meta_data.key
+val get_response_label: tr:trace -> a:Type -> {|comparse_parser_serializer a|} -> comm_meta_data a -> label
+let get_response_label tr a #ps req_meta_data = get_label #default_crypto_usages tr req_meta_data.key
 
 val is_comm_response_payload:
   {|crypto_invariants|} ->
-  #a:Type -> {| parseable_serializeable bytes a |} ->
-  trace -> principal -> comm_meta_data -> a -> prop
-let is_comm_response_payload #cusg #a tr server req_meta_data payload =
-  is_well_formed a (is_knowable_by (get_response_label tr req_meta_data) tr) payload
+  #a:Type -> {|comparse_parser_serializer a|} ->
+  trace -> principal -> comm_meta_data a -> a -> prop
+let is_comm_response_payload #cusg #a #ps tr server req_meta_data payload =
+  is_well_formed a #ps_able (is_knowable_by (get_response_label tr a req_meta_data) tr) payload
 
-val comm_meta_data_knowable: {|crypto_invariants|} -> trace -> principal -> comm_meta_data -> prop
-let comm_meta_data_knowable #cinvs tr prin req_meta_data =
+val comm_meta_data_knowable: 
+  {|crypto_invariants|} ->
+  trace ->
+  a:Type -> {|comparse_parser_serializer a|} ->
+  principal -> comm_meta_data a ->
+  prop
+let comm_meta_data_knowable #cinvs tr a #ps prin req_meta_data =
   is_knowable_by (principal_label prin) tr req_meta_data.key /\
-  is_knowable_by (principal_label prin) tr req_meta_data.request
+  is_well_formed a #ps_able (is_knowable_by (principal_label prin) tr) req_meta_data.request
 
 /// The communication layer makes use of many lemmas with SMT patterns.
 /// These lemmas depend, however, on the communication layer predicates
@@ -60,12 +65,12 @@ let enable_reqres_comm_layer_lemmas preds =
   normalize_term_spec (reqres_comm_layer_lemmas_enabled preds)
 
 val send_request_proof:
-  {|comm_layer_reqres_tag|} ->
+  {|tag:comm_layer_reqres_tag|} ->
   {|protocol_invariants|} ->
-  #a:Type -> {| parseable_serializeable bytes a |} ->
+  #a:Type -> {|comparse_parser_serializer a|} ->
   tr:trace ->
   comm_keys_ids:communication_keys_sess_ids ->
-  higher_layer_preds:comm_reqres_higher_layer_event_preds a ->
+  higher_layer_preds:comm_reqres_higher_layer_event_preds a #ps_able ->
   client:principal -> server:principal -> request:a ->
   Lemma
   (requires
@@ -73,41 +78,41 @@ val send_request_proof:
     has_pki_invariant /\
     has_communication_layer_crypto_predicates /\
     has_communication_layer_reqres_event_predicates request_response_event_preconditions higher_layer_preds /\
-    has_communication_layer_state_predicates /\
+    has_communication_layer_state_predicates a /\
     higher_layer_preds.send_request tr client server request (comm_label client server) /\
-    is_well_formed a (is_knowable_by (comm_label client server) tr) request
+    is_well_formed a #ps_able (is_knowable_by (comm_label client server) tr) request
   )
   (ensures (
     match send_request comm_keys_ids client server request tr with
     | (None, tr_out) -> trace_invariant tr_out
     | (Some (_, cmeta_data), tr_out) -> (
       trace_invariant tr_out /\
-      comm_meta_data_knowable tr_out client cmeta_data
+      comm_meta_data_knowable tr_out a client cmeta_data
     )
   ))
   [SMTPat (trace_invariant tr);
   SMTPat (reqres_comm_layer_lemmas_enabled higher_layer_preds);
   SMTPat (send_request comm_keys_ids client server request tr)]
-let send_request_proof #tag #invs #a tr comm_keys_ids higher_layer_preds client server request =
-  reveal_opaque (`%send_request) (send_request #tag #a);
+let send_request_proof #tag #invs #a #ps tr comm_keys_ids higher_layer_preds client server request =
+  reveal_opaque (`%send_request) (send_request #tag #a #ps);
   enable_core_comm_layer_lemmas request_response_event_preconditions;
-  let request_bytes = serialize #bytes a request in
+  let request_bytes = serialize #bytes a #ps_able request in
   match send_request comm_keys_ids client server request tr with
   | (None, tr_out) -> (
     let (key, tr') = mk_rand (AeadKey comm_layer_aead_tag empty) (comm_label client server) 32 tr in
     let (sid, tr') = new_session_id client tr' in
-    let ((), tr') = set_state client sid (ClientSendRequest {server; request=request_bytes; key} <: communication_states) tr' in
+    let ((), tr') = set_state client sid (ClientSendRequest {server; request=request; key} <: communication_states a) tr' in
     higher_layer_preds.send_request_later tr tr' client server request (get_label tr' key);
     ()
   )
   | (Some _, tr_out) -> (
     let (key, tr') = mk_rand (AeadKey comm_layer_aead_tag empty) (comm_label client server) 32 tr in
     let (sid, tr') = new_session_id client tr' in
-    let ((), tr') = set_state client sid (ClientSendRequest {server; request=request_bytes; key} <: communication_states) tr' in
+    let ((), tr') = set_state client sid (ClientSendRequest {server; request; key} <: communication_states a) tr' in
     higher_layer_preds.send_request_later tr tr' client server request (get_label tr' key);
     let ((), tr') = trigger_event client (CommClientSendRequest client server request_bytes key) tr' in
     assert(trace_invariant tr');
-    let req_payload:com_message_t = RequestMessage {request=(serialize a request); key} in
+    let req_payload:com_message_t = RequestMessage {request=request_bytes; key} in
     let req_payload_bytes = serialize #bytes com_message_t req_payload in
     let (Some msg_id, tr') = send_confidential comm_keys_ids client server req_payload tr' in
 
@@ -121,10 +126,10 @@ let send_request_proof #tag #invs #a tr comm_keys_ids higher_layer_preds client 
 val receive_request_proof:
   {|tag:comm_layer_reqres_tag|} ->
   {|protocol_invariants|} ->
-  #a:Type -> {| parseable_serializeable bytes a |} ->
+  #a:Type -> {|ps:comparse_parser_serializer a|} ->
   tr:trace ->
   comm_keys_ids:communication_keys_sess_ids ->
-  higher_layer_preds:comm_reqres_higher_layer_event_preds a ->
+  higher_layer_preds:comm_reqres_higher_layer_event_preds a #ps_able ->
   server:principal -> msg_id:timestamp ->
   Lemma
   (requires
@@ -133,31 +138,32 @@ val receive_request_proof:
     has_pki_invariant /\
     has_communication_layer_reqres_crypto_predicates /\
     has_communication_layer_reqres_event_predicates request_response_event_preconditions higher_layer_preds /\
-    has_communication_layer_state_predicates
+    has_communication_layer_state_predicates a
   )
   (ensures (
     match receive_request comm_keys_ids server msg_id tr with
     | (None, tr_out) -> trace_invariant tr_out
     | (Some (payload, req_meta_data), tr_out) -> (
-      let payload_bytes = serialize a payload in
+      let payload_bytes = serialize a #ps_able payload in
       trace_invariant tr_out /\
       event_triggered tr_out server (CommServerReceiveRequest server payload_bytes req_meta_data.key) /\
-      is_well_formed a (is_knowable_by (principal_label server) tr_out) payload /\
-      is_well_formed a (is_knowable_by (get_response_label tr_out req_meta_data) tr_out) payload /\
-      payload_bytes == req_meta_data.request
+      is_well_formed a #ps_able (is_knowable_by (principal_label server) tr_out) payload /\
+      is_well_formed a #ps_able (is_knowable_by (get_response_label tr_out a req_meta_data) tr_out) payload /\
+      payload == req_meta_data.request
     )
   ))
   [SMTPat (trace_invariant tr);
   SMTPat (reqres_comm_layer_lemmas_enabled higher_layer_preds);
-  SMTPat (receive_request #tag #a comm_keys_ids server msg_id tr)]
-let receive_request_proof #tag #invs #a tr comm_keys_ids higher_layer_preds server msg_id =
-  reveal_opaque (`%receive_request) (receive_request #tag #a);
+  SMTPat (receive_request #tag #a #ps comm_keys_ids server msg_id tr)]
+let receive_request_proof #tag #invs #a #ps tr comm_keys_ids higher_layer_preds server msg_id =
+  reveal_opaque (`%receive_request) (receive_request #tag #a #ps);
   enable_core_comm_layer_lemmas request_response_event_preconditions;
-  match receive_request #tag #a comm_keys_ids server msg_id tr with
+  match receive_request comm_keys_ids server msg_id tr with
   | (None, tr_out) -> ()
   | (Some (payload, req_meta_data), tr_out) -> (
     let (Some req_msg_t, tr') = receive_confidential comm_keys_ids server msg_id tr in
     let RequestMessage req_msg = req_msg_t in
+    let Some request = parse a #ps_able req_msg.request in
 
     let req_msg_bytes = serialize com_message_t req_msg_t in
     let req_send_event client = CommClientSendRequest client server req_msg.request req_msg.key in
@@ -169,7 +175,7 @@ let receive_request_proof #tag #invs #a tr comm_keys_ids higher_layer_preds serv
     eliminate (exists client. event_triggered tr' client (req_send_event client)) \/
               (is_publishable tr' req_msg.request /\ is_publishable tr' req_msg.key)
     returns (
-      is_knowable_by (get_response_label tr' req_meta_data) tr' req_msg.request /\
+      is_knowable_by (get_response_label tr' a req_meta_data) tr' req_msg.request /\
       req_msg.key `has_usage tr'` (AeadKey comm_layer_aead_tag empty)
     )
     with _. eliminate exists client. event_triggered tr' client (req_send_event client)
@@ -182,12 +188,12 @@ let receive_request_proof #tag #invs #a tr comm_keys_ids higher_layer_preds serv
     and _. has_usage_publishable tr' req_msg.key (AeadKey comm_layer_aead_tag empty);
 
     // Relating knowledge of the request to knowledge of its fields
-    serialize_parse_inv_lemma #bytes a req_msg.request;
+    serialize_parse_inv_lemma #bytes a #ps_able req_msg.request;
     assert(is_comm_response_payload tr' server req_meta_data payload);
 
     let ((), tr') = trigger_event server (CommServerReceiveRequest server req_msg.request req_msg.key) tr' in
     let (sid', tr') = new_session_id server tr' in
-    let ((), tr') = set_state server sid' (ServerReceiveRequest {request=req_msg.request; key=req_msg.key} <: communication_states) tr' in
+    let ((), tr') = set_state server sid' (ServerReceiveRequest {request; key=req_msg.key} <: communication_states a) tr' in
     assert(tr' == tr_out);
     assert(trace_invariant tr_out);
     ()
@@ -197,13 +203,14 @@ let receive_request_proof #tag #invs #a tr comm_keys_ids higher_layer_preds serv
 
 val mk_comm_layer_response_nonce_proof:
   {|comm_layer_reqres_tag|} ->
+  #a:Type -> {|comparse_parser_serializer a|} ->
   {|protocol_invariants|} ->
   tr:trace ->
-  req_meta_data:comm_meta_data -> usg:usage ->
+  req_meta_data:comm_meta_data a -> usg:usage ->
   Lemma
   (requires
     trace_invariant tr /\
-    has_communication_layer_state_predicates /\
+    has_communication_layer_state_predicates a /\
     has_communication_layer_reqres_crypto_predicates /\
     bytes_well_formed tr req_meta_data.key
   )
@@ -211,36 +218,36 @@ val mk_comm_layer_response_nonce_proof:
     match mk_comm_layer_response_nonce req_meta_data usg tr with
     | (None, tr_out) -> trace_invariant tr_out
     | (Some nonce, tr_out) -> (
-      is_knowable_by (get_response_label tr_out req_meta_data) tr_out nonce
+      is_knowable_by (get_response_label tr_out a req_meta_data) tr_out nonce
     )
   ))
-let mk_comm_layer_response_nonce_proof #tag #invs tr req_meta_data usg =
-  reveal_opaque (`%mk_comm_layer_response_nonce) (mk_comm_layer_response_nonce)
+let mk_comm_layer_response_nonce_proof #tag #a #ps #invs tr req_meta_data usg =
+  reveal_opaque (`%mk_comm_layer_response_nonce) (mk_comm_layer_response_nonce #a)
 
 
 val compute_response_message_proof:
   {|comm_layer_reqres_tag|} ->
   {|crypto_invariants|} ->
-  #a:Type -> {| parseable_serializeable bytes a |} ->
+  #a:Type -> {|comparse_parser_serializer a|} ->
   tr:trace ->
   server:principal ->
-  key:bytes -> nonce:bytes -> request:bytes -> response:a ->
+  key:bytes -> nonce:bytes -> request:a -> response:a ->
   Lemma
   (requires
     has_communication_layer_reqres_crypto_predicates /\
     is_knowable_by (principal_label server) tr key /\
-    is_well_formed a (is_knowable_by (get_label tr key) tr) response /\
+    is_well_formed a #ps_able (is_knowable_by (get_label tr key) tr) response /\
     is_publishable tr nonce /\
     key `has_usage tr` (AeadKey comm_layer_aead_tag empty) /\
-    event_triggered tr server (CommServerSendResponse server request (serialize a response))
+    event_triggered tr server (CommServerSendResponse server (serialize a #ps_able request) (serialize a #ps_able response))
   )
   (ensures
     is_publishable tr (compute_response_message #a server key nonce response)
   )
-let compute_response_message_proof #tag #cinvs #a tr server key nonce request response =
+let compute_response_message_proof #tag #cinvs #a #ps tr server key nonce request response =
   reveal_opaque (`%compute_response_message) (compute_response_message #a);
-  let res_bytes = serialize a response in
-  serialize_wf_lemma a (is_knowable_by (get_label tr key) tr) response;
+  let res_bytes = serialize a #ps_able response in
+  serialize_wf_lemma a #ps_able (is_knowable_by (get_label tr key) tr) response;
   let ad:authenticated_data = {server} in
   let ad_bytes = serialize authenticated_data ad in
   serialize_wf_lemma authenticated_data (is_publishable tr) ad;
@@ -253,20 +260,18 @@ let compute_response_message_proof #tag #cinvs #a tr server key nonce request re
 val send_response_proof:
   {|comm_layer_reqres_tag|} ->
   {|protocol_invariants|} ->
-  #a:Type -> {| parseable_serializeable bytes a |} ->
+  #a:eqtype -> {|comparse_parser_serializer a|} ->
   tr:trace ->
-  higher_layer_preds:comm_reqres_higher_layer_event_preds a ->
-  server:principal -> req_meta_data:comm_meta_data -> response:a ->
+  higher_layer_preds:comm_reqres_higher_layer_event_preds a #ps_able ->
+  server:principal -> req_meta_data:comm_meta_data a -> response:a ->
   Lemma
   (requires
     trace_invariant tr /\
     has_communication_layer_reqres_crypto_predicates /\
     has_communication_layer_reqres_event_predicates request_response_event_preconditions higher_layer_preds /\
-    (match parse a req_meta_data.request with
-    | None -> False
-    | Some request -> higher_layer_preds.send_response tr server request response) /\
-    has_communication_layer_state_predicates /\
-    is_well_formed a (is_knowable_by (get_response_label tr req_meta_data) tr) response
+    higher_layer_preds.send_response tr server req_meta_data.request response /\
+    has_communication_layer_state_predicates a /\
+    is_well_formed a #ps_able (is_knowable_by (get_response_label tr a req_meta_data) tr) response
   )
   (ensures (
     let (_, tr_out) = send_response server req_meta_data response tr in
@@ -275,14 +280,14 @@ val send_response_proof:
   [SMTPat (trace_invariant tr);
   SMTPat (reqres_comm_layer_lemmas_enabled higher_layer_preds);
   SMTPat (send_response server req_meta_data response tr)]
-let send_response_proof #tag #invs #a tr higher_layer_preds server req_meta_data response =
-  reveal_opaque (`%send_response) (send_response #tag #a);
+let send_response_proof #tag #invs #a #ps tr higher_layer_preds server req_meta_data response =
+  reveal_opaque (`%send_response) (send_response #tag #a #ps);
   match send_response server req_meta_data response tr with
   | (None, tr_out) -> ()
   | (Some msg_id, tr_out) -> (
-    let (Some state, tr') = get_state server req_meta_data.sid tr in
+    let (Some state, tr'):(option (communication_states a) & trace) = get_state server req_meta_data.sid tr in
     let ServerReceiveRequest srr = state in
-    let ((), tr') = trigger_event server (CommServerSendResponse server req_meta_data.request (serialize a response)) tr' in
+    let ((), tr') = trigger_event server (CommServerSendResponse server (serialize a #ps_able req_meta_data.request) (serialize a #ps_able response)) tr' in
     let (nonce, tr') = mk_rand NoUsage public 32 tr' in
     compute_response_message_proof tr' server req_meta_data.key nonce req_meta_data.request response;
     let resp_msg_bytes = compute_response_message server req_meta_data.key nonce response in
@@ -297,7 +302,7 @@ let send_response_proof #tag #invs #a tr higher_layer_preds server req_meta_data
 val decode_response_proof:
   {|comm_layer_reqres_tag|} ->
   {|crypto_invariants|} ->
-  #a:Type -> {| parseable_serializeable bytes a |} ->
+  #a:Type -> {|comparse_parser_serializer a|} ->
   tr:trace ->
   client:principal -> server:principal ->
   key:bytes -> response:bytes ->
@@ -312,9 +317,9 @@ val decode_response_proof:
     match decode_response_message server key response with
     | None -> True
     | Some payload -> (
-      is_well_formed a (is_knowable_by (get_label tr key) tr) payload /\
-      is_knowable_by (get_label tr key) tr (serialize a payload) /\
-      (exists request. event_triggered tr server (CommServerSendResponse server request (serialize a payload))
+      is_well_formed a #ps_able (is_knowable_by (get_label tr key) tr) payload /\
+      is_knowable_by (get_label tr key) tr (serialize a #ps_able payload) /\
+      (exists request. event_triggered tr server (CommServerSendResponse server request (serialize a #ps_able payload))
         \/ is_corrupt tr (principal_label client) \/ is_corrupt tr (principal_label server))
     )
   ))
@@ -328,7 +333,7 @@ let decode_response_proof #tag #cinvs #a #ps tr client server key msg_bytes =
     serialize_wf_lemma authenticated_data (is_publishable tr) {server};
     let ad_bytes = serialize authenticated_data {server} in
     let Some res_bytes = aead_dec key nonce ciphertext ad_bytes in
-    serialize_parse_inv_lemma #bytes a #ps res_bytes;
+    serialize_parse_inv_lemma #bytes a #ps_able res_bytes;
     ()
   )
 #pop-options
@@ -336,44 +341,44 @@ let decode_response_proof #tag #cinvs #a #ps tr client server key msg_bytes =
 val receive_response_proof:
   {|tag:comm_layer_reqres_tag|} ->
   {|protocol_invariants|} ->
-  #a:Type -> {| parseable_serializeable bytes a |} ->
+  #a:Type -> {|comparse_parser_serializer a|} ->
   tr:trace ->
-  higher_layer_preds:comm_reqres_higher_layer_event_preds a ->
-  client:principal -> req_meta_data:comm_meta_data -> msg_id:timestamp ->
+  higher_layer_preds:comm_reqres_higher_layer_event_preds a #ps_able ->
+  client:principal -> req_meta_data:comm_meta_data a -> msg_id:timestamp ->
   Lemma
   (requires
     trace_invariant tr /\
     has_communication_layer_reqres_crypto_predicates /\
     has_communication_layer_reqres_event_predicates request_response_event_preconditions higher_layer_preds /\
-    has_communication_layer_state_predicates
+    has_communication_layer_state_predicates a
   )
   (ensures (
     match receive_response client req_meta_data msg_id tr with
     | (None, tr_out) -> trace_invariant tr_out
     | (Some (payload, _), tr_out) -> (
       trace_invariant tr_out /\
-      event_triggered tr_out client (CommClientReceiveResponse client req_meta_data.server (serialize a payload) req_meta_data.key) /\
-      is_well_formed a (is_knowable_by (get_label tr_out req_meta_data.key) tr_out) payload
+      event_triggered tr_out client (CommClientReceiveResponse client req_meta_data.server (serialize a #ps_able payload) req_meta_data.key) /\
+      is_well_formed a #ps_able (is_knowable_by (get_label tr_out req_meta_data.key) tr_out) payload
     )
   ))
   [SMTPat (trace_invariant tr);
   SMTPat (reqres_comm_layer_lemmas_enabled higher_layer_preds);
-  SMTPat (receive_response #tag #a client req_meta_data msg_id tr)]
-let receive_response_proof #tag #invs #a tr higher_layer_preds client req_meta_data msg_id =
-  reveal_opaque (`%receive_response) (receive_response #tag #a);
-  match receive_response #tag #a client req_meta_data msg_id tr with
+  SMTPat (receive_response client req_meta_data msg_id tr)]
+let receive_response_proof #tag #invs #a #ps tr higher_layer_preds client req_meta_data msg_id =
+  reveal_opaque (`%receive_response) (receive_response #tag #a #ps);
+  match receive_response #tag #a #ps client req_meta_data msg_id tr with
   | (None, tr_out) -> ()
   | (Some (response, _), tr_out) -> (
     let server = req_meta_data.server in
     let key = req_meta_data.key in
-    let (Some state, tr') = get_state client req_meta_data.sid tr in
+    let (Some state, tr'):(option (communication_states a) & trace) = get_state client req_meta_data.sid tr in
     let ClientSendRequest csr = state in
     let (Some resp_msg_bytes, tr') = recv_msg msg_id tr' in
     decode_response_proof #tag #invs.crypto_invs #a tr' client csr.server csr.key resp_msg_bytes;
     let Some response = decode_response_message csr.server csr.key resp_msg_bytes in
-    let ((), tr') = set_state client req_meta_data.sid (ClientReceiveResponse {server=csr.server; response=(serialize a response); key=csr.key} <: communication_states) tr' in
-    let ((), tr') = trigger_event client (CommClientReceiveResponse client csr.server (serialize a response) csr.key) tr' in
-    assert(event_triggered tr' client (CommClientReceiveResponse client csr.server (serialize a response) csr.key));
+    let ((), tr') = set_state client req_meta_data.sid (ClientReceiveResponse {server=csr.server; response; key=csr.key} <: communication_states a) tr' in
+    let ((), tr') = trigger_event client (CommClientReceiveResponse client csr.server (serialize a #ps_able response) csr.key) tr' in
+    assert(event_triggered tr' client (CommClientReceiveResponse client csr.server (serialize a #ps_able response) csr.key));
     assert(tr_out == tr');
     assert(trace_invariant tr_out);
     ()

--- a/src/lib/communication/DY.Lib.Communication.RequestResponse.Lemmas.fst
+++ b/src/lib/communication/DY.Lib.Communication.RequestResponse.Lemmas.fst
@@ -53,12 +53,12 @@ let comm_meta_data_knowable #cinvs tr a #ps prin req_meta_data =
 
 [@@"opaque_to_smt"]
 val reqres_comm_layer_lemmas_enabled:
-  #a:Type -> {| parseable_serializeable bytes a |} ->
-  comm_reqres_higher_layer_event_preds a -> prop
+  #a:Type -> {| comparse_parser_serializer a |} ->
+  comm_reqres_higher_layer_event_preds a #ps_able -> prop
 let reqres_comm_layer_lemmas_enabled _ = True
 
 val enable_reqres_comm_layer_lemmas:
-  #a:Type -> {| parseable_serializeable bytes a |} ->
+  #a:Type -> {| comparse_parser_serializer a |} ->
   preds:comm_reqres_higher_layer_event_preds a ->
   Lemma (reqres_comm_layer_lemmas_enabled preds)
 let enable_reqres_comm_layer_lemmas preds =

--- a/src/lib/communication/DY.Lib.Communication.RequestResponse.Lemmas.fst
+++ b/src/lib/communication/DY.Lib.Communication.RequestResponse.Lemmas.fst
@@ -60,6 +60,7 @@ let enable_reqres_comm_layer_lemmas preds =
   normalize_term_spec (reqres_comm_layer_lemmas_enabled preds)
 
 val send_request_proof:
+  {|comm_layer_event_reqres_tag|} ->
   {|protocol_invariants|} ->
   #a:Type -> {| parseable_serializeable bytes a |} ->
   tr:trace ->
@@ -87,8 +88,8 @@ val send_request_proof:
   [SMTPat (trace_invariant tr);
   SMTPat (reqres_comm_layer_lemmas_enabled higher_layer_preds);
   SMTPat (send_request comm_keys_ids client server request tr)]
-let send_request_proof #invs #a tr comm_keys_ids higher_layer_preds client server request =
-  reveal_opaque (`%send_request) (send_request #a);
+let send_request_proof #event_tag #invs #a tr comm_keys_ids higher_layer_preds client server request =
+  reveal_opaque (`%send_request) (send_request #event_tag #a);
   enable_core_comm_layer_lemmas request_response_event_preconditions;
   let request_bytes = serialize #bytes a request in
   match send_request comm_keys_ids client server request tr with
@@ -116,8 +117,9 @@ let send_request_proof #invs #a tr comm_keys_ids higher_layer_preds client serve
   )
 
 
-#push-options "--ifuel 2 --z3rlimit 50"
+#push-options "--z3rlimit 50"
 val receive_request_proof:
+  {|event_tag:comm_layer_event_reqres_tag|} ->
   {|protocol_invariants|} ->
   #a:Type -> {| parseable_serializeable bytes a |} ->
   tr:trace ->
@@ -134,7 +136,7 @@ val receive_request_proof:
     has_communication_layer_state_predicates
   )
   (ensures (
-    match receive_request #a comm_keys_ids server msg_id tr with
+    match receive_request comm_keys_ids server msg_id tr with
     | (None, tr_out) -> trace_invariant tr_out
     | (Some (payload, req_meta_data), tr_out) -> (
       let payload_bytes = serialize a payload in
@@ -147,14 +149,14 @@ val receive_request_proof:
   ))
   [SMTPat (trace_invariant tr);
   SMTPat (reqres_comm_layer_lemmas_enabled higher_layer_preds);
-  SMTPat (receive_request #a comm_keys_ids server msg_id tr)]
-let receive_request_proof #invs #a tr comm_keys_ids higher_layer_preds server msg_id =
-  reveal_opaque (`%receive_request) (receive_request #a);
+  SMTPat (receive_request #event_tag #a comm_keys_ids server msg_id tr)]
+let receive_request_proof #event_tag #invs #a tr comm_keys_ids higher_layer_preds server msg_id =
+  reveal_opaque (`%receive_request) (receive_request #event_tag #a);
   enable_core_comm_layer_lemmas request_response_event_preconditions;
-  match receive_request #a comm_keys_ids server msg_id tr with
+  match receive_request #event_tag #a comm_keys_ids server msg_id tr with
   | (None, tr_out) -> ()
   | (Some (payload, req_meta_data), tr_out) -> (
-    let (Some req_msg_t, tr') = receive_confidential #com_message_t comm_keys_ids server msg_id tr in
+    let (Some req_msg_t, tr') = receive_confidential comm_keys_ids server msg_id tr in
     let RequestMessage req_msg = req_msg_t in
 
     let req_msg_bytes = serialize com_message_t req_msg_t in
@@ -194,6 +196,7 @@ let receive_request_proof #invs #a tr comm_keys_ids higher_layer_preds server ms
 
 
 val mk_comm_layer_response_nonce_proof:
+  {|comm_layer_event_reqres_tag|} ->
   {|protocol_invariants|} ->
   tr:trace ->
   req_meta_data:comm_meta_data -> usg:usage ->
@@ -211,11 +214,12 @@ val mk_comm_layer_response_nonce_proof:
       is_knowable_by (get_response_label tr_out req_meta_data) tr_out nonce
     )
   ))
-let mk_comm_layer_response_nonce_proof #invs tr req_meta_data usg =
+let mk_comm_layer_response_nonce_proof #event_tag #invs tr req_meta_data usg =
   reveal_opaque (`%mk_comm_layer_response_nonce) (mk_comm_layer_response_nonce)
 
 
 val compute_response_message_proof:
+  {|comm_layer_event_reqres_tag|} ->
   {|crypto_invariants|} ->
   #a:Type -> {| parseable_serializeable bytes a |} ->
   tr:trace ->
@@ -233,7 +237,7 @@ val compute_response_message_proof:
   (ensures
     is_publishable tr (compute_response_message #a server key nonce response)
   )
-let compute_response_message_proof #cinvs #a tr server key nonce request response =
+let compute_response_message_proof #event_tag #cinvs #a tr server key nonce request response =
   reveal_opaque (`%compute_response_message) (compute_response_message #a);
   let res_bytes = serialize a response in
   serialize_wf_lemma a (is_knowable_by (get_label tr key) tr) response;
@@ -247,6 +251,7 @@ let compute_response_message_proof #cinvs #a tr server key nonce request respons
   ()
 
 val send_response_proof:
+  {|comm_layer_event_reqres_tag|} ->
   {|protocol_invariants|} ->
   #a:Type -> {| parseable_serializeable bytes a |} ->
   tr:trace ->
@@ -264,14 +269,14 @@ val send_response_proof:
     is_well_formed a (is_knowable_by (get_response_label tr req_meta_data) tr) response
   )
   (ensures (
-    let (_, tr_out) = send_response #a server req_meta_data response tr in
+    let (_, tr_out) = send_response server req_meta_data response tr in
     trace_invariant tr_out
   ))
   [SMTPat (trace_invariant tr);
   SMTPat (reqres_comm_layer_lemmas_enabled higher_layer_preds);
   SMTPat (send_response server req_meta_data response tr)]
-let send_response_proof #invs #a tr higher_layer_preds server req_meta_data response =
-  reveal_opaque (`%send_response) (send_response #a);
+let send_response_proof #event_tag #invs #a tr higher_layer_preds server req_meta_data response =
+  reveal_opaque (`%send_response) (send_response #event_tag #a);
   match send_response server req_meta_data response tr with
   | (None, tr_out) -> ()
   | (Some msg_id, tr_out) -> (
@@ -290,6 +295,7 @@ let send_response_proof #invs #a tr higher_layer_preds server req_meta_data resp
 
 #push-options "--fuel 0 --ifuel 1 --z3rlimit 10"
 val decode_response_proof:
+  {|comm_layer_event_reqres_tag|} ->
   {|crypto_invariants|} ->
   #a:Type -> {| parseable_serializeable bytes a |} ->
   tr:trace ->
@@ -303,7 +309,7 @@ val decode_response_proof:
     key `has_usage tr` (AeadKey comm_layer_aead_tag empty)
   )
   (ensures (
-    match decode_response_message #a server key response with
+    match decode_response_message server key response with
     | None -> True
     | Some payload -> (
       is_well_formed a (is_knowable_by (get_label tr key) tr) payload /\
@@ -312,9 +318,9 @@ val decode_response_proof:
         \/ is_corrupt tr (principal_label client) \/ is_corrupt tr (principal_label server))
     )
   ))
-let decode_response_proof #cinvs #a #ps tr client server key msg_bytes =
-  reveal_opaque (`%decode_response_message) (decode_response_message #a);
-  match decode_response_message #a server key msg_bytes with
+let decode_response_proof #event_tag #cinvs #a #ps tr client server key msg_bytes =
+  reveal_opaque (`%decode_response_message) (decode_response_message #event_tag #a);
+  match decode_response_message #event_tag #a server key msg_bytes with
   | None -> ()
   | Some payload -> (
     parse_wf_lemma com_message_t (is_publishable tr) msg_bytes;
@@ -328,6 +334,7 @@ let decode_response_proof #cinvs #a #ps tr client server key msg_bytes =
 #pop-options
 
 val receive_response_proof:
+  {|event_tag:comm_layer_event_reqres_tag|} ->
   {|protocol_invariants|} ->
   #a:Type -> {| parseable_serializeable bytes a |} ->
   tr:trace ->
@@ -341,7 +348,7 @@ val receive_response_proof:
     has_communication_layer_state_predicates
   )
   (ensures (
-    match receive_response #a client req_meta_data msg_id tr with
+    match receive_response client req_meta_data msg_id tr with
     | (None, tr_out) -> trace_invariant tr_out
     | (Some (payload, _), tr_out) -> (
       trace_invariant tr_out /\
@@ -351,10 +358,10 @@ val receive_response_proof:
   ))
   [SMTPat (trace_invariant tr);
   SMTPat (reqres_comm_layer_lemmas_enabled higher_layer_preds);
-  SMTPat (receive_response #a client req_meta_data msg_id tr)]
-let receive_response_proof #invs #a tr higher_layer_preds client req_meta_data msg_id =
-  reveal_opaque (`%receive_response) (receive_response #a);
-  match receive_response #a client req_meta_data msg_id tr with
+  SMTPat (receive_response #event_tag #a client req_meta_data msg_id tr)]
+let receive_response_proof #event_tag #invs #a tr higher_layer_preds client req_meta_data msg_id =
+  reveal_opaque (`%receive_response) (receive_response #event_tag #a);
+  match receive_response #event_tag #a client req_meta_data msg_id tr with
   | (None, tr_out) -> ()
   | (Some (response, _), tr_out) -> (
     let server = req_meta_data.server in
@@ -362,8 +369,8 @@ let receive_response_proof #invs #a tr higher_layer_preds client req_meta_data m
     let (Some state, tr') = get_state client req_meta_data.sid tr in
     let ClientSendRequest csr = state in
     let (Some resp_msg_bytes, tr') = recv_msg msg_id tr' in
-    decode_response_proof #invs.crypto_invs #a tr' client csr.server csr.key resp_msg_bytes;
-    let Some response = decode_response_message #a csr.server csr.key resp_msg_bytes in
+    decode_response_proof #event_tag #invs.crypto_invs #a tr' client csr.server csr.key resp_msg_bytes;
+    let Some response = decode_response_message csr.server csr.key resp_msg_bytes in
     let ((), tr') = set_state client req_meta_data.sid (ClientReceiveResponse {server=csr.server; response=(serialize a response); key=csr.key} <: communication_states) tr' in
     let ((), tr') = trigger_event client (CommClientReceiveResponse client csr.server (serialize a response) csr.key) tr' in
     assert(event_triggered tr' client (CommClientReceiveResponse client csr.server (serialize a response) csr.key));

--- a/src/lib/communication/DY.Lib.Communication.RequestResponse.Lemmas.fst
+++ b/src/lib/communication/DY.Lib.Communication.RequestResponse.Lemmas.fst
@@ -21,8 +21,72 @@ open DY.Lib.Communication.RequestResponse.Invariants
 
 (*** Lemmas ***)
 
-val get_response_label: tr:trace -> #a:Type0 -> {|comm_layer_reqres_config a|} -> comm_meta_data a -> label
-let get_response_label tr #a #ps req_meta_data = get_label #default_crypto_usages tr req_meta_data.key
+val get_response_label_knowable:
+  {|cinvs:crypto_invariants|} ->
+  #a:Type0 -> {|comm_layer_reqres_config a|} -> tr:trace ->
+  req_meta_data:comm_meta_data a -> msg:a ->
+  Lemma
+  (requires
+    cinvs.usages == default_crypto_usages /\
+    is_well_formed a (is_knowable_by (get_response_label tr req_meta_data) tr) msg
+  )
+  (ensures
+    is_well_formed a (is_knowable_by (get_label tr req_meta_data.key) tr) msg
+  )
+let get_response_label_knowable #cinvs #a tr req_meta_data msg =
+  reveal_opaque (`%get_response_label) get_response_label;
+  ()
+
+val get_response_label_knowable_reverse:
+  {|cinvs:crypto_invariants|} ->
+  #a:Type0 -> {|comm_layer_reqres_config a|} -> tr:trace ->
+  req_meta_data:comm_meta_data a -> msg:a ->
+  Lemma
+  (requires
+    cinvs.usages == default_crypto_usages /\
+    is_well_formed a (is_knowable_by (get_label tr req_meta_data.key) tr) msg
+  )
+  (ensures
+    is_well_formed a (is_knowable_by (get_response_label tr req_meta_data) tr) msg
+  )
+let get_response_label_knowable_reverse #cinvs #a tr req_meta_data msg =
+  reveal_opaque (`%get_response_label) get_response_label;
+  ()
+
+val get_response_label_publishable:
+  {|cinvs:crypto_invariants|} ->
+  #a:Type0 -> {|comm_layer_reqres_config a|} -> tr:trace ->
+  req_meta_data:comm_meta_data a -> request:a ->
+  Lemma
+  (requires
+    (is_well_formed a (is_knowable_by (get_response_label tr req_meta_data) tr) request \/
+      (is_well_formed a (is_publishable tr) request /\ is_publishable tr req_meta_data.key))
+  )
+  (ensures
+    is_well_formed a (is_knowable_by (get_response_label tr req_meta_data) tr) request
+  )
+let get_response_label_publishable #cinvs #a tr req_meta_data request =
+  reveal_opaque (`%get_response_label) get_response_label;
+  ()
+
+val get_response_label_later:
+  #a:Type0 -> {|comm_layer_reqres_config a|} -> 
+  tr1:trace -> tr2:trace ->
+  req_meta_data:comm_meta_data a ->
+  Lemma
+  (requires
+    tr1 <$ tr2 /\
+    bytes_well_formed tr1 req_meta_data.key
+  )
+  (ensures
+    get_response_label tr1 req_meta_data == get_response_label tr2 req_meta_data
+  )
+  [SMTPat (get_response_label tr1 req_meta_data); SMTPat (tr1 <$ tr2)]
+let get_response_label_later #a tr1 tr2 req_meta_data =
+  reveal_opaque (`%get_response_label) get_response_label;
+  get_label_later #default_crypto_usages tr1 tr2 req_meta_data.key;
+  ()
+
 
 val is_comm_response_payload:
   {|crypto_invariants|} ->
@@ -89,6 +153,7 @@ let initialize_communication_reqres_proof tr a sender receiver =
 #pop-options
 
 
+#push-options "--z3rlimit 150"
 val send_request_proof:
   {|protocol_invariants|} ->
   #a:Type0 -> {|comm_layer_reqres_config a|} ->
@@ -143,9 +208,9 @@ let send_request_proof #invs #a tr comm_keys_ids higher_layer_preds client serve
   )
 
 
-#push-options "--z3rlimit 50"
+#push-options "--z3rlimit 200"
 val receive_request_proof:
-  {|protocol_invariants|} ->
+  {|invs:protocol_invariants|} ->
   #a:Type -> {|comm_layer_reqres_config a|} ->
   tr:trace ->
   comm_keys_ids:communication_keys_sess_ids ->
@@ -153,6 +218,7 @@ val receive_request_proof:
   server:principal -> msg_id:timestamp ->
   Lemma
   (requires
+    invs.crypto_invs.usages == default_crypto_usages /\
     trace_invariant tr /\
     has_private_keys_invariant /\
     has_pki_invariant /\
@@ -179,43 +245,52 @@ let receive_request_proof #invs #a #config tr comm_keys_ids higher_layer_preds s
   | (None, tr_out) -> ()
   | (Some (payload, req_meta_data), tr_out) -> (
     receive_confidential_proof #invs #comm_message_t #(comm_layer_tag_core_config_reqres a) tr (comm_core_higher_layer_event_preds_reqres a) comm_keys_ids server msg_id;
-    let (Some req_msg_t, tr') = receive_confidential #comm_message_t #(comm_layer_tag_core_config_reqres a) comm_keys_ids server msg_id tr in
+    let (Some req_msg_t, tr_recv) = receive_confidential #comm_message_t #(comm_layer_tag_core_config_reqres a) comm_keys_ids server msg_id tr in
     let RequestMessage req_msg = req_msg_t in
     let Some request = parse a req_msg.request in
 
     let req_msg_bytes:bytes = serialize comm_message_t req_msg_t in
     let req_send_event client:communication_reqres_event a = CommClientSendRequest client server request req_msg.key in
 
-    let i = find_event_triggered_at_timestamp tr' server (CommConfReceiveMsg server req_msg_t <: communication_core_event comm_message_t #(comm_layer_tag_core_config_reqres a)) in
-    conf_message_secrecy tr' i (comm_core_higher_layer_event_preds_reqres a) server req_msg_t;
-
+    let i = find_event_triggered_at_timestamp tr_recv server (CommConfReceiveMsg server req_msg_t <: communication_core_event comm_message_t #(comm_layer_tag_core_config_reqres a)) in
+    conf_message_secrecy tr_recv i (comm_core_higher_layer_event_preds_reqres a) server req_msg_t;
+    
     // Properties that can be proved uniformly in both the honest and corrupt case
-    eliminate (exists client. event_triggered tr' client (req_send_event client)) \/
-              (is_publishable tr' req_msg.request /\ is_publishable tr' req_msg.key)
+    eliminate (exists client. event_triggered tr_recv client (req_send_event client)) \/
+              (is_publishable tr_recv req_msg.request /\ is_publishable tr_recv req_msg.key)
     returns (
-      is_well_formed a (is_knowable_by (get_response_label tr' req_meta_data) tr') request /\
-      req_msg.key `has_usage tr'` (AeadKey (comm_layer_aead_tag a) empty)
+      is_well_formed a (is_knowable_by (get_response_label tr_recv req_meta_data) tr_recv) request /\
+      req_msg.key `has_usage tr_recv` (AeadKey (comm_layer_aead_tag a) empty)
     )
-    with _. eliminate exists client. event_triggered tr' client (req_send_event client)
+    with _. eliminate exists client. event_triggered tr_recv client (req_send_event client)
       returns _
       with _. (
-        let i = find_event_triggered_at_timestamp tr' client (req_send_event client) in
+        get_response_label_knowable_reverse tr_recv req_meta_data request;
+
+        let i = find_event_triggered_at_timestamp tr_recv client (req_send_event client) in
         // Triggers event_triggered_at_implies_pred
-        assert(event_triggered_at tr' i client (req_send_event client))
+        assert(event_predicate_communication_layer_reqres higher_layer_preds (prefix tr_recv i) client (req_send_event client));
+        assert(event_triggered_at tr_recv i client (req_send_event client))
       )
-    and _. (has_usage_publishable tr' req_msg.key (AeadKey (comm_layer_aead_tag a) empty);
-      parse_wf_lemma a (is_publishable tr') req_msg.request;
+    and _. (has_usage_publishable tr_recv req_msg.key (AeadKey (comm_layer_aead_tag a) empty);
+      parse_wf_lemma a (is_publishable tr_recv) req_msg.request;
       ()
     );
 
     // Relating knowledge of the request to knowledge of its fields
     serialize_parse_inv_lemma #bytes a req_msg.request;
-    assert(is_comm_response_payload tr' server req_meta_data payload);
+    assert(is_comm_response_payload tr_recv server req_meta_data payload);
 
-    let ((), tr') = trigger_event server (CommServerReceiveRequest server request req_msg.key <: communication_reqres_event a) tr' in
-    let (sid', tr') = new_session_id server tr' in
-    let ((), tr') = set_state server sid' (ServerReceiveRequest {request; key=req_msg.key} <: communication_states a) tr' in
-    assert(tr' == tr_out);
+    let ((), tr_ev) = trigger_event server (CommServerReceiveRequest server request req_msg.key <: communication_reqres_event a) tr_recv in
+    let (sid', tr_sess) = new_session_id server tr_ev in
+
+    // Needed for the proof to go through
+    assert((state_predicate_communication_layer_reqres a).pred tr_sess server sid' (ServerReceiveRequest {request; key=req_msg.key} <: communication_states a));
+    let ((), tr_st) = set_state server sid' (ServerReceiveRequest {request; key=req_msg.key} <: communication_states a) tr_sess in
+
+    get_response_label_publishable tr_recv req_meta_data request;
+    
+    assert(tr_out == tr_st);
     assert(trace_invariant tr_out);
     ()
   )
@@ -232,17 +307,47 @@ val mk_comm_layer_response_nonce_proof:
     trace_invariant tr /\
     has_communication_layer_reqres_state_predicate a /\
     has_communication_layer_reqres_crypto_predicates a /\
-    bytes_well_formed tr req_meta_data.key
+    bytes_well_formed tr req_meta_data.key // Can be derived from CommServerReceiveRequest event
   )
   (ensures (
     match mk_comm_layer_response_nonce req_meta_data usg tr with
     | (None, tr_out) -> trace_invariant tr_out
     | (Some nonce, tr_out) -> (
-      is_knowable_by (get_response_label tr_out req_meta_data) tr_out nonce
+      trace_invariant tr_out /\
+      is_knowable_by (get_response_label tr_out req_meta_data) tr_out nonce /\
+      get_label tr_out nonce `can_flow tr_out` get_label tr_out req_meta_data.key
     )
   ))
 let mk_comm_layer_response_nonce_proof #invs #a tr req_meta_data usg =
-  reveal_opaque (`%mk_comm_layer_response_nonce) (mk_comm_layer_response_nonce #a)
+  reveal_opaque (`%mk_comm_layer_response_nonce) (mk_comm_layer_response_nonce #a);
+  reveal_opaque (`%get_response_label) (get_response_label);
+  ()
+
+val mk_comm_layer_response_nonce_labeled_proof:
+  {|protocol_invariants|} ->
+  #a:Type -> {|comm_layer_reqres_config a|} ->
+  tr:trace ->
+  req_meta_data:comm_meta_data a -> usg:usage -> prin:label ->
+  Lemma
+  (requires
+    trace_invariant tr /\
+    has_communication_layer_reqres_state_predicate a /\
+    has_communication_layer_reqres_crypto_predicates a /\
+    bytes_well_formed tr req_meta_data.key // Can be derived from CommServerReceiveRequest event
+  )
+  (ensures (
+    match mk_comm_layer_response_nonce_labeled req_meta_data usg prin tr with
+    | (None, tr_out) -> trace_invariant tr_out
+    | (Some nonce, tr_out) -> (
+      trace_invariant tr_out /\
+      is_knowable_by (get_response_label tr_out req_meta_data) tr_out nonce /\
+      get_label tr_out nonce `can_flow tr_out` get_label tr_out req_meta_data.key
+    )
+  ))
+let mk_comm_layer_response_nonce_labeled_proof #invs #a tr req_meta_data usg prin =
+  reveal_opaque (`%mk_comm_layer_response_nonce_labeled) (mk_comm_layer_response_nonce_labeled #a);
+  reveal_opaque (`%get_response_label) (get_response_label);
+  ()
 
 
 val compute_response_message_proof:
@@ -250,29 +355,30 @@ val compute_response_message_proof:
   #a:Type0 -> {|comm_layer_reqres_config a|} ->
   tr:trace ->
   server:principal ->
-  key:bytes -> nonce:bytes -> request:a -> response:a ->
+  req_meta_data:comm_meta_data a -> nonce:bytes -> request:a -> response:a ->
   Lemma
   (requires
     has_communication_layer_reqres_crypto_predicates a /\
-    is_knowable_by (principal_label server) tr key /\
-    is_well_formed a (is_knowable_by (get_label tr key) tr) response /\
+    is_knowable_by (principal_label server) tr req_meta_data.key /\
+    is_well_formed a (is_knowable_by (get_response_label tr req_meta_data) tr) response /\
     is_publishable tr nonce /\
-    key `has_usage tr` (AeadKey (comm_layer_aead_tag a) empty) /\
+    req_meta_data.key `has_usage tr` (AeadKey (comm_layer_aead_tag a) empty) /\
     event_triggered tr server (CommServerSendResponse server request response <: communication_reqres_event a)
   )
   (ensures
-    is_publishable tr (compute_response_message #a server key nonce response)
+    is_publishable tr (compute_response_message #a server req_meta_data nonce response)
   )
-let compute_response_message_proof #cinvs #a tr server key nonce request response =
+let compute_response_message_proof #cinvs #a tr server req_meta_data nonce request response =
   reveal_opaque (`%compute_response_message) (compute_response_message #a);
+  get_response_label_knowable tr req_meta_data response;
   let res_bytes = serialize a response in
-  serialize_wf_lemma a (is_knowable_by (get_label tr key) tr) response;
+  serialize_wf_lemma a (is_knowable_by (get_response_label tr req_meta_data) tr) response;
   let ad:authenticated_data = {server} in
   let ad_bytes = serialize authenticated_data ad in
   serialize_wf_lemma authenticated_data (is_publishable tr) ad;
-  let ciphertext = aead_enc key nonce res_bytes ad_bytes in
+  let ciphertext = aead_enc req_meta_data.key nonce res_bytes ad_bytes in
   // Needed for the case that the key is publishable
-  FStar.Classical.move_requires (aead_enc_preserves_publishability tr key nonce res_bytes) ad_bytes;
+  FStar.Classical.move_requires (aead_enc_preserves_publishability tr req_meta_data.key nonce res_bytes) ad_bytes;
   serialize_wf_lemma comm_message_t (is_publishable tr) (ResponseMessage {nonce; ciphertext});
   ()
 
@@ -305,8 +411,8 @@ let send_response_proof #invs #a tr higher_layer_preds server req_meta_data resp
     let ServerReceiveRequest srr = state in
     let ((), tr') = trigger_event server (CommServerSendResponse server req_meta_data.request response <: communication_reqres_event a) tr' in
     let (nonce, tr') = mk_rand NoUsage public 32 tr' in
-    compute_response_message_proof tr' server req_meta_data.key nonce req_meta_data.request response;
-    let resp_msg_bytes = compute_response_message server req_meta_data.key nonce response in
+    compute_response_message_proof tr' server req_meta_data nonce req_meta_data.request response;
+    let resp_msg_bytes = compute_response_message server req_meta_data nonce response in
     let (msg_id, tr') = send_msg resp_msg_bytes tr' in
     assert(tr_out == tr');
     assert(trace_invariant tr_out);
@@ -353,6 +459,7 @@ let decode_response_proof #cinvs #a tr client server key msg_bytes =
   )
 #pop-options
 
+#push-options "--z3rlimit 50"
 val receive_response_proof:
   {|protocol_invariants|} ->
   #a:Type -> {|comm_layer_reqres_config a|} ->
@@ -370,7 +477,7 @@ val receive_response_proof:
     | (Some (payload, _), tr_out) -> (
       trace_invariant tr_out /\
       event_triggered tr_out client (CommClientReceiveResponse client req_meta_data.server payload req_meta_data.key <: communication_reqres_event a) /\
-      is_well_formed a (is_knowable_by (get_label tr_out req_meta_data.key) tr_out) payload
+      is_well_formed a (is_knowable_by (get_response_label tr_out req_meta_data) tr_out) payload
     )
   ))
   [SMTPat (trace_invariant tr);
@@ -388,6 +495,7 @@ let receive_response_proof #invs #a tr higher_layer_preds client req_meta_data m
     let (Some resp_msg_bytes, tr') = recv_msg msg_id tr' in
     decode_response_proof #invs.crypto_invs #a tr' client csr.server csr.key resp_msg_bytes;
     let Some response = decode_response_message csr.server csr.key resp_msg_bytes in
+    get_response_label_knowable_reverse tr' req_meta_data response;
     let ((), tr') = set_state client req_meta_data.sid (ClientReceiveResponse {server=csr.server; response; key=csr.key} <: communication_states a) tr' in
     let ((), tr') = trigger_event client (CommClientReceiveResponse client csr.server response csr.key <: communication_reqres_event a) tr' in
     assert(event_triggered tr' client (CommClientReceiveResponse client csr.server response csr.key <: communication_reqres_event a));

--- a/src/lib/communication/DY.Lib.Communication.RequestResponse.Lemmas.fst
+++ b/src/lib/communication/DY.Lib.Communication.RequestResponse.Lemmas.fst
@@ -27,29 +27,13 @@ val get_response_label_knowable:
   req_meta_data:comm_meta_data a -> msg:a ->
   Lemma
   (requires
-    cinvs.usages == default_crypto_usages /\
-    is_well_formed a (is_knowable_by (get_response_label tr req_meta_data) tr) msg
+    cinvs.usages == default_crypto_usages
   )
   (ensures
+    is_well_formed a (is_knowable_by (get_response_label tr req_meta_data) tr) msg <==>
     is_well_formed a (is_knowable_by (get_label tr req_meta_data.key) tr) msg
   )
 let get_response_label_knowable #cinvs #a tr req_meta_data msg =
-  reveal_opaque (`%get_response_label) get_response_label;
-  ()
-
-val get_response_label_knowable_reverse:
-  {|cinvs:crypto_invariants|} ->
-  #a:Type0 -> {|comm_layer_reqres_config a|} -> tr:trace ->
-  req_meta_data:comm_meta_data a -> msg:a ->
-  Lemma
-  (requires
-    cinvs.usages == default_crypto_usages /\
-    is_well_formed a (is_knowable_by (get_label tr req_meta_data.key) tr) msg
-  )
-  (ensures
-    is_well_formed a (is_knowable_by (get_response_label tr req_meta_data) tr) msg
-  )
-let get_response_label_knowable_reverse #cinvs #a tr req_meta_data msg =
   reveal_opaque (`%get_response_label) get_response_label;
   ()
 
@@ -66,6 +50,7 @@ val get_response_label_later:
     get_response_label tr1 req_meta_data == get_response_label tr2 req_meta_data
   )
   [SMTPat (get_response_label tr1 req_meta_data);
+   SMTPat (get_response_label tr2 req_meta_data);
    SMTPat (tr1 <$ tr2);
   ]
 let get_response_label_later #a tr1 tr2 req_meta_data =
@@ -251,7 +236,7 @@ let receive_request_proof #invs #a #config tr comm_keys_ids higher_layer_preds s
     with _. eliminate exists client. event_triggered tr_recv client (req_send_event client)
       returns _
       with _. (
-        get_response_label_knowable_reverse tr_recv req_meta_data request;
+        get_response_label_knowable tr_recv req_meta_data request;
 
         let i = find_event_triggered_at_timestamp tr_recv client (req_send_event client) in
         ()
@@ -395,6 +380,8 @@ let send_response_proof #invs #a tr higher_layer_preds server req_meta_data resp
     let ServerReceiveRequest srr = state in
     let ((), tr') = trigger_event server (CommServerSendResponse server req_meta_data.request response <: communication_reqres_event a) tr' in
     let (nonce, tr') = mk_rand NoUsage public 32 tr' in
+    // Triggers get_response_label_later
+    assert(tr <$ tr');
     compute_response_message_proof tr' server req_meta_data nonce req_meta_data.request response;
     let resp_msg_bytes = compute_response_message server req_meta_data nonce response in
     let (msg_id, tr') = send_msg resp_msg_bytes tr' in
@@ -479,7 +466,7 @@ let receive_response_proof #invs #a tr higher_layer_preds client req_meta_data m
     let (Some resp_msg_bytes, tr') = recv_msg msg_id tr' in
     decode_response_proof #invs.crypto_invs #a tr' client csr.server csr.key resp_msg_bytes;
     let Some response = decode_response_message csr.server csr.key resp_msg_bytes in
-    get_response_label_knowable_reverse tr' req_meta_data response;
+    get_response_label_knowable tr' req_meta_data response;
     let ((), tr') = set_state client req_meta_data.sid (ClientReceiveResponse {server=csr.server; response; key=csr.key} <: communication_states a) tr' in
     let ((), tr') = trigger_event client (CommClientReceiveResponse client csr.server response csr.key <: communication_reqres_event a) tr' in
     assert(event_triggered tr' client (CommClientReceiveResponse client csr.server response csr.key <: communication_reqres_event a));

--- a/src/lib/communication/DY.Lib.Communication.RequestResponse.Lemmas.fst
+++ b/src/lib/communication/DY.Lib.Communication.RequestResponse.Lemmas.fst
@@ -206,6 +206,7 @@ let send_request_proof #invs #a tr comm_keys_ids higher_layer_preds client serve
     assert(trace_invariant tr_out);
     ()
   )
+#pop-options
 
 
 #push-options "--z3rlimit 200"
@@ -503,3 +504,4 @@ let receive_response_proof #invs #a tr higher_layer_preds client req_meta_data m
     assert(trace_invariant tr_out);
     ()
   )
+#pop-options

--- a/src/lib/communication/DY.Lib.Communication.RequestResponse.Lemmas.fst
+++ b/src/lib/communication/DY.Lib.Communication.RequestResponse.Lemmas.fst
@@ -21,21 +21,20 @@ open DY.Lib.Communication.RequestResponse.Invariants
 
 (*** Lemmas ***)
 
-val get_response_label_knowable:
+val get_response_label_eq_key_label:
   {|cinvs:crypto_invariants|} ->
-  #a:Type0 -> {|comm_layer_reqres_config a|} -> tr:trace ->
-  req_meta_data:comm_meta_data a -> msg:a ->
+  #a:Type0 -> {|conf:comm_layer_reqres_config a|} -> tr:trace ->
+  req_meta_data:comm_meta_data a ->
   Lemma
   (requires
-    cinvs.usages == default_crypto_usages
+    cinvs.usages == default_crypto_usages /\
+    bytes_well_formed tr req_meta_data.key
   )
   (ensures
-    is_well_formed a (is_knowable_by (get_response_label tr req_meta_data) tr) msg <==>
-    is_well_formed a (is_knowable_by (get_label tr req_meta_data.key) tr) msg
+    get_response_label tr req_meta_data == get_label tr (req_meta_data.key)
   )
-let get_response_label_knowable #cinvs #a tr req_meta_data msg =
-  reveal_opaque (`%get_response_label) get_response_label;
-  ()
+let get_response_label_eq_key_label #cinvs #a #_ tr req_meta_data =
+  reveal_opaque (`%get_response_label) (get_response_label)
 
 val get_response_label_later:
   #a:Type0 -> {|comm_layer_reqres_config a|} ->
@@ -180,7 +179,7 @@ let send_request_proof #invs #a tr comm_keys_ids higher_layer_preds client serve
 #pop-options
 
 
-#push-options "--z3rlimit 50"
+#push-options "--z3rlimit 25"
 val receive_request_proof:
   {|invs:protocol_invariants|} ->
   #a:Type -> {|comm_layer_reqres_config a|} ->
@@ -218,24 +217,32 @@ let receive_request_proof #invs #a #config tr comm_keys_ids higher_layer_preds s
   | (Some (payload, req_meta_data), tr_out) -> (
     receive_confidential_proof #invs #comm_message_t #(comm_layer_tag_core_config_reqres a) tr (comm_core_higher_layer_event_preds_reqres a) comm_keys_ids server msg_id;
     let (Some req_msg_t, tr_recv) = receive_confidential #comm_message_t #(comm_layer_tag_core_config_reqres a) comm_keys_ids server msg_id tr in
+    assert(trace_invariant tr_recv);
+    
     let RequestMessage req_msg = req_msg_t in
     let Some request = parse a req_msg.request in
 
     let req_msg_bytes:bytes = serialize comm_message_t req_msg_t in
     let req_send_event client:communication_reqres_event a = CommClientSendRequest client server request req_msg.key in
 
-    conf_message_secrecy tr' request_response_event_preconditions server req_msg_bytes;
+    conf_message_secrecy tr_recv (comm_core_higher_layer_event_preds_reqres a) server req_msg_t;
 
-    assert(is_knowable_by (get_label tr' req_msg.key) tr' req_msg.request);
-    FStar.Classical.move_requires (has_usage_publishable tr' req_msg.key) (AeadKey comm_layer_aead_tag empty);
-    assert(req_msg.key `has_usage tr'` (AeadKey comm_layer_aead_tag empty));
+    parse_wf_lemma a (is_knowable_by (principal_label server) tr_recv) req_msg.request;
+    assert(is_well_formed a (is_knowable_by (principal_label server) tr_recv) request);
+    
+    FStar.Classical.move_requires (parse_wf_lemma a (is_publishable tr_recv)) req_msg.request;
+    get_response_label_eq_key_label tr_recv req_meta_data;
+    assert(is_well_formed a (is_knowable_by (get_response_label tr_recv req_meta_data) tr_recv) request);
 
-    // Relating knowledge of the request to knowledge of its fields
-    serialize_parse_inv_lemma #bytes a req_msg.request;
-    assert(is_comm_response_payload tr_recv server req_meta_data payload);
-
+    FStar.Classical.move_requires (has_usage_publishable tr_recv req_msg.key) (AeadKey (comm_layer_aead_tag a) empty);
+    assert(req_msg.key `has_usage tr_recv` (AeadKey (comm_layer_aead_tag a) empty));
+    
     let ((), tr_ev) = trigger_event server (CommServerReceiveRequest server request req_msg.key <: communication_reqres_event a) tr_recv in
+    assert(event_triggered tr_ev server (CommServerReceiveRequest server payload req_meta_data.key <: communication_reqres_event a));
+    assert(trace_invariant tr_ev);
+
     let (sid', tr_sess) = new_session_id server tr_ev in
+    assert(trace_invariant tr_sess);
 
     // Needed for the proof to go through
     assert((state_predicate_communication_layer_reqres a).pred tr_sess server sid' (ServerReceiveRequest {request; key=req_msg.key} <: communication_states a));
@@ -322,7 +329,7 @@ val compute_response_message_proof:
   )
 let compute_response_message_proof #cinvs #a tr server req_meta_data nonce request response =
   reveal_opaque (`%compute_response_message) (compute_response_message #a);
-  get_response_label_knowable tr req_meta_data response;
+  get_response_label_eq_key_label tr req_meta_data;
   let res_bytes = serialize a response in
   serialize_wf_lemma a (is_knowable_by (get_response_label tr req_meta_data) tr) response;
   let ad:authenticated_data = {server} in
@@ -377,7 +384,7 @@ let send_response_proof #invs #a tr higher_layer_preds server req_meta_data resp
 #pop-options
 
 
-#push-options "--fuel 0 --ifuel 1 --z3rlimit 10"
+#push-options "--fuel 0 --ifuel 1 --z3rlimit 20"
 val decode_response_proof:
   {|crypto_invariants|} ->
   #a:Type -> {|comm_layer_reqres_config a|} ->
@@ -452,7 +459,7 @@ let receive_response_proof #invs #a tr higher_layer_preds client req_meta_data m
     let (Some resp_msg_bytes, tr') = recv_msg msg_id tr' in
     decode_response_proof #invs.crypto_invs #a tr' client csr.server csr.key resp_msg_bytes;
     let Some response = decode_response_message csr.server csr.key resp_msg_bytes in
-    get_response_label_knowable tr' req_meta_data response;
+    get_response_label_eq_key_label tr' req_meta_data;
     let ((), tr') = set_state client req_meta_data.sid (ClientReceiveResponse {server=csr.server; response; key=csr.key} <: communication_states a) tr' in
     let ((), tr') = trigger_event client (CommClientReceiveResponse client csr.server response csr.key <: communication_reqres_event a) tr' in
     assert(event_triggered tr' client (CommClientReceiveResponse client csr.server response csr.key <: communication_reqres_event a));
@@ -460,5 +467,4 @@ let receive_response_proof #invs #a tr higher_layer_preds client req_meta_data m
     assert(trace_invariant tr_out);
     ()
   )
-#pop-options
 #pop-options

--- a/src/lib/communication/DY.Lib.Communication.RequestResponse.Lemmas.fst
+++ b/src/lib/communication/DY.Lib.Communication.RequestResponse.Lemmas.fst
@@ -21,25 +21,25 @@ open DY.Lib.Communication.RequestResponse.Invariants
 
 (*** Lemmas ***)
 
-val get_response_label: tr:trace -> a:Type -> {|comparse_parser_serializer a|} -> comm_meta_data a -> label
-let get_response_label tr a #ps req_meta_data = get_label #default_crypto_usages tr req_meta_data.key
+val get_response_label: tr:trace -> #a:Type0 -> {|comm_layer_reqres_config a|} -> comm_meta_data a -> label
+let get_response_label tr #a #ps req_meta_data = get_label #default_crypto_usages tr req_meta_data.key
 
 val is_comm_response_payload:
   {|crypto_invariants|} ->
-  #a:Type -> {|comparse_parser_serializer a|} ->
+  #a:Type0 -> {|comm_layer_reqres_config a|} ->
   trace -> principal -> comm_meta_data a -> a -> prop
 let is_comm_response_payload #cusg #a #ps tr server req_meta_data payload =
-  is_well_formed a #ps_able (is_knowable_by (get_response_label tr a req_meta_data) tr) payload
+  is_well_formed a (is_knowable_by (get_response_label tr req_meta_data) tr) payload
 
 val comm_meta_data_knowable: 
   {|crypto_invariants|} ->
   trace ->
-  a:Type -> {|comparse_parser_serializer a|} ->
+  a:Type -> {|comm_layer_reqres_config a|} ->
   principal -> comm_meta_data a ->
   prop
 let comm_meta_data_knowable #cinvs tr a #ps prin req_meta_data =
   is_knowable_by (principal_label prin) tr req_meta_data.key /\
-  is_well_formed a #ps_able (is_knowable_by (principal_label prin) tr) req_meta_data.request
+  is_well_formed a (is_knowable_by (principal_label prin) tr) req_meta_data.request
 
 /// The communication layer makes use of many lemmas with SMT patterns.
 /// These lemmas depend, however, on the communication layer predicates
@@ -53,34 +53,33 @@ let comm_meta_data_knowable #cinvs tr a #ps prin req_meta_data =
 
 [@@"opaque_to_smt"]
 val reqres_comm_layer_lemmas_enabled:
-  #a:Type -> {| comparse_parser_serializer a |} ->
-  comm_reqres_higher_layer_event_preds a #ps_able -> prop
+  #a:Type0 -> {| comm_layer_reqres_config a |} ->
+  comm_reqres_higher_layer_event_preds a -> prop
 let reqres_comm_layer_lemmas_enabled _ = True
 
 val enable_reqres_comm_layer_lemmas:
-  #a:Type -> {| comparse_parser_serializer a |} ->
+  #a:Type0 -> {| comm_layer_reqres_config a |} ->
   preds:comm_reqres_higher_layer_event_preds a ->
   Lemma (reqres_comm_layer_lemmas_enabled preds)
 let enable_reqres_comm_layer_lemmas preds =
   normalize_term_spec (reqres_comm_layer_lemmas_enabled preds)
 
 val send_request_proof:
-  {|tag:comm_layer_reqres_tag|} ->
   {|protocol_invariants|} ->
-  #a:Type -> {|comparse_parser_serializer a|} ->
+  #a:Type0 -> {|comm_layer_reqres_config a|} ->
   tr:trace ->
   comm_keys_ids:communication_keys_sess_ids ->
-  higher_layer_preds:comm_reqres_higher_layer_event_preds a #ps_able ->
+  higher_layer_preds:comm_reqres_higher_layer_event_preds a ->
   client:principal -> server:principal -> request:a ->
   Lemma
   (requires
     trace_invariant tr /\
     has_pki_invariant /\
-    has_communication_layer_crypto_predicates /\
-    has_communication_layer_reqres_event_predicates request_response_event_preconditions higher_layer_preds /\
+    has_communication_layer_crypto_predicates comm_message_t /\
+    has_communication_layer_reqres_event_predicates higher_layer_preds /\
     has_communication_layer_state_predicates a /\
     higher_layer_preds.send_request tr client server request (comm_label client server) /\
-    is_well_formed a #ps_able (is_knowable_by (comm_label client server) tr) request
+    is_well_formed a (is_knowable_by (comm_label client server) tr) request
   )
   (ensures (
     match send_request comm_keys_ids client server request tr with
@@ -93,27 +92,26 @@ val send_request_proof:
   [SMTPat (trace_invariant tr);
   SMTPat (reqres_comm_layer_lemmas_enabled higher_layer_preds);
   SMTPat (send_request comm_keys_ids client server request tr)]
-let send_request_proof #tag #invs #a #ps tr comm_keys_ids higher_layer_preds client server request =
-  reveal_opaque (`%send_request) (send_request #tag #a #ps);
-  enable_core_comm_layer_lemmas request_response_event_preconditions;
-  let request_bytes = serialize #bytes a #ps_able request in
+let send_request_proof #invs #a tr comm_keys_ids higher_layer_preds client server request =
+  reveal_opaque (`%send_request) (send_request #a);
+  enable_core_comm_layer_lemmas (request_response_event_preconditions a);
+  let request_bytes = serialize a request in
   match send_request comm_keys_ids client server request tr with
   | (None, tr_out) -> (
-    let (key, tr') = mk_rand (AeadKey comm_layer_aead_tag empty) (comm_label client server) 32 tr in
+    let (key, tr') = mk_rand (AeadKey (comm_layer_aead_tag a) empty) (comm_label client server) 32 tr in
     let (sid, tr') = new_session_id client tr' in
     let ((), tr') = set_state client sid (ClientSendRequest {server; request=request; key} <: communication_states a) tr' in
     higher_layer_preds.send_request_later tr tr' client server request (get_label tr' key);
     ()
   )
   | (Some _, tr_out) -> (
-    let (key, tr') = mk_rand (AeadKey comm_layer_aead_tag empty) (comm_label client server) 32 tr in
+    let (key, tr') = mk_rand (AeadKey (comm_layer_aead_tag a) empty) (comm_label client server) 32 tr in
     let (sid, tr') = new_session_id client tr' in
     let ((), tr') = set_state client sid (ClientSendRequest {server; request; key} <: communication_states a) tr' in
     higher_layer_preds.send_request_later tr tr' client server request (get_label tr' key);
-    let ((), tr') = trigger_event client (CommClientSendRequest client server request_bytes key) tr' in
+    let ((), tr') = trigger_event client (CommClientSendRequest client server request key <: communication_reqres_event a) tr' in
     assert(trace_invariant tr');
-    let req_payload:com_message_t = RequestMessage {request=request_bytes; key} in
-    let req_payload_bytes = serialize #bytes com_message_t req_payload in
+    let req_payload:comm_message_t = RequestMessage {request=request_bytes; key} in
     let (Some msg_id, tr') = send_confidential comm_keys_ids client server req_payload tr' in
 
     assert(tr_out == tr');
@@ -124,59 +122,58 @@ let send_request_proof #tag #invs #a #ps tr comm_keys_ids higher_layer_preds cli
 
 #push-options "--z3rlimit 50"
 val receive_request_proof:
-  {|tag:comm_layer_reqres_tag|} ->
   {|protocol_invariants|} ->
-  #a:Type -> {|ps:comparse_parser_serializer a|} ->
+  #a:Type -> {|comm_layer_reqres_config a|} ->
   tr:trace ->
   comm_keys_ids:communication_keys_sess_ids ->
-  higher_layer_preds:comm_reqres_higher_layer_event_preds a #ps_able ->
+  higher_layer_preds:comm_reqres_higher_layer_event_preds a ->
   server:principal -> msg_id:timestamp ->
   Lemma
   (requires
     trace_invariant tr /\
     has_private_keys_invariant /\
     has_pki_invariant /\
-    has_communication_layer_reqres_crypto_predicates /\
-    has_communication_layer_reqres_event_predicates request_response_event_preconditions higher_layer_preds /\
+    has_communication_layer_reqres_crypto_predicates a /\
+    has_communication_layer_reqres_event_predicates higher_layer_preds /\
     has_communication_layer_state_predicates a
   )
   (ensures (
-    match receive_request comm_keys_ids server msg_id tr with
+    match receive_request #a comm_keys_ids server msg_id tr with
     | (None, tr_out) -> trace_invariant tr_out
     | (Some (payload, req_meta_data), tr_out) -> (
-      let payload_bytes = serialize a #ps_able payload in
       trace_invariant tr_out /\
-      event_triggered tr_out server (CommServerReceiveRequest server payload_bytes req_meta_data.key) /\
-      is_well_formed a #ps_able (is_knowable_by (principal_label server) tr_out) payload /\
-      is_well_formed a #ps_able (is_knowable_by (get_response_label tr_out a req_meta_data) tr_out) payload /\
+      event_triggered tr_out server (CommServerReceiveRequest server payload req_meta_data.key <: communication_reqres_event a) /\
+      is_well_formed a (is_knowable_by (principal_label server) tr_out) payload /\
+      is_well_formed a (is_knowable_by (get_response_label tr_out req_meta_data) tr_out) payload /\
       payload == req_meta_data.request
     )
   ))
   [SMTPat (trace_invariant tr);
   SMTPat (reqres_comm_layer_lemmas_enabled higher_layer_preds);
-  SMTPat (receive_request #tag #a #ps comm_keys_ids server msg_id tr)]
-let receive_request_proof #tag #invs #a #ps tr comm_keys_ids higher_layer_preds server msg_id =
-  reveal_opaque (`%receive_request) (receive_request #tag #a #ps);
-  enable_core_comm_layer_lemmas request_response_event_preconditions;
-  match receive_request comm_keys_ids server msg_id tr with
+  SMTPat (receive_request #a comm_keys_ids server msg_id tr)]
+let receive_request_proof #invs #a tr comm_keys_ids higher_layer_preds server msg_id =
+  reveal_opaque (`%receive_request) (receive_request #a);
+  enable_core_comm_layer_lemmas (request_response_event_preconditions a);
+  match receive_request #a comm_keys_ids server msg_id tr with
   | (None, tr_out) -> ()
   | (Some (payload, req_meta_data), tr_out) -> (
+    receive_confidential_proof tr (request_response_event_preconditions a) comm_keys_ids server msg_id;
     let (Some req_msg_t, tr') = receive_confidential comm_keys_ids server msg_id tr in
     let RequestMessage req_msg = req_msg_t in
-    let Some request = parse a #ps_able req_msg.request in
+    let Some request = parse a req_msg.request in
 
-    let req_msg_bytes = serialize com_message_t req_msg_t in
-    let req_send_event client = CommClientSendRequest client server req_msg.request req_msg.key in
+    let req_msg_bytes:bytes = serialize comm_message_t req_msg_t in
+    let req_send_event client:communication_reqres_event a = CommClientSendRequest client server request req_msg.key in
 
-    let i = find_event_triggered_at_timestamp tr' server (CommConfReceiveMsg server req_msg_bytes) in
-    conf_message_secrecy tr' i request_response_event_preconditions server req_msg_bytes;
+    let i = find_event_triggered_at_timestamp tr' server (CommConfReceiveMsg server req_msg_t <: communication_core_event comm_message_t) in
+    conf_message_secrecy tr' i (request_response_event_preconditions a) server req_msg_t;
 
     // Properties that can be proved uniformly in both the honest and corrupt case
     eliminate (exists client. event_triggered tr' client (req_send_event client)) \/
               (is_publishable tr' req_msg.request /\ is_publishable tr' req_msg.key)
     returns (
-      is_knowable_by (get_response_label tr' a req_meta_data) tr' req_msg.request /\
-      req_msg.key `has_usage tr'` (AeadKey comm_layer_aead_tag empty)
+      is_well_formed a (is_knowable_by (get_response_label tr' req_meta_data) tr') request /\
+      req_msg.key `has_usage tr'` (AeadKey (comm_layer_aead_tag a) empty)
     )
     with _. eliminate exists client. event_triggered tr' client (req_send_event client)
       returns _
@@ -185,13 +182,16 @@ let receive_request_proof #tag #invs #a #ps tr comm_keys_ids higher_layer_preds 
         // Triggers event_triggered_at_implies_pred
         assert(event_triggered_at tr' i client (req_send_event client))
       )
-    and _. has_usage_publishable tr' req_msg.key (AeadKey comm_layer_aead_tag empty);
+    and _. (has_usage_publishable tr' req_msg.key (AeadKey (comm_layer_aead_tag a) empty);
+      parse_wf_lemma a (is_publishable tr') req_msg.request;
+      ()
+    );
 
     // Relating knowledge of the request to knowledge of its fields
-    serialize_parse_inv_lemma #bytes a #ps_able req_msg.request;
+    serialize_parse_inv_lemma #bytes a req_msg.request;
     assert(is_comm_response_payload tr' server req_meta_data payload);
 
-    let ((), tr') = trigger_event server (CommServerReceiveRequest server req_msg.request req_msg.key) tr' in
+    let ((), tr') = trigger_event server (CommServerReceiveRequest server request req_msg.key <: communication_reqres_event a) tr' in
     let (sid', tr') = new_session_id server tr' in
     let ((), tr') = set_state server sid' (ServerReceiveRequest {request; key=req_msg.key} <: communication_states a) tr' in
     assert(tr' == tr_out);
@@ -202,76 +202,73 @@ let receive_request_proof #tag #invs #a #ps tr comm_keys_ids higher_layer_preds 
 
 
 val mk_comm_layer_response_nonce_proof:
-  {|comm_layer_reqres_tag|} ->
-  #a:Type -> {|comparse_parser_serializer a|} ->
   {|protocol_invariants|} ->
+  #a:Type -> {|comm_layer_reqres_config a|} ->
   tr:trace ->
   req_meta_data:comm_meta_data a -> usg:usage ->
   Lemma
   (requires
     trace_invariant tr /\
     has_communication_layer_state_predicates a /\
-    has_communication_layer_reqres_crypto_predicates /\
+    has_communication_layer_reqres_crypto_predicates a /\
     bytes_well_formed tr req_meta_data.key
   )
   (ensures (
     match mk_comm_layer_response_nonce req_meta_data usg tr with
     | (None, tr_out) -> trace_invariant tr_out
     | (Some nonce, tr_out) -> (
-      is_knowable_by (get_response_label tr_out a req_meta_data) tr_out nonce
+      is_knowable_by (get_response_label tr_out req_meta_data) tr_out nonce
     )
   ))
-let mk_comm_layer_response_nonce_proof #tag #a #ps #invs tr req_meta_data usg =
+let mk_comm_layer_response_nonce_proof #invs #a tr req_meta_data usg =
   reveal_opaque (`%mk_comm_layer_response_nonce) (mk_comm_layer_response_nonce #a)
 
 
 val compute_response_message_proof:
-  {|comm_layer_reqres_tag|} ->
   {|crypto_invariants|} ->
-  #a:Type -> {|comparse_parser_serializer a|} ->
+  #a:Type0 -> {|comm_layer_reqres_config a|} ->
   tr:trace ->
   server:principal ->
   key:bytes -> nonce:bytes -> request:a -> response:a ->
   Lemma
   (requires
-    has_communication_layer_reqres_crypto_predicates /\
+    has_communication_layer_reqres_crypto_predicates a /\
     is_knowable_by (principal_label server) tr key /\
-    is_well_formed a #ps_able (is_knowable_by (get_label tr key) tr) response /\
+    is_well_formed a (is_knowable_by (get_label tr key) tr) response /\
     is_publishable tr nonce /\
-    key `has_usage tr` (AeadKey comm_layer_aead_tag empty) /\
-    event_triggered tr server (CommServerSendResponse server (serialize a #ps_able request) (serialize a #ps_able response))
+    key `has_usage tr` (AeadKey (comm_layer_aead_tag a) empty) /\
+    event_triggered tr server (CommServerSendResponse server request response <: communication_reqres_event a)
   )
   (ensures
     is_publishable tr (compute_response_message #a server key nonce response)
   )
-let compute_response_message_proof #tag #cinvs #a #ps tr server key nonce request response =
+let compute_response_message_proof #cinvs #a tr server key nonce request response =
   reveal_opaque (`%compute_response_message) (compute_response_message #a);
-  let res_bytes = serialize a #ps_able response in
-  serialize_wf_lemma a #ps_able (is_knowable_by (get_label tr key) tr) response;
+  let res_bytes = serialize a response in
+  serialize_wf_lemma a (is_knowable_by (get_label tr key) tr) response;
   let ad:authenticated_data = {server} in
   let ad_bytes = serialize authenticated_data ad in
   serialize_wf_lemma authenticated_data (is_publishable tr) ad;
   let ciphertext = aead_enc key nonce res_bytes ad_bytes in
   // Needed for the case that the key is publishable
   FStar.Classical.move_requires (aead_enc_preserves_publishability tr key nonce res_bytes) ad_bytes;
-  serialize_wf_lemma com_message_t (is_publishable tr) (ResponseMessage {nonce; ciphertext});
+  serialize_wf_lemma comm_message_t (is_publishable tr) (ResponseMessage {nonce; ciphertext});
   ()
 
 val send_response_proof:
-  {|comm_layer_reqres_tag|} ->
   {|protocol_invariants|} ->
-  #a:eqtype -> {|comparse_parser_serializer a|} ->
+  #a:eqtype -> {|comm_layer_reqres_config a|} ->
   tr:trace ->
-  higher_layer_preds:comm_reqres_higher_layer_event_preds a #ps_able ->
+  higher_layer_preds:comm_reqres_higher_layer_event_preds a ->
   server:principal -> req_meta_data:comm_meta_data a -> response:a ->
   Lemma
   (requires
     trace_invariant tr /\
-    has_communication_layer_reqres_crypto_predicates /\
-    has_communication_layer_reqres_event_predicates request_response_event_preconditions higher_layer_preds /\
+    has_communication_layer_reqres_crypto_predicates a /\
+    has_communication_layer_reqres_event_predicates higher_layer_preds /\
     higher_layer_preds.send_response tr server req_meta_data.request response /\
     has_communication_layer_state_predicates a /\
-    is_well_formed a #ps_able (is_knowable_by (get_response_label tr a req_meta_data) tr) response
+    is_well_formed a (is_knowable_by (get_response_label tr req_meta_data) tr) response
   )
   (ensures (
     let (_, tr_out) = send_response server req_meta_data response tr in
@@ -280,14 +277,14 @@ val send_response_proof:
   [SMTPat (trace_invariant tr);
   SMTPat (reqres_comm_layer_lemmas_enabled higher_layer_preds);
   SMTPat (send_response server req_meta_data response tr)]
-let send_response_proof #tag #invs #a #ps tr higher_layer_preds server req_meta_data response =
-  reveal_opaque (`%send_response) (send_response #tag #a #ps);
+let send_response_proof #invs #a tr higher_layer_preds server req_meta_data response =
+  reveal_opaque (`%send_response) (send_response #a);
   match send_response server req_meta_data response tr with
   | (None, tr_out) -> ()
   | (Some msg_id, tr_out) -> (
     let (Some state, tr'):(option (communication_states a) & trace) = get_state server req_meta_data.sid tr in
     let ServerReceiveRequest srr = state in
-    let ((), tr') = trigger_event server (CommServerSendResponse server (serialize a #ps_able req_meta_data.request) (serialize a #ps_able response)) tr' in
+    let ((), tr') = trigger_event server (CommServerSendResponse server req_meta_data.request response <: communication_reqres_event a) tr' in
     let (nonce, tr') = mk_rand NoUsage public 32 tr' in
     compute_response_message_proof tr' server req_meta_data.key nonce req_meta_data.request response;
     let resp_msg_bytes = compute_response_message server req_meta_data.key nonce response in
@@ -300,56 +297,54 @@ let send_response_proof #tag #invs #a #ps tr higher_layer_preds server req_meta_
 
 #push-options "--fuel 0 --ifuel 1 --z3rlimit 10"
 val decode_response_proof:
-  {|comm_layer_reqres_tag|} ->
   {|crypto_invariants|} ->
-  #a:Type -> {|comparse_parser_serializer a|} ->
+  #a:Type -> {|comm_layer_reqres_config a|} ->
   tr:trace ->
   client:principal -> server:principal ->
   key:bytes -> response:bytes ->
   Lemma
   (requires
-    has_communication_layer_reqres_crypto_predicates /\
+    has_communication_layer_reqres_crypto_predicates a /\
     is_publishable tr response /\
     is_secret (comm_label client server) tr key /\
-    key `has_usage tr` (AeadKey comm_layer_aead_tag empty)
+    key `has_usage tr` (AeadKey (comm_layer_aead_tag a) empty)
   )
   (ensures (
     match decode_response_message server key response with
     | None -> True
     | Some payload -> (
-      is_well_formed a #ps_able (is_knowable_by (get_label tr key) tr) payload /\
-      is_knowable_by (get_label tr key) tr (serialize a #ps_able payload) /\
-      (exists request. event_triggered tr server (CommServerSendResponse server request (serialize a #ps_able payload))
+      is_well_formed a (is_knowable_by (get_label tr key) tr) payload /\
+      is_knowable_by (get_label tr key) tr (serialize a payload) /\
+      (exists request. event_triggered tr server (CommServerSendResponse server request payload <: communication_reqres_event a)
         \/ is_corrupt tr (principal_label client) \/ is_corrupt tr (principal_label server))
     )
   ))
-let decode_response_proof #tag #cinvs #a #ps tr client server key msg_bytes =
-  reveal_opaque (`%decode_response_message) (decode_response_message #tag #a);
-  match decode_response_message #tag #a server key msg_bytes with
+let decode_response_proof #cinvs #a tr client server key msg_bytes =
+  reveal_opaque (`%decode_response_message) (decode_response_message #a);
+  match decode_response_message #a server key msg_bytes with
   | None -> ()
   | Some payload -> (
-    parse_wf_lemma com_message_t (is_publishable tr) msg_bytes;
-    let Some (ResponseMessage {nonce; ciphertext}) = parse com_message_t msg_bytes in
+    parse_wf_lemma comm_message_t (is_publishable tr) msg_bytes;
+    let Some (ResponseMessage {nonce; ciphertext}) = parse comm_message_t msg_bytes in
     serialize_wf_lemma authenticated_data (is_publishable tr) {server};
     let ad_bytes = serialize authenticated_data {server} in
     let Some res_bytes = aead_dec key nonce ciphertext ad_bytes in
-    serialize_parse_inv_lemma #bytes a #ps_able res_bytes;
+    serialize_parse_inv_lemma a res_bytes;
     ()
   )
 #pop-options
 
 val receive_response_proof:
-  {|tag:comm_layer_reqres_tag|} ->
   {|protocol_invariants|} ->
-  #a:Type -> {|comparse_parser_serializer a|} ->
+  #a:Type -> {|comm_layer_reqres_config a|} ->
   tr:trace ->
-  higher_layer_preds:comm_reqres_higher_layer_event_preds a #ps_able ->
+  higher_layer_preds:comm_reqres_higher_layer_event_preds a->
   client:principal -> req_meta_data:comm_meta_data a -> msg_id:timestamp ->
   Lemma
   (requires
     trace_invariant tr /\
-    has_communication_layer_reqres_crypto_predicates /\
-    has_communication_layer_reqres_event_predicates request_response_event_preconditions higher_layer_preds /\
+    has_communication_layer_reqres_crypto_predicates a /\
+    has_communication_layer_reqres_event_predicates higher_layer_preds /\
     has_communication_layer_state_predicates a
   )
   (ensures (
@@ -357,16 +352,16 @@ val receive_response_proof:
     | (None, tr_out) -> trace_invariant tr_out
     | (Some (payload, _), tr_out) -> (
       trace_invariant tr_out /\
-      event_triggered tr_out client (CommClientReceiveResponse client req_meta_data.server (serialize a #ps_able payload) req_meta_data.key) /\
-      is_well_formed a #ps_able (is_knowable_by (get_label tr_out req_meta_data.key) tr_out) payload
+      event_triggered tr_out client (CommClientReceiveResponse client req_meta_data.server payload req_meta_data.key <: communication_reqres_event a) /\
+      is_well_formed a (is_knowable_by (get_label tr_out req_meta_data.key) tr_out) payload
     )
   ))
   [SMTPat (trace_invariant tr);
   SMTPat (reqres_comm_layer_lemmas_enabled higher_layer_preds);
   SMTPat (receive_response client req_meta_data msg_id tr)]
-let receive_response_proof #tag #invs #a #ps tr higher_layer_preds client req_meta_data msg_id =
-  reveal_opaque (`%receive_response) (receive_response #tag #a #ps);
-  match receive_response #tag #a #ps client req_meta_data msg_id tr with
+let receive_response_proof #invs #a tr higher_layer_preds client req_meta_data msg_id =
+  reveal_opaque (`%receive_response) (receive_response #a);
+  match receive_response #a client req_meta_data msg_id tr with
   | (None, tr_out) -> ()
   | (Some (response, _), tr_out) -> (
     let server = req_meta_data.server in
@@ -374,11 +369,11 @@ let receive_response_proof #tag #invs #a #ps tr higher_layer_preds client req_me
     let (Some state, tr'):(option (communication_states a) & trace) = get_state client req_meta_data.sid tr in
     let ClientSendRequest csr = state in
     let (Some resp_msg_bytes, tr') = recv_msg msg_id tr' in
-    decode_response_proof #tag #invs.crypto_invs #a tr' client csr.server csr.key resp_msg_bytes;
+    decode_response_proof #invs.crypto_invs #a tr' client csr.server csr.key resp_msg_bytes;
     let Some response = decode_response_message csr.server csr.key resp_msg_bytes in
     let ((), tr') = set_state client req_meta_data.sid (ClientReceiveResponse {server=csr.server; response; key=csr.key} <: communication_states a) tr' in
-    let ((), tr') = trigger_event client (CommClientReceiveResponse client csr.server (serialize a #ps_able response) csr.key) tr' in
-    assert(event_triggered tr' client (CommClientReceiveResponse client csr.server (serialize a #ps_able response) csr.key));
+    let ((), tr') = trigger_event client (CommClientReceiveResponse client csr.server response csr.key <: communication_reqres_event a) tr' in
+    assert(event_triggered tr' client (CommClientReceiveResponse client csr.server response csr.key <: communication_reqres_event a));
     assert(tr_out == tr');
     assert(trace_invariant tr_out);
     ()

--- a/src/lib/communication/DY.Lib.Communication.RequestResponse.Lemmas.fst
+++ b/src/lib/communication/DY.Lib.Communication.RequestResponse.Lemmas.fst
@@ -53,24 +53,8 @@ let get_response_label_knowable_reverse #cinvs #a tr req_meta_data msg =
   reveal_opaque (`%get_response_label) get_response_label;
   ()
 
-val get_response_label_publishable:
-  {|cinvs:crypto_invariants|} ->
-  #a:Type0 -> {|comm_layer_reqres_config a|} -> tr:trace ->
-  req_meta_data:comm_meta_data a -> request:a ->
-  Lemma
-  (requires
-    (is_well_formed a (is_knowable_by (get_response_label tr req_meta_data) tr) request \/
-      (is_well_formed a (is_publishable tr) request /\ is_publishable tr req_meta_data.key))
-  )
-  (ensures
-    is_well_formed a (is_knowable_by (get_response_label tr req_meta_data) tr) request
-  )
-let get_response_label_publishable #cinvs #a tr req_meta_data request =
-  reveal_opaque (`%get_response_label) get_response_label;
-  ()
-
 val get_response_label_later:
-  #a:Type0 -> {|comm_layer_reqres_config a|} -> 
+  #a:Type0 -> {|comm_layer_reqres_config a|} ->
   tr1:trace -> tr2:trace ->
   req_meta_data:comm_meta_data a ->
   Lemma
@@ -81,7 +65,9 @@ val get_response_label_later:
   (ensures
     get_response_label tr1 req_meta_data == get_response_label tr2 req_meta_data
   )
-  [SMTPat (get_response_label tr1 req_meta_data); SMTPat (tr1 <$ tr2)]
+  [SMTPat (get_response_label tr1 req_meta_data);
+   SMTPat (tr1 <$ tr2);
+  ]
 let get_response_label_later #a tr1 tr2 req_meta_data =
   reveal_opaque (`%get_response_label) get_response_label;
   get_label_later #default_crypto_usages tr1 tr2 req_meta_data.key;
@@ -95,7 +81,7 @@ val is_comm_response_payload:
 let is_comm_response_payload #cusg #a #ps tr server req_meta_data payload =
   is_well_formed a (is_knowable_by (get_response_label tr req_meta_data) tr) payload
 
-val comm_meta_data_knowable: 
+val comm_meta_data_knowable:
   {|crypto_invariants|} ->
   trace ->
   a:Type -> {|comm_layer_reqres_config a|} ->
@@ -254,7 +240,7 @@ let receive_request_proof #invs #a #config tr comm_keys_ids higher_layer_preds s
 
     let i = find_event_triggered_at_timestamp tr_recv server (CommConfReceiveMsg server req_msg_t <: communication_core_event comm_message_t #(comm_layer_tag_core_config_reqres a)) in
     conf_message_secrecy tr_recv i (comm_core_higher_layer_event_preds_reqres a) server req_msg_t;
-    
+
     // Properties that can be proved uniformly in both the honest and corrupt case
     eliminate (exists client. event_triggered tr_recv client (req_send_event client)) \/
               (is_publishable tr_recv req_msg.request /\ is_publishable tr_recv req_msg.key)
@@ -268,9 +254,7 @@ let receive_request_proof #invs #a #config tr comm_keys_ids higher_layer_preds s
         get_response_label_knowable_reverse tr_recv req_meta_data request;
 
         let i = find_event_triggered_at_timestamp tr_recv client (req_send_event client) in
-        // Triggers event_triggered_at_implies_pred
-        assert(event_predicate_communication_layer_reqres higher_layer_preds (prefix tr_recv i) client (req_send_event client));
-        assert(event_triggered_at tr_recv i client (req_send_event client))
+        ()
       )
     and _. (has_usage_publishable tr_recv req_msg.key (AeadKey (comm_layer_aead_tag a) empty);
       parse_wf_lemma a (is_publishable tr_recv) req_msg.request;
@@ -288,8 +272,6 @@ let receive_request_proof #invs #a #config tr comm_keys_ids higher_layer_preds s
     assert((state_predicate_communication_layer_reqres a).pred tr_sess server sid' (ServerReceiveRequest {request; key=req_msg.key} <: communication_states a));
     let ((), tr_st) = set_state server sid' (ServerReceiveRequest {request; key=req_msg.key} <: communication_states a) tr_sess in
 
-    get_response_label_publishable tr_recv req_meta_data request;
-    
     assert(tr_out == tr_st);
     assert(trace_invariant tr_out);
     ()
@@ -315,7 +297,7 @@ val mk_comm_layer_response_nonce_proof:
     | (Some nonce, tr_out) -> (
       trace_invariant tr_out /\
       is_knowable_by (get_response_label tr_out req_meta_data) tr_out nonce /\
-      get_label tr_out nonce `can_flow tr_out` get_label tr_out req_meta_data.key
+      is_knowable_by (get_label tr_out req_meta_data.key) tr_out nonce
     )
   ))
 let mk_comm_layer_response_nonce_proof #invs #a tr req_meta_data usg =
@@ -341,7 +323,8 @@ val mk_comm_layer_response_nonce_labeled_proof:
     | (Some nonce, tr_out) -> (
       trace_invariant tr_out /\
       is_knowable_by (get_response_label tr_out req_meta_data) tr_out nonce /\
-      get_label tr_out nonce `can_flow tr_out` get_label tr_out req_meta_data.key
+      is_knowable_by (get_label tr_out req_meta_data.key) tr_out nonce /\
+      is_knowable_by prin tr_out nonce
     )
   ))
 let mk_comm_layer_response_nonce_labeled_proof #invs #a tr req_meta_data usg prin =

--- a/src/lib/communication/DY.Lib.Communication.RequestResponse.Lemmas.fst
+++ b/src/lib/communication/DY.Lib.Communication.RequestResponse.Lemmas.fst
@@ -64,6 +64,31 @@ val enable_reqres_comm_layer_lemmas:
 let enable_reqres_comm_layer_lemmas preds =
   normalize_term_spec (reqres_comm_layer_lemmas_enabled preds)
 
+
+#push-options "--ifuel 2"
+val initialize_communication_reqres_proof:
+  {|invs:protocol_invariants|} ->
+  tr:trace ->
+  a:Type -> {|comm_layer_reqres_config a|} ->
+  sender:principal -> receiver:principal ->
+  Lemma
+  (requires
+    trace_invariant tr /\
+    has_private_keys_invariant /\
+    has_pki_invariant
+  )
+  (ensures (
+    let (_, tr_out) = initialize_communication_reqres a sender receiver tr in
+    trace_invariant tr_out
+  ))
+  [SMTPat (trace_invariant #invs tr);
+   SMTPat (initialize_communication_reqres a sender receiver tr);
+  ]
+let initialize_communication_reqres_proof tr a sender receiver =
+  reveal_opaque (`%initialize_communication_reqres) (initialize_communication_reqres a sender receiver)
+#pop-options
+
+
 val send_request_proof:
   {|protocol_invariants|} ->
   #a:Type0 -> {|comm_layer_reqres_config a|} ->
@@ -75,9 +100,9 @@ val send_request_proof:
   (requires
     trace_invariant tr /\
     has_pki_invariant /\
-    has_communication_layer_crypto_predicates comm_message_t /\
+    has_communication_layer_reqres_crypto_predicates a /\
     has_communication_layer_reqres_event_predicates higher_layer_preds /\
-    has_communication_layer_state_predicates a /\
+    has_communication_layer_reqres_state_predicates a /\
     higher_layer_preds.send_request tr client server request (comm_label client server) /\
     is_well_formed a (is_knowable_by (comm_label client server) tr) request
   )
@@ -94,7 +119,7 @@ val send_request_proof:
   SMTPat (send_request comm_keys_ids client server request tr)]
 let send_request_proof #invs #a tr comm_keys_ids higher_layer_preds client server request =
   reveal_opaque (`%send_request) (send_request #a);
-  enable_core_comm_layer_lemmas (request_response_event_preconditions a);
+  enable_core_comm_layer_lemmas (comm_core_higher_layer_event_preds_reqres a);
   let request_bytes = serialize a request in
   match send_request comm_keys_ids client server request tr with
   | (None, tr_out) -> (
@@ -112,7 +137,7 @@ let send_request_proof #invs #a tr comm_keys_ids higher_layer_preds client serve
     let ((), tr') = trigger_event client (CommClientSendRequest client server request key <: communication_reqres_event a) tr' in
     assert(trace_invariant tr');
     let req_payload:comm_message_t = RequestMessage {request=request_bytes; key} in
-    let (Some msg_id, tr') = send_confidential comm_keys_ids client server req_payload tr' in
+    let (Some msg_id, tr') = send_confidential #comm_message_t #(comm_layer_tag_core_config_reqres a) comm_keys_ids client server req_payload tr' in
 
     assert(tr_out == tr');
     assert(trace_invariant tr_out);
@@ -135,7 +160,7 @@ val receive_request_proof:
     has_pki_invariant /\
     has_communication_layer_reqres_crypto_predicates a /\
     has_communication_layer_reqres_event_predicates higher_layer_preds /\
-    has_communication_layer_state_predicates a
+    has_communication_layer_reqres_state_predicates a
   )
   (ensures (
     match receive_request #a comm_keys_ids server msg_id tr with
@@ -151,22 +176,22 @@ val receive_request_proof:
   [SMTPat (trace_invariant tr);
   SMTPat (reqres_comm_layer_lemmas_enabled higher_layer_preds);
   SMTPat (receive_request #a comm_keys_ids server msg_id tr)]
-let receive_request_proof #invs #a tr comm_keys_ids higher_layer_preds server msg_id =
+let receive_request_proof #invs #a #config tr comm_keys_ids higher_layer_preds server msg_id =
   reveal_opaque (`%receive_request) (receive_request #a);
-  enable_core_comm_layer_lemmas (request_response_event_preconditions a);
+  enable_core_comm_layer_lemmas (comm_core_higher_layer_event_preds_reqres a);
   match receive_request #a comm_keys_ids server msg_id tr with
   | (None, tr_out) -> ()
   | (Some (payload, req_meta_data), tr_out) -> (
-    receive_confidential_proof tr (request_response_event_preconditions a) comm_keys_ids server msg_id;
-    let (Some req_msg_t, tr') = receive_confidential comm_keys_ids server msg_id tr in
+    receive_confidential_proof #invs #comm_message_t #(comm_layer_tag_core_config_reqres a) tr (comm_core_higher_layer_event_preds_reqres a) comm_keys_ids server msg_id;
+    let (Some req_msg_t, tr') = receive_confidential #comm_message_t #(comm_layer_tag_core_config_reqres a) comm_keys_ids server msg_id tr in
     let RequestMessage req_msg = req_msg_t in
     let Some request = parse a req_msg.request in
 
     let req_msg_bytes:bytes = serialize comm_message_t req_msg_t in
     let req_send_event client:communication_reqres_event a = CommClientSendRequest client server request req_msg.key in
 
-    let i = find_event_triggered_at_timestamp tr' server (CommConfReceiveMsg server req_msg_t <: communication_core_event comm_message_t) in
-    conf_message_secrecy tr' i (request_response_event_preconditions a) server req_msg_t;
+    let i = find_event_triggered_at_timestamp tr' server (CommConfReceiveMsg server req_msg_t <: communication_core_event comm_message_t #(comm_layer_tag_core_config_reqres a)) in
+    conf_message_secrecy tr' i (comm_core_higher_layer_event_preds_reqres a) server req_msg_t;
 
     // Properties that can be proved uniformly in both the honest and corrupt case
     eliminate (exists client. event_triggered tr' client (req_send_event client)) \/
@@ -209,7 +234,7 @@ val mk_comm_layer_response_nonce_proof:
   Lemma
   (requires
     trace_invariant tr /\
-    has_communication_layer_state_predicates a /\
+    has_communication_layer_reqres_state_predicates a /\
     has_communication_layer_reqres_crypto_predicates a /\
     bytes_well_formed tr req_meta_data.key
   )
@@ -267,7 +292,7 @@ val send_response_proof:
     has_communication_layer_reqres_crypto_predicates a /\
     has_communication_layer_reqres_event_predicates higher_layer_preds /\
     higher_layer_preds.send_response tr server req_meta_data.request response /\
-    has_communication_layer_state_predicates a /\
+    has_communication_layer_reqres_state_predicates a /\
     is_well_formed a (is_knowable_by (get_response_label tr req_meta_data) tr) response
   )
   (ensures (
@@ -345,7 +370,7 @@ val receive_response_proof:
     trace_invariant tr /\
     has_communication_layer_reqres_crypto_predicates a /\
     has_communication_layer_reqres_event_predicates higher_layer_preds /\
-    has_communication_layer_state_predicates a
+    has_communication_layer_reqres_state_predicates a
   )
   (ensures (
     match receive_response client req_meta_data msg_id tr with

--- a/src/lib/communication/DY.Lib.Communication.RequestResponse.Lemmas.fst
+++ b/src/lib/communication/DY.Lib.Communication.RequestResponse.Lemmas.fst
@@ -100,9 +100,7 @@ val send_request_proof:
   (requires
     trace_invariant tr /\
     has_pki_invariant /\
-    has_communication_layer_reqres_crypto_predicates a /\
-    has_communication_layer_reqres_event_predicates higher_layer_preds /\
-    has_communication_layer_reqres_state_predicates a /\
+    has_communication_layer_reqres_predicates higher_layer_preds /\
     higher_layer_preds.send_request tr client server request (comm_label client server) /\
     is_well_formed a (is_knowable_by (comm_label client server) tr) request
   )
@@ -158,9 +156,7 @@ val receive_request_proof:
     trace_invariant tr /\
     has_private_keys_invariant /\
     has_pki_invariant /\
-    has_communication_layer_reqres_crypto_predicates a /\
-    has_communication_layer_reqres_event_predicates higher_layer_preds /\
-    has_communication_layer_reqres_state_predicates a
+    has_communication_layer_reqres_predicates higher_layer_preds
   )
   (ensures (
     match receive_request #a comm_keys_ids server msg_id tr with
@@ -234,7 +230,7 @@ val mk_comm_layer_response_nonce_proof:
   Lemma
   (requires
     trace_invariant tr /\
-    has_communication_layer_reqres_state_predicates a /\
+    has_communication_layer_reqres_state_predicate a /\
     has_communication_layer_reqres_crypto_predicates a /\
     bytes_well_formed tr req_meta_data.key
   )
@@ -289,10 +285,8 @@ val send_response_proof:
   Lemma
   (requires
     trace_invariant tr /\
-    has_communication_layer_reqres_crypto_predicates a /\
-    has_communication_layer_reqres_event_predicates higher_layer_preds /\
+    has_communication_layer_reqres_predicates higher_layer_preds /\
     higher_layer_preds.send_response tr server req_meta_data.request response /\
-    has_communication_layer_reqres_state_predicates a /\
     is_well_formed a (is_knowable_by (get_response_label tr req_meta_data) tr) response
   )
   (ensures (
@@ -368,9 +362,7 @@ val receive_response_proof:
   Lemma
   (requires
     trace_invariant tr /\
-    has_communication_layer_reqres_crypto_predicates a /\
-    has_communication_layer_reqres_event_predicates higher_layer_preds /\
-    has_communication_layer_reqres_state_predicates a
+    has_communication_layer_reqres_predicates higher_layer_preds
   )
   (ensures (
     match receive_response client req_meta_data msg_id tr with

--- a/src/lib/communication/DY.Lib.Communication.RequestResponse.Properties.fst
+++ b/src/lib/communication/DY.Lib.Communication.RequestResponse.Properties.fst
@@ -20,6 +20,7 @@ open DY.Lib.Communication.RequestResponse.Invariants
 (*** Authentication Security Properties ***)
 
 val server_authentication:
+  {|comm_layer_event_reqres_tag|} ->
   {|protocol_invariants|} ->
   #a:Type -> {| parseable_serializeable bytes a |} ->
   tr:trace -> i:timestamp ->
@@ -36,7 +37,7 @@ val server_authentication:
     is_corrupt (prefix tr i) (principal_label client) \/
     is_corrupt (prefix tr i) (principal_label server)
   )
-let server_authentication #invs #a tr i higher_layer_resreq_preds client server response key = ()
+let server_authentication #event_tag #invs #a tr i higher_layer_resreq_preds client server response key = ()
 
 
 (*** Secrecy Security Property ***)

--- a/src/lib/communication/DY.Lib.Communication.RequestResponse.Properties.fst
+++ b/src/lib/communication/DY.Lib.Communication.RequestResponse.Properties.fst
@@ -20,7 +20,7 @@ open DY.Lib.Communication.RequestResponse.Invariants
 (*** Authentication Security Properties ***)
 
 val server_authentication:
-  {|comm_layer_event_reqres_tag|} ->
+  {|comm_layer_reqres_tag|} ->
   {|protocol_invariants|} ->
   #a:Type -> {| parseable_serializeable bytes a |} ->
   tr:trace -> i:timestamp ->
@@ -37,12 +37,13 @@ val server_authentication:
     is_corrupt (prefix tr i) (principal_label client) \/
     is_corrupt (prefix tr i) (principal_label server)
   )
-let server_authentication #event_tag #invs #a tr i higher_layer_resreq_preds client server response key = ()
+let server_authentication #tag #invs #a tr i higher_layer_resreq_preds client server response key = ()
 
 
 (*** Secrecy Security Property ***)
 
 val key_secrecy_client:
+  {|comm_layer_reqres_tag|} ->
   {|protocol_invariants|} ->
   tr:trace ->
   client:principal -> server:principal ->
@@ -60,6 +61,6 @@ val key_secrecy_client:
   (ensures
     is_corrupt tr (principal_label client) \/ is_corrupt tr (principal_label server)
   )
-let key_secrecy_client tr client server key request response =
+let key_secrecy_client #tag #invs tr client server key request response =
   attacker_only_knows_publishable_values tr key;
   ()

--- a/src/lib/communication/DY.Lib.Communication.RequestResponse.Properties.fst
+++ b/src/lib/communication/DY.Lib.Communication.RequestResponse.Properties.fst
@@ -45,17 +45,18 @@ let server_authentication #tag #invs #a tr i higher_layer_resreq_preds client se
 val key_secrecy_client:
   {|comm_layer_reqres_tag|} ->
   {|protocol_invariants|} ->
+  #a:Type -> {|comparse_parser_serializer a|} ->
   tr:trace ->
   client:principal -> server:principal ->
-  key:bytes -> request:bytes -> response:bytes ->
+  key:bytes -> request:a -> response:a ->
   Lemma
   (requires
     trace_invariant tr /\
-    has_communication_layer_state_predicates /\
+    has_communication_layer_state_predicates a /\
     attacker_knows tr key /\
     (
-      (exists sid. state_was_set tr client sid (ClientSendRequest {server; request; key})) \/
-      (exists sid. state_was_set tr client sid (ClientReceiveResponse {server; response; key}))
+      (exists sid. state_was_set #(communication_states a) #(local_state_communication_layer_session a) tr client sid (ClientSendRequest {server; request; key} <: communication_states a)) \/
+      (exists sid. state_was_set #(communication_states a) #(local_state_communication_layer_session a) tr client sid (ClientReceiveResponse {server; response; key} <: communication_states a))
     )
   )
   (ensures

--- a/src/lib/communication/DY.Lib.Communication.RequestResponse.Properties.fst
+++ b/src/lib/communication/DY.Lib.Communication.RequestResponse.Properties.fst
@@ -20,20 +20,19 @@ open DY.Lib.Communication.RequestResponse.Invariants
 (*** Authentication Security Properties ***)
 
 val server_authentication:
-  {|comm_layer_reqres_tag|} ->
   {|protocol_invariants|} ->
-  #a:Type -> {| parseable_serializeable bytes a |} ->
+  #a:Type -> {| comm_layer_reqres_config a |} ->
   tr:trace -> i:timestamp ->
   higher_layer_resreq_preds:comm_reqres_higher_layer_event_preds a ->
-  client:principal -> server:principal -> response:bytes -> key:bytes ->
+  client:principal -> server:principal -> response:a -> key:bytes ->
   Lemma
   (requires
     trace_invariant tr /\
-    has_communication_layer_reqres_event_predicates request_response_event_preconditions higher_layer_resreq_preds /\
-    event_triggered_at tr i client (CommClientReceiveResponse client server  response key)
+    has_communication_layer_reqres_event_predicates higher_layer_resreq_preds /\
+    event_triggered_at tr i client (CommClientReceiveResponse client server  response key <: communication_reqres_event a)
   )
   (ensures
-    (exists request. event_triggered (prefix tr i) server (CommServerSendResponse server request response)) \/
+    (exists request. event_triggered (prefix tr i) server (CommServerSendResponse server request response <: communication_reqres_event a)) \/
     is_corrupt (prefix tr i) (principal_label client) \/
     is_corrupt (prefix tr i) (principal_label server)
   )
@@ -43,9 +42,8 @@ let server_authentication #tag #invs #a tr i higher_layer_resreq_preds client se
 (*** Secrecy Security Property ***)
 
 val key_secrecy_client:
-  {|comm_layer_reqres_tag|} ->
   {|protocol_invariants|} ->
-  #a:Type -> {|comparse_parser_serializer a|} ->
+  #a:Type -> {|comm_layer_reqres_config a|} ->
   tr:trace ->
   client:principal -> server:principal ->
   key:bytes -> request:a -> response:a ->

--- a/src/lib/communication/DY.Lib.Communication.RequestResponse.Properties.fst
+++ b/src/lib/communication/DY.Lib.Communication.RequestResponse.Properties.fst
@@ -9,6 +9,7 @@ open DY.Lib.State.PKI
 open DY.Lib.State.PrivateKeys
 open DY.Lib.State.Typed
 
+open DY.Lib.Communication.Data
 open DY.Lib.Communication.RequestResponse
 open DY.Lib.Communication.RequestResponse.Invariants
 
@@ -50,11 +51,11 @@ val key_secrecy_client:
   Lemma
   (requires
     trace_invariant tr /\
-    has_communication_layer_reqres_state_predicates a /\
+    has_communication_layer_reqres_state_predicate a /\
     attacker_knows tr key /\
     (
-      (exists sid. state_was_set #(communication_states a) #(local_state_communication_layer_session a) tr client sid (ClientSendRequest {server; request; key} <: communication_states a)) \/
-      (exists sid. state_was_set #(communication_states a) #(local_state_communication_layer_session a) tr client sid (ClientReceiveResponse {server; response; key} <: communication_states a))
+      (exists sid. state_was_set tr client sid (ClientSendRequest {server; request; key} <: communication_states a)) \/
+      (exists sid. state_was_set tr client sid (ClientReceiveResponse {server; response; key} <: communication_states a))
     )
   )
   (ensures

--- a/src/lib/communication/DY.Lib.Communication.RequestResponse.Properties.fst
+++ b/src/lib/communication/DY.Lib.Communication.RequestResponse.Properties.fst
@@ -50,7 +50,7 @@ val key_secrecy_client:
   Lemma
   (requires
     trace_invariant tr /\
-    has_communication_layer_state_predicates a /\
+    has_communication_layer_reqres_state_predicates a /\
     attacker_knows tr key /\
     (
       (exists sid. state_was_set #(communication_states a) #(local_state_communication_layer_session a) tr client sid (ClientSendRequest {server; request; key} <: communication_states a)) \/

--- a/src/lib/communication/DY.Lib.Communication.RequestResponse.fst
+++ b/src/lib/communication/DY.Lib.Communication.RequestResponse.fst
@@ -74,27 +74,23 @@ type communication_reqres_event =
 %splice [ps_communication_reqres_event_is_well_formed] (gen_is_well_formed_lemma (`communication_reqres_event))
 #pop-options
 
-class comm_layer_event_reqres_tag = {
+class comm_layer_reqres_tag = {
   tag: string;
 }
 
-instance default_comm_layer_event_reqres_tag: comm_layer_event_reqres_tag = {
-  tag = "DY.Lib.Communication.Event.RequestResponse"
-}
-
-instance event_communication_reqres_event {|t:comm_layer_event_reqres_tag|}: event communication_reqres_event = {
+instance event_communication_reqres_event {|t:comm_layer_reqres_tag|}: event communication_reqres_event = {
   tag = t.tag;
   format = mk_parseable_serializeable ps_communication_reqres_event;
 }
 
-instance comm_layer_event_tag_core_reqres: comm_layer_event_core_tag = {
+instance comm_layer_tag_core_reqres: comm_layer_core_tag = {
   tag = "DY.Lib.Communication.Event.RequestResponse.Core"
 }
 
 (*** Layer Setup ***)
 
-val comm_layer_aead_tag: string
-let comm_layer_aead_tag = "DY.Lib.Communication.Aead.Key"
+val comm_layer_aead_tag: {|comm_layer_reqres_tag|} -> string
+let comm_layer_aead_tag #tag = tag.tag ^ ".Aead.Key"
 
 [@@with_bytes bytes]
 type comm_meta_data = {
@@ -112,12 +108,12 @@ type comm_meta_data = {
 
 [@@ "opaque_to_smt"]
 val send_request:
-  {|comm_layer_event_reqres_tag|} ->
+  {|comm_layer_reqres_tag|} ->
   #a:Type -> {| parseable_serializeable bytes a |} ->
   communication_keys_sess_ids ->
   principal -> principal -> a ->
   traceful (option (timestamp & comm_meta_data))
-let send_request #event_tag #a comm_keys_ids client server request =
+let send_request #tag #a comm_keys_ids client server request =
   let* key = mk_rand (AeadKey comm_layer_aead_tag empty) (comm_label client server) 32 in
   let payload_bytes = serialize #bytes a request in
   let* sid = new_session_id client in
@@ -130,12 +126,12 @@ let send_request #event_tag #a comm_keys_ids client server request =
 
 [@@ "opaque_to_smt"]
 val receive_request:
-  {|comm_layer_event_reqres_tag|} ->
+  {|comm_layer_reqres_tag|} ->
   #a:Type -> {| parseable_serializeable bytes a |} ->
   communication_keys_sess_ids ->
   principal -> timestamp ->
   traceful (option (a & comm_meta_data))
-let receive_request #event_tag #a comm_keys_ids server msg_id =
+let receive_request #tag #a comm_keys_ids server msg_id =
   let*? req_msg_t:com_message_t = receive_confidential comm_keys_ids server msg_id in
   guard_tr (RequestMessage? req_msg_t);*?
   let RequestMessage req_msg = req_msg_t in
@@ -174,10 +170,10 @@ let compute_response_message #a server key nonce response =
 
 [@@ "opaque_to_smt"]
 val send_response:
-  {|comm_layer_event_reqres_tag|} ->
+  {|comm_layer_reqres_tag|} ->
   #a:Type -> {| parseable_serializeable bytes a |} ->
   principal -> comm_meta_data -> a -> traceful (option timestamp)
-let send_response #event_tag #a server req_meta_data response =
+let send_response #tag #a server req_meta_data response =
   let*? state = get_state server req_meta_data.sid in
   guard_tr (ServerReceiveRequest? state);*?
   let ServerReceiveRequest srr = state in
@@ -191,10 +187,10 @@ let send_response #event_tag #a server req_meta_data response =
 
 [@@ "opaque_to_smt"]
 val decode_response_message:
-  {|comm_layer_event_reqres_tag|} ->
+  {|comm_layer_reqres_tag|} ->
   #a:Type -> {| parseable_serializeable bytes a |} ->
   principal -> bytes -> bytes -> option a
-let decode_response_message #event_tag #a server key msg_bytes =
+let decode_response_message #tag #a server key msg_bytes =
   let? resp_env_t:com_message_t = parse com_message_t msg_bytes in
   guard (ResponseMessage? resp_env_t);?
   let ResponseMessage resp_env = resp_env_t in
@@ -206,11 +202,11 @@ let decode_response_message #event_tag #a server key msg_bytes =
 
 [@@ "opaque_to_smt"]
 val receive_response:
-  {|comm_layer_event_reqres_tag|} ->
+  {|comm_layer_reqres_tag|} ->
   #a:Type -> {| parseable_serializeable bytes a |} ->
   principal -> comm_meta_data -> timestamp ->
   traceful (option (a & comm_meta_data))
-let receive_response #event_tag #a client req_meta_data msg_id =
+let receive_response #tag #a client req_meta_data msg_id =
   let*? state = get_state client req_meta_data.sid in
   guard_tr (ClientSendRequest? state);*?
   let ClientSendRequest csr = state in

--- a/src/lib/communication/DY.Lib.Communication.RequestResponse.fst
+++ b/src/lib/communication/DY.Lib.Communication.RequestResponse.fst
@@ -6,18 +6,53 @@ open DY.Lib.State.PKI
 open DY.Lib.State.PrivateKeys
 open DY.Lib.Event.Typed
 open DY.Lib.State.Typed
+open DY.Lib.Comparse.Glue
 
 open DY.Lib.Communication.Data
 open DY.Lib.Communication.Core
 
 #set-options "--fuel 0 --ifuel 0 --z3cliopt 'smt.qi.eager_threshold=100'"
 
+(*** Layer Setup ***)
+
+class comparse_parser_serializer (a:Type) = {
+  ps_a: parser_serializer bytes a;
+  ps_able: parseable_serializeable bytes a;
+  [@@@FStar.Tactics.Typeclasses.no_method]
+  eq_property: squash (ps_able == mk_parseable_serializeable ps_a);
+}
+
+class comm_layer_reqres_tag = {
+  tag: string;
+}
+
+instance comm_layer_tag_core_reqres: comm_layer_core_tag = {
+  tag = "DY.Lib.Communication.Event.RequestResponse.Core"
+}
+
+val comm_layer_aead_tag: {|comm_layer_reqres_tag|} -> string
+let comm_layer_aead_tag #tag = tag.tag ^ ".Aead.Key"
+
+[@@with_bytes bytes]
+type comm_meta_data (a:Type) {|ps:comparse_parser_serializer a|} = {
+  key:bytes;
+  server:principal;
+  sid:state_id;
+  [@@@ with_parser #bytes ps.ps_a]
+  request:a;
+}
+
+%splice [ps_comm_meta_data] (gen_parser (`comm_meta_data))
+%splice [ps_comm_meta_data_is_well_formed] (gen_is_well_formed_lemma (`comm_meta_data))
+
+
 (*** States ***)
 
 [@@with_bytes bytes]
-type client_send_request = {
+type client_send_request (a:Type) {|ps:comparse_parser_serializer a|} = {
   server:principal;
-  request:bytes;
+  [@@@ with_parser #bytes ps.ps_a]
+  request:a;
   key:bytes
 }
 
@@ -25,8 +60,9 @@ type client_send_request = {
 %splice [ps_client_send_request_is_well_formed] (gen_is_well_formed_lemma (`client_send_request))
 
 [@@with_bytes bytes]
-type server_receive_request = {
-  request:bytes;
+type server_receive_request (a:Type) {|ps:comparse_parser_serializer a|} = {
+  [@@@ with_parser #bytes ps.ps_a]
+  request:a;
   key:bytes
 }
 
@@ -34,9 +70,10 @@ type server_receive_request = {
 %splice [ps_server_receive_request_is_well_formed] (gen_is_well_formed_lemma (`server_receive_request))
 
 [@@with_bytes bytes]
-type client_receive_response = {
+type client_receive_response (a:Type) {|ps:comparse_parser_serializer a|} = {
   server:principal;
-  response:bytes;
+  [@@@ with_parser #bytes ps.ps_a]
+  response:a;
   key:bytes
 }
 
@@ -44,22 +81,22 @@ type client_receive_response = {
 %splice [ps_client_receive_response_is_well_formed] (gen_is_well_formed_lemma (`client_receive_response))
 
 [@@with_bytes bytes]
-type communication_states =
-  | ClientSendRequest: client_send_request -> communication_states
-  | ServerReceiveRequest: server_receive_request -> communication_states
-  | ClientReceiveResponse: client_receive_response -> communication_states
+type communication_states (a:Type) {|ps:comparse_parser_serializer a|} =
+  | ClientSendRequest: client_send_request a -> communication_states a
+  | ServerReceiveRequest: server_receive_request a -> communication_states a
+  | ClientReceiveResponse: client_receive_response a -> communication_states a
 
 #push-options "--ifuel 1"
 %splice [ps_communication_states] (gen_parser (`communication_states))
 %splice [ps_communication_states_is_well_formed] (gen_is_well_formed_lemma (`communication_states))
 #pop-options
 
-instance parseable_serializeable_bytes_communication_states: parseable_serializeable bytes communication_states
-  = mk_parseable_serializeable ps_communication_states
+instance parseable_serializeable_bytes_communication_states (a:Type) {|comparse_parser_serializer a|}: parseable_serializeable bytes (communication_states a)
+  = mk_parseable_serializeable (ps_communication_states a)
 
-instance local_state_communication_layer_session: local_state communication_states = {
-  tag = "DY.Lib.Communication.State.RequestResponse";
-  format = parseable_serializeable_bytes_communication_states;
+instance local_state_communication_layer_session {|t:comm_layer_reqres_tag|} (a:Type) {|comparse_parser_serializer a|}: local_state (communication_states a) = {
+  tag = t.tag ^ ".State";
+  format = parseable_serializeable_bytes_communication_states a;
 }
 
 [@@with_bytes bytes]
@@ -74,34 +111,10 @@ type communication_reqres_event =
 %splice [ps_communication_reqres_event_is_well_formed] (gen_is_well_formed_lemma (`communication_reqres_event))
 #pop-options
 
-class comm_layer_reqres_tag = {
-  tag: string;
-}
-
 instance event_communication_reqres_event {|t:comm_layer_reqres_tag|}: event communication_reqres_event = {
-  tag = t.tag;
+  tag = t.tag ^ ".Event";
   format = mk_parseable_serializeable ps_communication_reqres_event;
 }
-
-instance comm_layer_tag_core_reqres: comm_layer_core_tag = {
-  tag = "DY.Lib.Communication.Event.RequestResponse.Core"
-}
-
-(*** Layer Setup ***)
-
-val comm_layer_aead_tag: {|comm_layer_reqres_tag|} -> string
-let comm_layer_aead_tag #tag = tag.tag ^ ".Aead.Key"
-
-[@@with_bytes bytes]
-type comm_meta_data = {
-  key:bytes;
-  server:principal;
-  sid:state_id;
-  request:bytes;
-}
-
-%splice [ps_comm_meta_data] (gen_parser (`comm_meta_data))
-%splice [ps_comm_meta_data_is_well_formed] (gen_is_well_formed_lemma (`comm_meta_data))
 
 
 (*** API ***)
@@ -109,49 +122,49 @@ type comm_meta_data = {
 [@@ "opaque_to_smt"]
 val send_request:
   {|comm_layer_reqres_tag|} ->
-  #a:Type -> {| parseable_serializeable bytes a |} ->
+  #a:Type -> {|comparse_parser_serializer a|} ->
   communication_keys_sess_ids ->
   principal -> principal -> a ->
-  traceful (option (timestamp & comm_meta_data))
-let send_request #tag #a comm_keys_ids client server request =
+  traceful (option (timestamp & comm_meta_data a))
+let send_request #tag #a #ps comm_keys_ids client server request =
   let* key = mk_rand (AeadKey comm_layer_aead_tag empty) (comm_label client server) 32 in
-  let payload_bytes = serialize #bytes a request in
+  let payload_bytes:bytes = serialize a #ps_able request in
   let* sid = new_session_id client in
-  set_state client sid (ClientSendRequest {server; request=payload_bytes; key} <: communication_states);*
+  set_state client sid (ClientSendRequest {server; request; key} <: communication_states a);*
   trigger_event client (CommClientSendRequest client server payload_bytes key);*
   let req_payload:com_message_t = RequestMessage {request=payload_bytes; key} in
   let*? msg_id = send_confidential comm_keys_ids client server req_payload in
-  let req_meta_data = {key; server; sid; request=payload_bytes} in
+  let req_meta_data:comm_meta_data a = {key; server; sid; request} in
   return (Some (msg_id, req_meta_data))
 
 [@@ "opaque_to_smt"]
 val receive_request:
   {|comm_layer_reqres_tag|} ->
-  #a:Type -> {| parseable_serializeable bytes a |} ->
+  #a:Type -> {|comparse_parser_serializer a|} ->
   communication_keys_sess_ids ->
   principal -> timestamp ->
-  traceful (option (a & comm_meta_data))
-let receive_request #tag #a comm_keys_ids server msg_id =
+  traceful (option (a & comm_meta_data a))
+let receive_request #tag #a #ps comm_keys_ids server msg_id =
   let*? req_msg_t:com_message_t = receive_confidential comm_keys_ids server msg_id in
   guard_tr (RequestMessage? req_msg_t);*?
   let RequestMessage req_msg = req_msg_t in
-  let*? request = return (parse a req_msg.request) in
+  let*? request = return (parse a #ps_able req_msg.request) in
   trigger_event server (CommServerReceiveRequest server req_msg.request req_msg.key);*
   let* sid = new_session_id server in
-  set_state server sid (ServerReceiveRequest {request=req_msg.request; key=req_msg.key} <: communication_states);*
-  let req_meta_data = {key=req_msg.key; server; sid; request=req_msg.request} in
+  set_state server sid (ServerReceiveRequest {request; key=req_msg.key} <: communication_states a);*
+  let req_meta_data:comm_meta_data a = {key=req_msg.key; server; sid; request} in
   return (Some (request, req_meta_data))
 
 [@@ "opaque_to_smt"]
-val mk_comm_layer_response_nonce: comm_meta_data -> usage -> traceful (option bytes)
-let mk_comm_layer_response_nonce req_meta_data usg =
+val mk_comm_layer_response_nonce: #a:Type -> {|comparse_parser_serializer a|} -> comm_meta_data a -> usage -> traceful (option bytes)
+let mk_comm_layer_response_nonce #a #ps_a req_meta_data usg =
   let* tr = get_trace in
   let* nonce = mk_rand usg (get_label #default_crypto_usages tr req_meta_data.key) 32 in
   return (Some nonce)
 
 [@@ "opaque_to_smt"]
-val mk_comm_layer_response_nonce_labeled: comm_meta_data -> usage -> label -> traceful (option bytes)
-let mk_comm_layer_response_nonce_labeled req_meta_data usg lab =
+val mk_comm_layer_response_nonce_labeled: #a:Type -> {|comparse_parser_serializer a|} -> comm_meta_data a -> usage -> label -> traceful (option bytes)
+let mk_comm_layer_response_nonce_labeled #a #ps_a req_meta_data usg lab =
   let* tr = get_trace in
   let lab_join = join lab (get_label #default_crypto_usages tr req_meta_data.key) in
   let* nonce = mk_rand usg lab_join 32 in
@@ -159,10 +172,10 @@ let mk_comm_layer_response_nonce_labeled req_meta_data usg lab =
 
 [@@ "opaque_to_smt"]
 val compute_response_message:
-  #a:Type -> {| parseable_serializeable bytes a |} ->
+  #a:Type -> {|comparse_parser_serializer a|} ->
   principal -> bytes -> bytes -> a -> bytes
-let compute_response_message #a server key nonce response =
-  let res_bytes = serialize a response in
+let compute_response_message #a #ps server key nonce response =
+  let res_bytes = serialize a #ps_able response in
   let ad:authenticated_data = {server} in
   let ad_bytes = serialize authenticated_data ad in
   let ciphertext = aead_enc key nonce res_bytes ad_bytes in
@@ -171,15 +184,15 @@ let compute_response_message #a server key nonce response =
 [@@ "opaque_to_smt"]
 val send_response:
   {|comm_layer_reqres_tag|} ->
-  #a:Type -> {| parseable_serializeable bytes a |} ->
-  principal -> comm_meta_data -> a -> traceful (option timestamp)
-let send_response #tag #a server req_meta_data response =
+  #a:eqtype -> {|comparse_parser_serializer a|} ->
+  principal -> comm_meta_data a -> a -> traceful (option timestamp)
+let send_response #tag #a #ps server req_meta_data response =
   let*? state = get_state server req_meta_data.sid in
   guard_tr (ServerReceiveRequest? state);*?
   let ServerReceiveRequest srr = state in
   guard_tr (srr.key = req_meta_data.key);*?
   guard_tr (srr.request = req_meta_data.request);*?
-  trigger_event server (CommServerSendResponse server srr.request (serialize a response));*
+  trigger_event server (CommServerSendResponse server (serialize a #ps_able srr.request) (serialize a #ps_able response));*
   let* nonce = mk_rand NoUsage public 32 in
   let resp_msg = compute_response_message server req_meta_data.key nonce response in
   let* msg_id = send_msg resp_msg in
@@ -188,32 +201,32 @@ let send_response #tag #a server req_meta_data response =
 [@@ "opaque_to_smt"]
 val decode_response_message:
   {|comm_layer_reqres_tag|} ->
-  #a:Type -> {| parseable_serializeable bytes a |} ->
+  #a:Type -> {|comparse_parser_serializer a|} ->
   principal -> bytes -> bytes -> option a
-let decode_response_message #tag #a server key msg_bytes =
+let decode_response_message #tag #a #ps server key msg_bytes =
   let? resp_env_t:com_message_t = parse com_message_t msg_bytes in
   guard (ResponseMessage? resp_env_t);?
   let ResponseMessage resp_env = resp_env_t in
   let ad:authenticated_data = {server} in
   let ad_bytes = serialize authenticated_data ad in
   let? resp_bytes = aead_dec key resp_env.nonce resp_env.ciphertext ad_bytes in
-  let? resp = parse a resp_bytes in
+  let? resp = parse a #ps_able resp_bytes in
   Some resp
 
 [@@ "opaque_to_smt"]
 val receive_response:
   {|comm_layer_reqres_tag|} ->
-  #a:Type -> {| parseable_serializeable bytes a |} ->
-  principal -> comm_meta_data -> timestamp ->
-  traceful (option (a & comm_meta_data))
-let receive_response #tag #a client req_meta_data msg_id =
-  let*? state = get_state client req_meta_data.sid in
+  #a:Type -> {|comparse_parser_serializer a|} ->
+  principal -> comm_meta_data a -> timestamp ->
+  traceful (option (a & comm_meta_data a))
+let receive_response #tag #a #ps client req_meta_data msg_id =
+  let*? state:communication_states a = get_state client req_meta_data.sid in
   guard_tr (ClientSendRequest? state);*?
   let ClientSendRequest csr = state in
   let*? resp_msg_bytes = recv_msg msg_id in
   let*? payload = return (decode_response_message csr.server csr.key resp_msg_bytes) in
   guard_tr (csr.server = req_meta_data.server);*?
   guard_tr (csr.key = req_meta_data.key);*?
-  set_state client req_meta_data.sid (ClientReceiveResponse {server=csr.server; response=(serialize a payload); key=csr.key} <: communication_states);*
-  trigger_event client (CommClientReceiveResponse client csr.server (serialize a payload) csr.key);*
+  set_state client req_meta_data.sid (ClientReceiveResponse {server=csr.server; response=payload; key=csr.key} <: communication_states a);*
+  trigger_event client (CommClientReceiveResponse client csr.server (serialize a #ps_able payload) csr.key);*
   return (Some (payload, req_meta_data))

--- a/src/lib/communication/DY.Lib.Communication.RequestResponse.fst
+++ b/src/lib/communication/DY.Lib.Communication.RequestResponse.fst
@@ -20,11 +20,11 @@ class comm_layer_reqres_config (a:Type) = {
   ps_a: parser_serializer bytes a;
 }
 
-instance parseable_serializeable_bytes_a (#a:Type) {|c:comm_layer_reqres_config a|}: parseable_serializeable bytes a =
-  mk_parseable_serializeable c.ps_a
+instance parseable_serializeable_bytes_a (#a:Type) {|config:comm_layer_reqres_config a|}: parseable_serializeable bytes a =
+  mk_parseable_serializeable config.ps_a
 
-instance comm_layer_tag_core_config_reqres: comm_layer_core_config comm_message_t = {
-  tag = "DY.Lib.Communication.CoreConfig.ReqRes";
+instance comm_layer_tag_core_config_reqres (a:Type) {|config:comm_layer_reqres_config a|}: comm_layer_core_config comm_message_t = {
+  tag = config.tag ^ ".CoreConfig.ReqRes";
   ps_a = ps_comm_message_t;
 }
 
@@ -109,8 +109,8 @@ type communication_reqres_event (a:Type) {|c:comm_layer_reqres_config a|} =
 %splice [ps_communication_reqres_event_is_well_formed] (gen_is_well_formed_lemma (`communication_reqres_event))
 #pop-options
 
-instance event_communication_reqres_event (#a:Type) {|c:comm_layer_reqres_config a|}: event (communication_reqres_event a) = {
-  tag = c.tag ^ ".Event";
+instance event_communication_reqres_event (#a:Type) {|config:comm_layer_reqres_config a|}: event (communication_reqres_event a) = {
+  tag = config.tag ^ ".Event";
   format = mk_parseable_serializeable (ps_communication_reqres_event a);
 }
 
@@ -119,18 +119,18 @@ instance event_communication_reqres_event (#a:Type) {|c:comm_layer_reqres_config
 
 [@@ "opaque_to_smt"]
 val send_request:
-  #a:Type -> {|comm_layer_reqres_config a|} ->
+  #a:Type0 -> {|comm_layer_reqres_config a|} ->
   communication_keys_sess_ids ->
   principal -> principal -> a ->
   traceful (option (timestamp & comm_meta_data a))
-let send_request #a comm_keys_ids client server request =
+let send_request #a #config comm_keys_ids client server request =
   let* key = mk_rand (AeadKey (comm_layer_aead_tag a) empty) (comm_label client server) 32 in
   let payload_bytes:bytes = serialize a request in
   let* sid = new_session_id client in
   set_state client sid (ClientSendRequest {server; request; key} <: communication_states a);*
   trigger_event client (CommClientSendRequest client server request key <: communication_reqres_event a);*
   let req_payload:comm_message_t = RequestMessage {request=payload_bytes; key} in
-  let*? msg_id = send_confidential comm_keys_ids client server req_payload in
+  let*? msg_id = send_confidential #comm_message_t #(comm_layer_tag_core_config_reqres a) comm_keys_ids client server req_payload in
   let req_meta_data:comm_meta_data a = {key; server; sid; request} in
   return (Some (msg_id, req_meta_data))
 
@@ -141,7 +141,7 @@ val receive_request:
   principal -> timestamp ->
   traceful (option (a & comm_meta_data a))
 let receive_request #a comm_keys_ids server msg_id =
-  let*? req_msg_t:comm_message_t = receive_confidential comm_keys_ids server msg_id in
+  let*? req_msg_t:comm_message_t = receive_confidential #comm_message_t #(comm_layer_tag_core_config_reqres a) comm_keys_ids server msg_id in
   guard_tr (RequestMessage? req_msg_t);*?
   let RequestMessage req_msg = req_msg_t in
   let*? request = return (parse a req_msg.request) in
@@ -223,3 +223,10 @@ let receive_response #a client req_meta_data msg_id =
   set_state client req_meta_data.sid (ClientReceiveResponse {server=csr.server; response=payload; key=csr.key} <: communication_states a);*
   trigger_event client (CommClientReceiveResponse client csr.server payload csr.key <: communication_reqres_event a);*
   return (Some (payload, req_meta_data))
+
+
+(**** Layer Initialization ****)
+
+[@@ "opaque_to_smt"]
+val initialize_communication_reqres: a:Type -> {|comm_layer_reqres_config a|} -> principal -> principal -> traceful (option (communication_keys_sess_ids & communication_keys_sess_ids))
+let initialize_communication_reqres a client server = initialize_communication_core comm_message_t #(comm_layer_tag_core_config_reqres a) client server

--- a/src/lib/communication/DY.Lib.Communication.RequestResponse.fst
+++ b/src/lib/communication/DY.Lib.Communication.RequestResponse.fst
@@ -15,30 +15,28 @@ open DY.Lib.Communication.Core
 
 (*** Layer Setup ***)
 
-class comparse_parser_serializer (a:Type) = {
-  ps_a: parser_serializer bytes a;
-  ps_able: parseable_serializeable bytes a;
-  [@@@FStar.Tactics.Typeclasses.no_method]
-  eq_property: squash (ps_able == mk_parseable_serializeable ps_a);
-}
-
-class comm_layer_reqres_tag = {
+class comm_layer_reqres_config (a:Type) = {
   tag: string;
+  ps_a: parser_serializer bytes a;
 }
 
-instance comm_layer_tag_core_reqres: comm_layer_core_tag = {
-  tag = "DY.Lib.Communication.Event.RequestResponse.Core"
+instance parseable_serializeable_bytes_a (#a:Type) {|c:comm_layer_reqres_config a|}: parseable_serializeable bytes a =
+  mk_parseable_serializeable c.ps_a
+
+instance comm_layer_tag_core_config_reqres: comm_layer_core_config comm_message_t = {
+  tag = "DY.Lib.Communication.CoreConfig.ReqRes";
+  ps_a = ps_comm_message_t;
 }
 
-val comm_layer_aead_tag: {|comm_layer_reqres_tag|} -> string
-let comm_layer_aead_tag #tag = tag.tag ^ ".Aead.Key"
+val comm_layer_aead_tag: a:Type -> {|comm_layer_reqres_config a|} -> string
+let comm_layer_aead_tag a #config = config.tag ^ ".Aead.Key"
 
 [@@with_bytes bytes]
-type comm_meta_data (a:Type) {|ps:comparse_parser_serializer a|} = {
+type comm_meta_data (a:Type) {|c:comm_layer_reqres_config a|} = {
   key:bytes;
   server:principal;
   sid:state_id;
-  [@@@ with_parser #bytes ps.ps_a]
+  [@@@ with_parser #bytes c.ps_a]
   request:a;
 }
 
@@ -49,9 +47,9 @@ type comm_meta_data (a:Type) {|ps:comparse_parser_serializer a|} = {
 (*** States ***)
 
 [@@with_bytes bytes]
-type client_send_request (a:Type) {|ps:comparse_parser_serializer a|} = {
+type client_send_request (a:Type) {|c:comm_layer_reqres_config a|}  = {
   server:principal;
-  [@@@ with_parser #bytes ps.ps_a]
+  [@@@ with_parser #bytes c.ps_a]
   request:a;
   key:bytes
 }
@@ -60,8 +58,8 @@ type client_send_request (a:Type) {|ps:comparse_parser_serializer a|} = {
 %splice [ps_client_send_request_is_well_formed] (gen_is_well_formed_lemma (`client_send_request))
 
 [@@with_bytes bytes]
-type server_receive_request (a:Type) {|ps:comparse_parser_serializer a|} = {
-  [@@@ with_parser #bytes ps.ps_a]
+type server_receive_request (a:Type) {|c:comm_layer_reqres_config a|}  = {
+  [@@@ with_parser #bytes c.ps_a]
   request:a;
   key:bytes
 }
@@ -70,9 +68,9 @@ type server_receive_request (a:Type) {|ps:comparse_parser_serializer a|} = {
 %splice [ps_server_receive_request_is_well_formed] (gen_is_well_formed_lemma (`server_receive_request))
 
 [@@with_bytes bytes]
-type client_receive_response (a:Type) {|ps:comparse_parser_serializer a|} = {
+type client_receive_response (a:Type) {|c:comm_layer_reqres_config a|}  = {
   server:principal;
-  [@@@ with_parser #bytes ps.ps_a]
+  [@@@ with_parser #bytes c.ps_a]
   response:a;
   key:bytes
 }
@@ -81,7 +79,7 @@ type client_receive_response (a:Type) {|ps:comparse_parser_serializer a|} = {
 %splice [ps_client_receive_response_is_well_formed] (gen_is_well_formed_lemma (`client_receive_response))
 
 [@@with_bytes bytes]
-type communication_states (a:Type) {|ps:comparse_parser_serializer a|} =
+type communication_states (a:Type) {|c:comm_layer_reqres_config a|}  =
   | ClientSendRequest: client_send_request a -> communication_states a
   | ServerReceiveRequest: server_receive_request a -> communication_states a
   | ClientReceiveResponse: client_receive_response a -> communication_states a
@@ -91,29 +89,29 @@ type communication_states (a:Type) {|ps:comparse_parser_serializer a|} =
 %splice [ps_communication_states_is_well_formed] (gen_is_well_formed_lemma (`communication_states))
 #pop-options
 
-instance parseable_serializeable_bytes_communication_states (a:Type) {|comparse_parser_serializer a|}: parseable_serializeable bytes (communication_states a)
+instance parseable_serializeable_bytes_communication_states (a:Type) {|c:comm_layer_reqres_config a|}: parseable_serializeable bytes (communication_states a)
   = mk_parseable_serializeable (ps_communication_states a)
 
-instance local_state_communication_layer_session {|t:comm_layer_reqres_tag|} (a:Type) {|comparse_parser_serializer a|}: local_state (communication_states a) = {
-  tag = t.tag ^ ".State";
+instance local_state_communication_layer_session (a:Type) {|c:comm_layer_reqres_config a|}: local_state (communication_states a) = {
+  tag = c.tag ^ ".State";
   format = parseable_serializeable_bytes_communication_states a;
 }
 
 [@@with_bytes bytes]
-type communication_reqres_event =
-  | CommClientSendRequest: client:principal -> server:principal -> request:bytes -> key:bytes -> communication_reqres_event
-  | CommServerReceiveRequest: server:principal -> request:bytes -> key:bytes -> communication_reqres_event
-  | CommServerSendResponse: server:principal -> request:bytes -> response:bytes -> communication_reqres_event
-  | CommClientReceiveResponse: client:principal -> server:principal -> response:bytes -> key:bytes -> communication_reqres_event
+type communication_reqres_event (a:Type) {|c:comm_layer_reqres_config a|} =
+  | CommClientSendRequest: client:principal -> server:principal -> [@@@ with_parser #bytes c.ps_a] request:a -> key:bytes -> communication_reqres_event a
+  | CommServerReceiveRequest: server:principal -> [@@@ with_parser #bytes c.ps_a] request:a -> key:bytes -> communication_reqres_event a
+  | CommServerSendResponse: server:principal -> [@@@ with_parser #bytes c.ps_a] request:a -> [@@@ with_parser #bytes c.ps_a] response:a -> communication_reqres_event a
+  | CommClientReceiveResponse: client:principal -> server:principal -> [@@@ with_parser #bytes c.ps_a] response:a -> key:bytes -> communication_reqres_event a
 
 #push-options "--ifuel 1"
 %splice [ps_communication_reqres_event] (gen_parser (`communication_reqres_event))
 %splice [ps_communication_reqres_event_is_well_formed] (gen_is_well_formed_lemma (`communication_reqres_event))
 #pop-options
 
-instance event_communication_reqres_event {|t:comm_layer_reqres_tag|}: event communication_reqres_event = {
-  tag = t.tag ^ ".Event";
-  format = mk_parseable_serializeable ps_communication_reqres_event;
+instance event_communication_reqres_event (#a:Type) {|c:comm_layer_reqres_config a|}: event (communication_reqres_event a) = {
+  tag = c.tag ^ ".Event";
+  format = mk_parseable_serializeable (ps_communication_reqres_event a);
 }
 
 
@@ -121,50 +119,48 @@ instance event_communication_reqres_event {|t:comm_layer_reqres_tag|}: event com
 
 [@@ "opaque_to_smt"]
 val send_request:
-  {|comm_layer_reqres_tag|} ->
-  #a:Type -> {|comparse_parser_serializer a|} ->
+  #a:Type -> {|comm_layer_reqres_config a|} ->
   communication_keys_sess_ids ->
   principal -> principal -> a ->
   traceful (option (timestamp & comm_meta_data a))
-let send_request #tag #a #ps comm_keys_ids client server request =
-  let* key = mk_rand (AeadKey comm_layer_aead_tag empty) (comm_label client server) 32 in
-  let payload_bytes:bytes = serialize a #ps_able request in
+let send_request #a comm_keys_ids client server request =
+  let* key = mk_rand (AeadKey (comm_layer_aead_tag a) empty) (comm_label client server) 32 in
+  let payload_bytes:bytes = serialize a request in
   let* sid = new_session_id client in
   set_state client sid (ClientSendRequest {server; request; key} <: communication_states a);*
-  trigger_event client (CommClientSendRequest client server payload_bytes key);*
-  let req_payload:com_message_t = RequestMessage {request=payload_bytes; key} in
+  trigger_event client (CommClientSendRequest client server request key <: communication_reqres_event a);*
+  let req_payload:comm_message_t = RequestMessage {request=payload_bytes; key} in
   let*? msg_id = send_confidential comm_keys_ids client server req_payload in
   let req_meta_data:comm_meta_data a = {key; server; sid; request} in
   return (Some (msg_id, req_meta_data))
 
 [@@ "opaque_to_smt"]
 val receive_request:
-  {|comm_layer_reqres_tag|} ->
-  #a:Type -> {|comparse_parser_serializer a|} ->
+  #a:Type -> {|comm_layer_reqres_config a|} ->
   communication_keys_sess_ids ->
   principal -> timestamp ->
   traceful (option (a & comm_meta_data a))
-let receive_request #tag #a #ps comm_keys_ids server msg_id =
-  let*? req_msg_t:com_message_t = receive_confidential comm_keys_ids server msg_id in
+let receive_request #a comm_keys_ids server msg_id =
+  let*? req_msg_t:comm_message_t = receive_confidential comm_keys_ids server msg_id in
   guard_tr (RequestMessage? req_msg_t);*?
   let RequestMessage req_msg = req_msg_t in
-  let*? request = return (parse a #ps_able req_msg.request) in
-  trigger_event server (CommServerReceiveRequest server req_msg.request req_msg.key);*
+  let*? request = return (parse a req_msg.request) in
+  trigger_event server (CommServerReceiveRequest server request req_msg.key <: communication_reqres_event a);*
   let* sid = new_session_id server in
   set_state server sid (ServerReceiveRequest {request; key=req_msg.key} <: communication_states a);*
   let req_meta_data:comm_meta_data a = {key=req_msg.key; server; sid; request} in
   return (Some (request, req_meta_data))
 
 [@@ "opaque_to_smt"]
-val mk_comm_layer_response_nonce: #a:Type -> {|comparse_parser_serializer a|} -> comm_meta_data a -> usage -> traceful (option bytes)
-let mk_comm_layer_response_nonce #a #ps_a req_meta_data usg =
+val mk_comm_layer_response_nonce: #a:Type -> {|comm_layer_reqres_config a|} -> comm_meta_data a -> usage -> traceful (option bytes)
+let mk_comm_layer_response_nonce #a req_meta_data usg =
   let* tr = get_trace in
   let* nonce = mk_rand usg (get_label #default_crypto_usages tr req_meta_data.key) 32 in
   return (Some nonce)
 
 [@@ "opaque_to_smt"]
-val mk_comm_layer_response_nonce_labeled: #a:Type -> {|comparse_parser_serializer a|} -> comm_meta_data a -> usage -> label -> traceful (option bytes)
-let mk_comm_layer_response_nonce_labeled #a #ps_a req_meta_data usg lab =
+val mk_comm_layer_response_nonce_labeled: #a:Type -> {|comm_layer_reqres_config a|} -> comm_meta_data a -> usage -> label -> traceful (option bytes)
+let mk_comm_layer_response_nonce_labeled #a req_meta_data usg lab =
   let* tr = get_trace in
   let lab_join = join lab (get_label #default_crypto_usages tr req_meta_data.key) in
   let* nonce = mk_rand usg lab_join 32 in
@@ -172,27 +168,26 @@ let mk_comm_layer_response_nonce_labeled #a #ps_a req_meta_data usg lab =
 
 [@@ "opaque_to_smt"]
 val compute_response_message:
-  #a:Type -> {|comparse_parser_serializer a|} ->
+  #a:Type -> {|comm_layer_reqres_config a|} ->
   principal -> bytes -> bytes -> a -> bytes
-let compute_response_message #a #ps server key nonce response =
-  let res_bytes = serialize a #ps_able response in
+let compute_response_message #a server key nonce response =
+  let res_bytes = serialize a response in
   let ad:authenticated_data = {server} in
   let ad_bytes = serialize authenticated_data ad in
   let ciphertext = aead_enc key nonce res_bytes ad_bytes in
-  serialize com_message_t (ResponseMessage {nonce; ciphertext})
+  serialize comm_message_t (ResponseMessage {nonce; ciphertext})
 
 [@@ "opaque_to_smt"]
 val send_response:
-  {|comm_layer_reqres_tag|} ->
-  #a:eqtype -> {|comparse_parser_serializer a|} ->
+  #a:eqtype -> {|comm_layer_reqres_config a|} ->
   principal -> comm_meta_data a -> a -> traceful (option timestamp)
-let send_response #tag #a #ps server req_meta_data response =
+let send_response #a server req_meta_data response =
   let*? state = get_state server req_meta_data.sid in
   guard_tr (ServerReceiveRequest? state);*?
   let ServerReceiveRequest srr = state in
   guard_tr (srr.key = req_meta_data.key);*?
   guard_tr (srr.request = req_meta_data.request);*?
-  trigger_event server (CommServerSendResponse server (serialize a #ps_able srr.request) (serialize a #ps_able response));*
+  trigger_event server (CommServerSendResponse server srr.request response <: communication_reqres_event a);*
   let* nonce = mk_rand NoUsage public 32 in
   let resp_msg = compute_response_message server req_meta_data.key nonce response in
   let* msg_id = send_msg resp_msg in
@@ -200,26 +195,24 @@ let send_response #tag #a #ps server req_meta_data response =
 
 [@@ "opaque_to_smt"]
 val decode_response_message:
-  {|comm_layer_reqres_tag|} ->
-  #a:Type -> {|comparse_parser_serializer a|} ->
+  #a:Type -> {|comm_layer_reqres_config a|} ->
   principal -> bytes -> bytes -> option a
-let decode_response_message #tag #a #ps server key msg_bytes =
-  let? resp_env_t:com_message_t = parse com_message_t msg_bytes in
+let decode_response_message #a server key msg_bytes =
+  let? resp_env_t:comm_message_t = parse comm_message_t msg_bytes in
   guard (ResponseMessage? resp_env_t);?
   let ResponseMessage resp_env = resp_env_t in
   let ad:authenticated_data = {server} in
   let ad_bytes = serialize authenticated_data ad in
   let? resp_bytes = aead_dec key resp_env.nonce resp_env.ciphertext ad_bytes in
-  let? resp = parse a #ps_able resp_bytes in
+  let? resp = parse a resp_bytes in
   Some resp
 
 [@@ "opaque_to_smt"]
 val receive_response:
-  {|comm_layer_reqres_tag|} ->
-  #a:Type -> {|comparse_parser_serializer a|} ->
+  #a:Type -> {|comm_layer_reqres_config a|} ->
   principal -> comm_meta_data a -> timestamp ->
   traceful (option (a & comm_meta_data a))
-let receive_response #tag #a #ps client req_meta_data msg_id =
+let receive_response #a client req_meta_data msg_id =
   let*? state:communication_states a = get_state client req_meta_data.sid in
   guard_tr (ClientSendRequest? state);*?
   let ClientSendRequest csr = state in
@@ -228,5 +221,5 @@ let receive_response #tag #a #ps client req_meta_data msg_id =
   guard_tr (csr.server = req_meta_data.server);*?
   guard_tr (csr.key = req_meta_data.key);*?
   set_state client req_meta_data.sid (ClientReceiveResponse {server=csr.server; response=payload; key=csr.key} <: communication_states a);*
-  trigger_event client (CommClientReceiveResponse client csr.server (serialize a #ps_able payload) csr.key);*
+  trigger_event client (CommClientReceiveResponse client csr.server payload csr.key <: communication_reqres_event a);*
   return (Some (payload, req_meta_data))

--- a/src/lib/communication/DY.Lib.Communication.RequestResponse.fst
+++ b/src/lib/communication/DY.Lib.Communication.RequestResponse.fst
@@ -35,6 +35,10 @@ type comm_meta_data (a:Type) {|config:comm_layer_reqres_config a|} = {
 %splice [ps_comm_meta_data] (gen_parser (`comm_meta_data))
 %splice [ps_comm_meta_data_is_well_formed] (gen_is_well_formed_lemma (`comm_meta_data))
 
+[@@"opaque_to_smt"]
+val get_response_label: tr:trace -> #a:Type0 -> {|comm_layer_reqres_config a|} -> comm_meta_data a -> label
+let get_response_label tr #a #ps req_meta_data = get_label #default_crypto_usages tr req_meta_data.key
+
 
 (*** States ***)
 
@@ -147,26 +151,26 @@ let receive_request #a comm_keys_ids server msg_id =
 val mk_comm_layer_response_nonce: #a:Type -> {|comm_layer_reqres_config a|} -> comm_meta_data a -> usage -> traceful (option bytes)
 let mk_comm_layer_response_nonce #a req_meta_data usg =
   let* tr = get_trace in
-  let* nonce = mk_rand usg (get_label #default_crypto_usages tr req_meta_data.key) 32 in
+  let* nonce = mk_rand usg (get_response_label tr req_meta_data) 32 in
   return (Some nonce)
 
 [@@ "opaque_to_smt"]
 val mk_comm_layer_response_nonce_labeled: #a:Type -> {|comm_layer_reqres_config a|} -> comm_meta_data a -> usage -> label -> traceful (option bytes)
 let mk_comm_layer_response_nonce_labeled #a req_meta_data usg lab =
   let* tr = get_trace in
-  let lab_join = join lab (get_label #default_crypto_usages tr req_meta_data.key) in
+  let lab_join = join lab (get_response_label tr req_meta_data) in
   let* nonce = mk_rand usg lab_join 32 in
   return (Some nonce)
 
 [@@ "opaque_to_smt"]
 val compute_response_message:
   #a:Type -> {|comm_layer_reqres_config a|} ->
-  principal -> bytes -> bytes -> a -> bytes
-let compute_response_message #a server key nonce response =
+  principal -> comm_meta_data a -> bytes -> a -> bytes
+let compute_response_message #a server req_meta_data nonce response =
   let res_bytes = serialize a response in
   let ad:authenticated_data = {server} in
   let ad_bytes = serialize authenticated_data ad in
-  let ciphertext = aead_enc key nonce res_bytes ad_bytes in
+  let ciphertext = aead_enc req_meta_data.key nonce res_bytes ad_bytes in
   serialize comm_message_t (ResponseMessage {nonce; ciphertext})
 
 [@@ "opaque_to_smt"]
@@ -181,7 +185,7 @@ let send_response #a server req_meta_data response =
   guard_tr (srr.request = req_meta_data.request);*?
   trigger_event server (CommServerSendResponse server srr.request response <: communication_reqres_event a);*
   let* nonce = mk_rand NoUsage public 32 in
-  let resp_msg = compute_response_message server req_meta_data.key nonce response in
+  let resp_msg = compute_response_message server req_meta_data nonce response in
   let* msg_id = send_msg resp_msg in
   return (Some msg_id)
 

--- a/src/lib/communication/DY.Lib.Communication.RequestResponse.fst
+++ b/src/lib/communication/DY.Lib.Communication.RequestResponse.fst
@@ -15,28 +15,20 @@ open DY.Lib.Communication.Core
 
 (*** Layer Setup ***)
 
-class comm_layer_reqres_config (a:Type) = {
-  tag: string;
-  ps_a: parser_serializer bytes a;
-}
-
-instance parseable_serializeable_bytes_a (#a:Type) {|config:comm_layer_reqres_config a|}: parseable_serializeable bytes a =
-  mk_parseable_serializeable config.ps_a
-
 instance comm_layer_tag_core_config_reqres (a:Type) {|config:comm_layer_reqres_config a|}: comm_layer_core_config comm_message_t = {
-  tag = config.tag ^ ".CoreConfig.ReqRes";
-  ps_a = ps_comm_message_t;
+  core_tag = config.reqres_tag ^ ".CoreConfig.ReqRes";
+  core_ps_a = ps_comm_message_t;
 }
 
 val comm_layer_aead_tag: a:Type -> {|comm_layer_reqres_config a|} -> string
-let comm_layer_aead_tag a #config = config.tag ^ ".Aead.Key"
+let comm_layer_aead_tag a #config = config.reqres_tag ^ ".Aead.Key"
 
 [@@with_bytes bytes]
-type comm_meta_data (a:Type) {|c:comm_layer_reqres_config a|} = {
+type comm_meta_data (a:Type) {|config:comm_layer_reqres_config a|} = {
   key:bytes;
   server:principal;
   sid:state_id;
-  [@@@ with_parser #bytes c.ps_a]
+  [@@@ with_parser #bytes config.reqres_ps_a]
   request:a;
 }
 
@@ -47,9 +39,9 @@ type comm_meta_data (a:Type) {|c:comm_layer_reqres_config a|} = {
 (*** States ***)
 
 [@@with_bytes bytes]
-type client_send_request (a:Type) {|c:comm_layer_reqres_config a|}  = {
+type client_send_request (a:Type) {|config:comm_layer_reqres_config a|}  = {
   server:principal;
-  [@@@ with_parser #bytes c.ps_a]
+  [@@@ with_parser #bytes config.reqres_ps_a]
   request:a;
   key:bytes
 }
@@ -58,8 +50,8 @@ type client_send_request (a:Type) {|c:comm_layer_reqres_config a|}  = {
 %splice [ps_client_send_request_is_well_formed] (gen_is_well_formed_lemma (`client_send_request))
 
 [@@with_bytes bytes]
-type server_receive_request (a:Type) {|c:comm_layer_reqres_config a|}  = {
-  [@@@ with_parser #bytes c.ps_a]
+type server_receive_request (a:Type) {|config:comm_layer_reqres_config a|}  = {
+  [@@@ with_parser #bytes config.reqres_ps_a]
   request:a;
   key:bytes
 }
@@ -68,9 +60,9 @@ type server_receive_request (a:Type) {|c:comm_layer_reqres_config a|}  = {
 %splice [ps_server_receive_request_is_well_formed] (gen_is_well_formed_lemma (`server_receive_request))
 
 [@@with_bytes bytes]
-type client_receive_response (a:Type) {|c:comm_layer_reqres_config a|}  = {
+type client_receive_response (a:Type) {|config:comm_layer_reqres_config a|}  = {
   server:principal;
-  [@@@ with_parser #bytes c.ps_a]
+  [@@@ with_parser #bytes config.reqres_ps_a]
   response:a;
   key:bytes
 }
@@ -89,20 +81,20 @@ type communication_states (a:Type) {|c:comm_layer_reqres_config a|}  =
 %splice [ps_communication_states_is_well_formed] (gen_is_well_formed_lemma (`communication_states))
 #pop-options
 
-instance parseable_serializeable_bytes_communication_states (a:Type) {|c:comm_layer_reqres_config a|}: parseable_serializeable bytes (communication_states a)
+instance parseable_serializeable_bytes_communication_states (a:Type) {|comm_layer_reqres_config a|}: parseable_serializeable bytes (communication_states a)
   = mk_parseable_serializeable (ps_communication_states a)
 
-instance local_state_communication_layer_session (a:Type) {|c:comm_layer_reqres_config a|}: local_state (communication_states a) = {
-  tag = c.tag ^ ".State";
+instance local_state_communication_layer_session (a:Type) {|config:comm_layer_reqres_config a|}: local_state (communication_states a) = {
+  tag = config.reqres_tag ^ ".State";
   format = parseable_serializeable_bytes_communication_states a;
 }
 
 [@@with_bytes bytes]
-type communication_reqres_event (a:Type) {|c:comm_layer_reqres_config a|} =
-  | CommClientSendRequest: client:principal -> server:principal -> [@@@ with_parser #bytes c.ps_a] request:a -> key:bytes -> communication_reqres_event a
-  | CommServerReceiveRequest: server:principal -> [@@@ with_parser #bytes c.ps_a] request:a -> key:bytes -> communication_reqres_event a
-  | CommServerSendResponse: server:principal -> [@@@ with_parser #bytes c.ps_a] request:a -> [@@@ with_parser #bytes c.ps_a] response:a -> communication_reqres_event a
-  | CommClientReceiveResponse: client:principal -> server:principal -> [@@@ with_parser #bytes c.ps_a] response:a -> key:bytes -> communication_reqres_event a
+type communication_reqres_event (a:Type) {|config:comm_layer_reqres_config a|} =
+  | CommClientSendRequest: client:principal -> server:principal -> [@@@ with_parser #bytes config.reqres_ps_a] request:a -> key:bytes -> communication_reqres_event a
+  | CommServerReceiveRequest: server:principal -> [@@@ with_parser #bytes config.reqres_ps_a] request:a -> key:bytes -> communication_reqres_event a
+  | CommServerSendResponse: server:principal -> [@@@ with_parser #bytes config.reqres_ps_a] request:a -> [@@@ with_parser #bytes config.reqres_ps_a] response:a -> communication_reqres_event a
+  | CommClientReceiveResponse: client:principal -> server:principal -> [@@@ with_parser #bytes config.reqres_ps_a] response:a -> key:bytes -> communication_reqres_event a
 
 #push-options "--ifuel 1"
 %splice [ps_communication_reqres_event] (gen_parser (`communication_reqres_event))
@@ -110,7 +102,7 @@ type communication_reqres_event (a:Type) {|c:comm_layer_reqres_config a|} =
 #pop-options
 
 instance event_communication_reqres_event (#a:Type) {|config:comm_layer_reqres_config a|}: event (communication_reqres_event a) = {
-  tag = config.tag ^ ".Event";
+  tag = config.reqres_tag ^ ".Event";
   format = mk_parseable_serializeable (ps_communication_reqres_event a);
 }
 


### PR DESCRIPTION
This PR allows users of the communication layer to specify which tag should be used for the events. This makes the usage of the comm layer more flexible in higher layers because every layer can use its custom tag for the comm layer events and thereby also use different ``higher_layer_event_preds``.