### PR TITLE
chore: update F*

### DIFF
--- a/.fst.config.json
+++ b/.fst.config.json
@@ -1,5 +1,12 @@
 { "fstar_exe":"fstar.exe",
-  "options":["--cache_dir", "cache", "--hint_dir", "hints", "--use_hints", "--record_hints"],
+  "options":[
+    "--cache_dir",
+    "cache",
+    "--hint_dir", "hints",
+    "--use_hints",
+    "--record_hints",
+    "--z3version", "4.8.5"
+  ],
   "include_dirs":[
     "${COMPARSE_HOME}/src",
     "src/core",

--- a/.fst.config.json
+++ b/.fst.config.json
@@ -1,7 +1,6 @@
 { "fstar_exe":"fstar.exe",
   "options":[
-    "--cache_dir",
-    "cache",
+    "--cache_dir", "cache",
     "--hint_dir", "hints",
     "--use_hints",
     "--record_hints",

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ FSTAR_EXTRACT = --extract '-* +DY +Comparse'
 # - (Warning 242) Definitions of inner let-rec ... and its enclosing top-level letbinding are not encoded to the solver, you will only be able to reason with their types
 # - (Warning 335) Interface ... is admitted without an implementation 
 
-FSTAR_FLAGS = $(FSTAR_INCLUDE_DIRS) --cache_checked_modules --already_cached '+Prims +FStar' --warn_error '@0..1000' --warn_error '+242-335' --record_hints --hint_dir $(DY_HOME)/hints --cache_dir $(DY_HOME)/cache --odir $(DY_HOME)/obj --cmi
+FSTAR_FLAGS = $(FSTAR_INCLUDE_DIRS) --cache_checked_modules --already_cached '+Prims +FStar' --warn_error '@0..1000' --warn_error '+242-335' --record_hints --hint_dir $(DY_HOME)/hints --cache_dir $(DY_HOME)/cache --odir $(DY_HOME)/obj --cmi --z3version 4.8.5
 
 .PHONY: all clean
 

--- a/default.nix
+++ b/default.nix
@@ -8,6 +8,7 @@ let
         "Makefile"
         "src(/.*)?"
         "examples(/[^/]*)?"
+        "test(/[^/]*)?"
       ]
     ;
     enableParallelBuilding = true;
@@ -27,6 +28,7 @@ let
         "Makefile"
         "src(/.*)?"
         "examples(/.*)?"
+        "test(/.*)?"
       ]
     ;
     enableParallelBuilding = true;

--- a/flake.lock
+++ b/flake.lock
@@ -46,11 +46,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1748199801,
-        "narHash": "sha256-clP79o0NsSjoNi59GxHxfN8lfc+5BPQyWnriYceyoHg=",
+        "lastModified": 1756679367,
+        "narHash": "sha256-0l3aIn1NzL7GcvyBZVrY+ml9OBBnxzbmpV3syx+1JUY=",
         "owner": "FStarLang",
         "repo": "FStar",
-        "rev": "ff868e03ee0d16303c514ae396706ba283b328a3",
+        "rev": "afa650706d68233d3284144edb68c781ed76769c",
         "type": "github"
       },
       "original": {
@@ -61,11 +61,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1743588408,
-        "narHash": "sha256-WRZyK13yucGjwNBMOGjU8ljRJ8FYFv8MBru/bXqZUn0=",
+        "lastModified": 1751011381,
+        "narHash": "sha256-krGXKxvkBhnrSC/kGBmg5MyupUUT5R6IBCLEzx9jhMM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "88efe689298b1863db0310c0a22b3ebb4d04fbc3",
+        "rev": "30e2e2857ba47844aa71991daa6ed1fc678bcbb7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
F* nows defaults to Z3 4.13.3 which breaks DY*. Fixing proofs that broke due to this change is non-trivial, in the meantime this PR passes a flag to F* to stick to Z3 4.8.5.

Furthermore this PR fixes some source filtering happening on the nix side of things, where it would not see the "test" directory. Weirdly, this passed as a warning in the build on the main branch, but now gives an error (an arguably a better behavior).