### PR TITLE
feat: add three LLM-synthesized benchmarks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ COMPARSE_HOME 	?= $(DY_HOME)/../comparse
 
 INNER_SOURCE_DIRS = core lib lib/comparse lib/crypto lib/event lib/hpke lib/label lib/state lib/utils lib/communication
 SOURCE_DIRS = $(addprefix $(DY_HOME)/src/, $(INNER_SOURCE_DIRS))
-INNER_EXAMPLE_DIRS = nsl_pk iso_dh
+INNER_EXAMPLE_DIRS = nsl_pk iso_dh BAN_CCITT_X509_3 andrew_rpc ccitt_x509_1c
 EXAMPLE_DIRS ?= $(addprefix $(DY_HOME)/examples/, $(INNER_EXAMPLE_DIRS))
 INNER_TEST_DIRS = core
 TEST_DIRS = $(addprefix $(DY_HOME)/test/, $(INNER_TEST_DIRS))

--- a/examples/BAN_CCITT_X509_3/DY.Example.BAN_CCITT_X509_3.Debug.Proof.fst
+++ b/examples/BAN_CCITT_X509_3/DY.Example.BAN_CCITT_X509_3.Debug.Proof.fst
@@ -1,0 +1,83 @@
+module DY.Example.BAN_CCITT_X509_3.Debug.Proof
+
+open Comparse
+open DY.Core
+open DY.Lib
+open DY.Lib.Comparse.Parsers
+open DY.Example.BAN_CCITT_X509_3.Protocol.Total
+open DY.Example.BAN_CCITT_X509_3.Protocol.Total.Proof
+open DY.Example.BAN_CCITT_X509_3.Protocol.Stateful
+open DY.Example.BAN_CCITT_X509_3.Protocol.Stateful.Proof
+open DY.Example.BAN_CCITT_X509_3.Debug
+
+#set-options "--fuel 1 --ifuel 1 --z3rlimit 1000 --split_queries always --z3cliopt 'smt.qi.eager_threshold=100'"
+
+val debug_proof:
+  tr:trace ->
+  Lemma
+  (requires
+    trace_invariant tr /\
+    has_pki_invariant /\
+    has_private_keys_invariant
+  )
+  (ensures (let (_, tr_out) = debug () tr in trace_invariant tr_out))
+let debug_proof tr =
+  let alice = "alice" in
+  let bob = "bob" in
+
+  let (alice_priv_sid, tr) = initialize_private_keys alice tr in
+  let (_, tr) = generate_private_key alice alice_priv_sid (LongTermSigKey "BAN_CCITT.SigKey") tr in
+  let (_, tr) = generate_private_key alice alice_priv_sid (LongTermPkeKey "BAN_CCITT.PkeKey") tr in
+  let (alice_pki_sid, tr) = initialize_pki alice tr in
+
+  let (bob_priv_sid, tr) = initialize_private_keys bob tr in
+  let (_, tr) = generate_private_key bob bob_priv_sid (LongTermSigKey "BAN_CCITT.SigKey") tr in
+  let (_, tr) = generate_private_key bob bob_priv_sid (LongTermPkeKey "BAN_CCITT.PkeKey") tr in
+  let (bob_pki_sid, tr) = initialize_pki bob tr in
+
+  match compute_public_key bob bob_priv_sid (LongTermPkeKey "BAN_CCITT.PkeKey") tr with
+  | (None, _) -> ()
+  | (Some pk_b, tr) -> (
+    match compute_public_key bob bob_priv_sid (LongTermSigKey "BAN_CCITT.SigKey") tr with
+    | (None, _) -> ()
+    | (Some vk_b, tr) -> (
+      let (_, tr) = install_public_key alice alice_pki_sid (LongTermPkeKey "BAN_CCITT.PkeKey") bob pk_b tr in
+      let (_, tr) = install_public_key alice alice_pki_sid (LongTermSigKey "BAN_CCITT.SigKey") bob vk_b tr in
+      match compute_public_key alice alice_priv_sid (LongTermPkeKey "BAN_CCITT.PkeKey") tr with
+      | (None, _) -> ()
+      | (Some pk_a, tr) -> (
+        match compute_public_key alice alice_priv_sid (LongTermSigKey "BAN_CCITT.SigKey") tr with
+        | (None, _) -> ()
+        | (Some vk_a, tr) -> (
+          let (_, tr) = install_public_key bob bob_pki_sid (LongTermPkeKey "BAN_CCITT.PkeKey") alice pk_a tr in
+          let (_, tr) = install_public_key bob bob_pki_sid (LongTermSigKey "BAN_CCITT.SigKey") alice vk_a tr in
+          let alice_globals = { pki = alice_pki_sid; private_keys = alice_priv_sid } in
+          let bob_globals = { pki = bob_pki_sid; private_keys = bob_priv_sid } in
+          let x_a = serialize principal "Xa" in
+          let y_a = serialize principal "Ya" in
+          let x_b = serialize principal "Xb" in
+          let y_b = serialize principal "Yb" in
+          serialize_wf_lemma principal (is_publishable tr) "Xa";
+          serialize_wf_lemma principal (is_publishable tr) "Ya";
+          serialize_wf_lemma principal (is_publishable tr) "Xb";
+          serialize_wf_lemma principal (is_publishable tr) "Yb";
+          send_msg1_proof alice_globals alice bob x_a y_a tr;
+          match send_msg1 alice_globals alice bob x_a y_a tr with
+          | (None, _) -> ()
+          | (Some (alice_si, msg1_id), tr) -> (
+            receive_msg1_send_msg2_proof bob_globals bob alice msg1_id x_b y_b tr;
+            match receive_msg1_send_msg2 bob_globals bob alice msg1_id x_b y_b tr with
+            | (None, _) -> ()
+            | (Some (bob_si, msg2_id), tr) -> (
+              match receive_msg2_send_msg3 alice_globals alice alice_si bob msg2_id tr with
+              | (None, _) -> ()
+              | (Some msg3_id, tr) -> (
+                match receive_msg3 bob_globals bob bob_si alice msg3_id tr with
+                | _ -> ()
+              )
+            )
+          )
+        )
+      )
+    )
+  )

--- a/examples/BAN_CCITT_X509_3/DY.Example.BAN_CCITT_X509_3.Debug.fst
+++ b/examples/BAN_CCITT_X509_3/DY.Example.BAN_CCITT_X509_3.Debug.fst
@@ -1,0 +1,65 @@
+module DY.Example.BAN_CCITT_X509_3.Debug
+
+open Comparse
+open DY.Core
+open DY.Lib
+open DY.Lib.Comparse.Parsers
+open DY.Example.BAN_CCITT_X509_3.Protocol.Total
+open DY.Example.BAN_CCITT_X509_3.Protocol.Stateful
+
+val debug: unit -> traceful (option unit)
+let debug () =
+  let alice = "alice" in
+  let bob = "bob" in
+
+  // Alice setup
+  let* alice_priv_sid = initialize_private_keys alice in
+  generate_private_key alice alice_priv_sid (LongTermSigKey "BAN_CCITT.SigKey");*
+  generate_private_key alice alice_priv_sid (LongTermPkeKey "BAN_CCITT.PkeKey");*
+  let* alice_pki_sid = initialize_pki alice in
+
+  // Bob setup
+  let* bob_priv_sid = initialize_private_keys bob in
+  generate_private_key bob bob_priv_sid (LongTermSigKey "BAN_CCITT.SigKey");*
+  generate_private_key bob bob_priv_sid (LongTermPkeKey "BAN_CCITT.PkeKey");*
+  let* bob_pki_sid = initialize_pki bob in
+
+  // Alice's PKI: Bob's keys
+  let*? pk_b = compute_public_key bob bob_priv_sid (LongTermPkeKey "BAN_CCITT.PkeKey") in
+  let*? vk_b = compute_public_key bob bob_priv_sid (LongTermSigKey "BAN_CCITT.SigKey") in
+  install_public_key alice alice_pki_sid (LongTermPkeKey "BAN_CCITT.PkeKey") bob pk_b;*
+  install_public_key alice alice_pki_sid (LongTermSigKey "BAN_CCITT.SigKey") bob vk_b;*
+
+  // Bob's PKI: Alice's keys
+  let*? pk_a = compute_public_key alice alice_priv_sid (LongTermPkeKey "BAN_CCITT.PkeKey") in
+  let*? vk_a = compute_public_key alice alice_priv_sid (LongTermSigKey "BAN_CCITT.SigKey") in
+  install_public_key bob bob_pki_sid (LongTermPkeKey "BAN_CCITT.PkeKey") alice pk_a;*
+  install_public_key bob bob_pki_sid (LongTermSigKey "BAN_CCITT.SigKey") alice vk_a;*
+
+  let alice_globals = { pki = alice_pki_sid; private_keys = alice_priv_sid } in
+  let bob_globals = { pki = bob_pki_sid; private_keys = bob_priv_sid } in
+
+  let x_a = serialize principal "Xa" in
+  let y_a = serialize principal "Ya" in
+  let x_b = serialize principal "Xb" in
+  let y_b = serialize principal "Yb" in
+
+  // Step 1
+  let*? (alice_si, msg1_id) = send_msg1 alice_globals alice bob x_a y_a in
+  
+  // Step 2
+  let*? (bob_si, msg2_id) = receive_msg1_send_msg2 bob_globals bob alice msg1_id x_b y_b in
+  
+  // Step 3
+  let*? msg3_id = receive_msg2_send_msg3 alice_globals alice alice_si bob msg2_id in
+  
+  // Bob receives Step 3
+  let*? _ = receive_msg3 bob_globals bob bob_si alice msg3_id in
+
+  let* tr = get_trace in
+  let _ = IO.debug_print_string (trace_to_string default_trace_to_string_printers tr) in
+  return (Some ())
+
+#push-options "--warn_error -272"
+let _ = debug () empty_trace
+#pop-options

--- a/examples/BAN_CCITT_X509_3/DY.Example.BAN_CCITT_X509_3.Protocol.Stateful.Proof.fst
+++ b/examples/BAN_CCITT_X509_3/DY.Example.BAN_CCITT_X509_3.Protocol.Stateful.Proof.fst
@@ -1,0 +1,263 @@
+module DY.Example.BAN_CCITT_X509_3.Protocol.Stateful.Proof
+
+open Comparse
+open DY.Core
+open DY.Lib
+open DY.Example.BAN_CCITT_X509_3.Protocol.Total
+open DY.Example.BAN_CCITT_X509_3.Protocol.Total.Proof
+open DY.Example.BAN_CCITT_X509_3.Protocol.Stateful
+
+#set-options "--fuel 0 --ifuel 0 --z3rlimit 25  --z3cliopt 'smt.qi.eager_threshold=100'"
+
+(*** Trace invariants ***)
+
+#push-options "--ifuel 1"
+let ban_ccitt_session_pred: local_state_predicate ban_ccitt_session = {
+  pred = (fun tr prin sess_id st ->
+    match st with
+    | InitiatorSentMsg1 bob n_a x_a y_a -> (
+      let alice = prin in
+      is_publishable tr x_a /\
+      is_publishable tr n_a /\
+      is_knowable_by (ban_ccitt_label alice bob) tr y_a /\
+      event_triggered tr alice (Initiate1 alice bob n_a x_a y_a)
+    )
+    | ResponderSentMsg2 alice n_b x_b y_b n_a -> (
+      let bob = prin in
+      is_publishable tr x_b /\ is_publishable tr n_a /\
+      is_publishable tr n_b /\
+      is_knowable_by (ban_ccitt_label alice bob) tr y_b /\
+      event_triggered tr bob (Respond1 bob alice n_b x_b y_b n_a)
+    )
+    | InitiatorSentMsg3 bob n_b -> (
+      let alice = prin in
+      is_publishable tr n_b /\
+      event_triggered tr alice (Initiate2 alice bob n_b)
+    )
+    | ResponderReceivedMsg3 alice n_b -> (
+      let bob = prin in
+      is_publishable tr n_b /\
+      event_triggered tr bob (Respond2 bob alice n_b)
+    )
+  );
+  pred_later = (fun tr1 tr2 prin sess_id st -> ());
+  pred_knowable = (fun tr prin sess_id st -> ());
+}
+#pop-options
+
+#push-options "--ifuel 1"
+let ban_ccitt_event_pred: event_predicate ban_ccitt_event =
+  fun tr prin e ->
+    match e with
+    | Initiate1 alice bob n_a x_a y_a ->
+      prin == alice /\
+      is_publishable tr x_a /\
+      is_publishable tr n_a /\
+      is_knowable_by (ban_ccitt_label alice bob) tr y_a
+    | Respond1 bob alice n_b x_b y_b n_a ->
+      prin == bob /\
+      is_publishable tr x_b /\ is_publishable tr n_a /\
+      is_publishable tr n_b /\
+      is_knowable_by (ban_ccitt_label alice bob) tr y_b
+    | Initiate2 alice bob n_b ->
+      prin == alice /\
+      is_publishable tr n_b /\
+      (is_corrupt tr (long_term_key_label bob) \/
+        (exists x_b y_b n_a. event_triggered tr bob (Respond1 bob alice n_b x_b y_b n_a)))
+    | Respond2 bob alice n_b ->
+      prin == bob /\
+      is_publishable tr n_b /\
+      (is_corrupt tr (long_term_key_label alice) \/
+        (event_triggered tr alice (Initiate2 alice bob n_b)))
+#pop-options
+
+let all_sessions = [
+  pki_tag_and_invariant;
+  private_keys_tag_and_invariant;
+  mk_local_state_tag_and_pred ban_ccitt_session_pred;
+]
+
+let all_events = [
+  mk_event_tag_and_pred ban_ccitt_event_pred;
+]
+
+let ban_ccitt_trace_invs: trace_invariants = {
+  state_pred = mk_state_pred all_sessions;
+  event_pred = mk_event_pred all_events;
+}
+
+instance ban_ccitt_protocol_invs: protocol_invariants = {
+  crypto_invs = ban_ccitt_crypto_invs;
+  trace_invs = ban_ccitt_trace_invs;
+}
+
+let _ = do_split_boilerplate mk_state_pred_correct all_sessions
+let _ = do_split_boilerplate mk_event_pred_correct all_events
+
+(*** Proofs ****)
+
+#push-options "--z3rlimit 1000 --ifuel 2 --fuel 1 --split_queries always"
+val send_msg1_proof:
+  global_sess_id:ban_ccitt_global_sess_ids -> alice:principal -> bob:principal -> x_a:bytes -> y_a:bytes -> tr:trace ->
+  Lemma
+  (requires
+    trace_invariant tr /\
+    is_publishable tr x_a /\
+    is_knowable_by (ban_ccitt_label alice bob) tr y_a
+  )
+  (ensures (
+    let (_, tr_out) = send_msg1 global_sess_id alice bob x_a y_a tr in
+    trace_invariant tr_out
+  ))
+  [SMTPat (trace_invariant tr); SMTPat (send_msg1 global_sess_id alice bob x_a y_a tr)]
+let send_msg1_proof global_sess_id alice bob x_a y_a tr =
+  reveal_opaque (`%send_msg1) (send_msg1 global_sess_id alice bob x_a y_a);
+  let (alice_si, tr1) = new_session_id alice tr in
+  let (n_a, tr2) = mk_rand NoUsage public 32 tr1 in
+  let (pke_nonce, tr3) = mk_rand PkeNonce (long_term_key_label alice) 32 tr2 in
+  let (sig_nonce, tr4) = mk_rand SigNonce (long_term_key_label alice) 32 tr3 in
+  match get_public_key alice global_sess_id.pki (LongTermPkeKey "BAN_CCITT.PkeKey") bob tr4 with
+  | (None, _) -> ()
+  | (Some pk_b, tr5) -> (
+    match get_private_key alice global_sess_id.private_keys (LongTermSigKey "BAN_CCITT.SigKey") tr5 with
+    | (None, _) -> ()
+    | (Some sk_a, tr6) -> (
+      let (_, tr7) = trigger_event alice (Initiate1 alice bob n_a x_a y_a) tr6 in
+      compute_message1_proof tr7 alice bob pk_b n_a x_a y_a pke_nonce sig_nonce sk_a
+    )
+  )
+#pop-options
+
+#push-options "--z3rlimit 1000 --ifuel 2 --fuel 1 --split_queries always"
+val receive_msg1_send_msg2_proof:
+  global_sess_id:ban_ccitt_global_sess_ids -> bob:principal -> alice:principal -> msg1_id:nat -> x_b:bytes -> y_b:bytes -> tr:trace ->
+  Lemma
+  (requires
+    trace_invariant tr /\
+    is_publishable tr x_b /\
+    is_knowable_by (ban_ccitt_label alice bob) tr y_b
+  )
+  (ensures (
+    let (_, tr_out) = receive_msg1_send_msg2 global_sess_id bob alice msg1_id x_b y_b tr in
+    trace_invariant tr_out
+  ))
+  [SMTPat (trace_invariant tr); SMTPat (receive_msg1_send_msg2 global_sess_id bob alice msg1_id x_b y_b tr)]
+let receive_msg1_send_msg2_proof global_sess_id bob alice msg1_id x_b y_b tr =
+  reveal_opaque (`%receive_msg1_send_msg2) (receive_msg1_send_msg2 global_sess_id bob alice msg1_id x_b y_b);
+  match get_public_key bob global_sess_id.pki (LongTermSigKey "BAN_CCITT.SigKey") alice tr with
+  | (None, _) -> ()
+  | (Some vk_a, tr1) -> (
+    match recv_msg msg1_id tr1 with
+    | (None, _) -> ()
+    | (Some msg1_bytes, tr2) -> (
+      decode_message1_proof tr2 msg1_bytes bob alice vk_a;
+      match decode_message1 msg1_bytes bob vk_a with
+      | None -> ()
+      | Some msg1 -> (
+        let (bob_si, tr3) = new_session_id bob tr2 in
+        let (n_b, tr4) = mk_rand NoUsage public 32 tr3 in
+        let (pke_nonce, tr5) = mk_rand PkeNonce (long_term_key_label bob) 32 tr4 in
+        let (sig_nonce, tr6) = mk_rand SigNonce (long_term_key_label bob) 32 tr5 in
+        match get_public_key bob global_sess_id.pki (LongTermPkeKey "BAN_CCITT.PkeKey") alice tr6 with
+        | (None, _) -> ()
+        | (Some pk_a, tr7) -> (
+          match get_private_key bob global_sess_id.private_keys (LongTermSigKey "BAN_CCITT.SigKey") tr7 with
+          | (None, _) -> ()
+          | (Some sk_b, tr8) -> (
+            let (_, tr9) = trigger_event bob (Respond1 bob alice n_b x_b y_b msg1.m1_n_a) tr8 in
+            compute_message2_proof tr9 bob alice pk_a n_b msg1.m1_n_a x_b y_b pke_nonce sig_nonce sk_b
+          )
+        )
+      )
+    )
+  )
+#pop-options
+
+#push-options "--z3rlimit 1000 --ifuel 2 --fuel 1 --split_queries always"
+val receive_msg2_send_msg3_proof:
+  global_sess_id:ban_ccitt_global_sess_ids -> alice:principal -> alice_si:state_id -> bob:principal -> msg2_id:nat -> tr:trace ->
+  Lemma
+  (requires trace_invariant tr)
+  (ensures (
+    let (_, tr_out) = receive_msg2_send_msg3 global_sess_id alice alice_si bob msg2_id tr in
+    trace_invariant tr_out
+  ))
+  [SMTPat (trace_invariant tr); SMTPat (receive_msg2_send_msg3 global_sess_id alice alice_si bob msg2_id tr)]
+let receive_msg2_send_msg3_proof global_sess_id alice alice_si bob msg2_id tr =
+  reveal_opaque (`%receive_msg2_send_msg3) (receive_msg2_send_msg3 global_sess_id alice alice_si bob msg2_id);
+  allow_inversion ban_ccitt_session;
+  match get_state alice alice_si tr with
+  | (None, _) -> ()
+  | (Some session_state, tr1) -> (
+    if not (InitiatorSentMsg1? session_state) then () else (
+      let InitiatorSentMsg1 bob_id n_a x_a y_a = session_state in
+      if bob <> bob_id then () else (
+        match get_public_key alice global_sess_id.pki (LongTermSigKey "BAN_CCITT.SigKey") bob tr1 with
+        | (None, _) -> ()
+        | (Some vk_b, tr2) -> (
+          match recv_msg msg2_id tr2 with
+          | (None, _) -> ()
+          | (Some msg2_bytes, tr3) -> (
+            decode_message2_proof tr3 msg2_bytes alice bob vk_b n_a;
+            match decode_message2 msg2_bytes alice vk_b n_a with
+            | None -> ()
+            | Some msg2 -> (
+              assert(is_publishable tr3 msg2.m2_n_b);
+              assert(
+                is_corrupt tr3 (long_term_key_label bob) \/
+                (exists y_b. event_triggered tr3 bob (Respond1 bob alice msg2.m2_n_b msg2.m2_x_b y_b n_a))
+              );
+              let (sig_nonce, tr4) = mk_rand SigNonce (long_term_key_label alice) 32 tr3 in
+              match get_private_key alice global_sess_id.private_keys (LongTermSigKey "BAN_CCITT.SigKey") tr4 with
+              | (None, _) -> ()
+              | (Some sk_a, tr5) -> (
+                let (_, tr6) = trigger_event alice (Initiate2 alice bob msg2.m2_n_b) tr5 in
+                compute_message3_proof tr6 alice bob msg2.m2_n_b sig_nonce sk_a
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+#pop-options
+
+#push-options "--z3rlimit 1000 --ifuel 2 --fuel 1 --split_queries always"
+val receive_msg3_proof:
+  global_sess_id:ban_ccitt_global_sess_ids -> bob:principal -> bob_si:state_id -> alice:principal -> msg3_id:nat -> tr:trace ->
+  Lemma
+  (requires trace_invariant tr)
+  (ensures (
+    let (_, tr_out) = receive_msg3 global_sess_id bob bob_si alice msg3_id tr in
+    trace_invariant tr_out
+  ))
+  [SMTPat (trace_invariant tr); SMTPat (receive_msg3 global_sess_id bob bob_si alice msg3_id tr)]
+let receive_msg3_proof global_sess_id bob bob_si alice msg3_id tr =
+  reveal_opaque (`%receive_msg3) (receive_msg3 global_sess_id bob bob_si alice msg3_id);
+  allow_inversion ban_ccitt_session;
+  match get_state bob bob_si tr with
+  | (None, _) -> ()
+  | (Some session_state, tr1) -> (
+    if not (ResponderSentMsg2? session_state) then () else (
+      let ResponderSentMsg2 alice_id n_b x_b y_b n_a = session_state in
+      if alice <> alice_id then () else (
+        match get_public_key bob global_sess_id.pki (LongTermSigKey "BAN_CCITT.SigKey") alice tr1 with
+        | (None, _) -> ()
+        | (Some vk_a, tr2) -> (
+          match recv_msg msg3_id tr2 with
+          | (None, _) -> ()
+          | (Some msg3_bytes, tr3) -> (
+            decode_message3_proof tr3 msg3_bytes bob alice vk_a n_b;
+            match decode_message3 msg3_bytes bob vk_a n_b with
+            | None -> ()
+            | Some msg3 -> (
+              assert(is_publishable tr3 n_b);
+              assert(is_corrupt tr3 (long_term_key_label alice) \/ event_triggered tr3 alice (Initiate2 alice bob n_b));
+              ()
+            )
+          )
+        )
+      )
+    )
+  )
+#pop-options

--- a/examples/BAN_CCITT_X509_3/DY.Example.BAN_CCITT_X509_3.Protocol.Stateful.fst
+++ b/examples/BAN_CCITT_X509_3/DY.Example.BAN_CCITT_X509_3.Protocol.Stateful.fst
@@ -1,0 +1,125 @@
+module DY.Example.BAN_CCITT_X509_3.Protocol.Stateful
+
+open Comparse
+open DY.Core
+open DY.Lib
+open DY.Example.BAN_CCITT_X509_3.Protocol.Total
+
+(*** Definition of state ***)
+
+[@@ with_bytes bytes]
+type ban_ccitt_session =
+  | InitiatorSentMsg1: bob:principal -> n_a:bytes -> x_a:bytes -> y_a:bytes -> ban_ccitt_session
+  | ResponderSentMsg2: alice:principal -> n_b:bytes -> x_b:bytes -> y_b:bytes -> n_a:bytes -> ban_ccitt_session
+  | InitiatorSentMsg3: bob:principal -> n_b:bytes -> ban_ccitt_session
+  | ResponderReceivedMsg3: alice:principal -> n_b:bytes -> ban_ccitt_session
+
+%splice [ps_ban_ccitt_session] (gen_parser (`ban_ccitt_session))
+%splice [ps_ban_ccitt_session_is_well_formed] (gen_is_well_formed_lemma (`ban_ccitt_session))
+
+instance ban_ccitt_session_parseable_serializeable: parseable_serializeable bytes ban_ccitt_session
+ = mk_parseable_serializeable ps_ban_ccitt_session
+
+(*** Definition of events ***)
+[@@ with_bytes bytes]
+type ban_ccitt_event =
+  | Initiate1: alice:principal -> bob:principal -> n_a:bytes -> x_a:bytes -> y_a:bytes -> ban_ccitt_event
+  | Respond1: bob:principal -> alice:principal -> n_b:bytes -> x_b:bytes -> y_b:bytes -> n_a:bytes -> ban_ccitt_event
+  | Initiate2: alice:principal -> bob:principal -> n_b:bytes -> ban_ccitt_event
+  | Respond2: bob:principal -> alice:principal -> n_b:bytes -> ban_ccitt_event
+
+%splice [ps_ban_ccitt_event] (gen_parser (`ban_ccitt_event))
+
+instance ban_ccitt_event_instance: event ban_ccitt_event = {
+  tag = "BAN_CCITT.Event";
+  format = mk_parseable_serializeable ps_ban_ccitt_event;
+}
+
+(*** Setup for the stateful code ***)
+
+instance local_state_ban_ccitt_session: local_state ban_ccitt_session = {
+  tag = "BAN_CCITT.Session";
+  format = mk_parseable_serializeable ps_ban_ccitt_session;
+}
+
+type ban_ccitt_global_sess_ids = {
+  pki: state_id;
+  private_keys: state_id;
+}
+
+(*** Labels ***)
+
+val ban_ccitt_label: principal -> principal -> label
+let ban_ccitt_label p1 p2 =
+  principal_label p1 `join` principal_label p2
+
+(*** Stateful code ***)
+
+// Alice prepares and sends message 1
+[@@ "opaque_to_smt"]
+val send_msg1: ban_ccitt_global_sess_ids -> principal -> principal -> bytes -> bytes -> traceful (option (state_id * nat))
+let send_msg1 global_sess_id alice bob x_a y_a =
+  let* alice_si = new_session_id alice in
+  let* n_a = mk_rand NoUsage public 32 in
+  let* pke_nonce = mk_rand PkeNonce (long_term_key_label alice) 32 in
+  let* sig_nonce = mk_rand SigNonce (long_term_key_label alice) 32 in
+  let*? pk_b = get_public_key alice global_sess_id.pki (LongTermPkeKey "BAN_CCITT.PkeKey") bob in
+  let*? sk_a = get_private_key alice global_sess_id.private_keys (LongTermSigKey "BAN_CCITT.SigKey") in
+  trigger_event alice (Initiate1 alice bob n_a x_a y_a);*
+  let msg = compute_message1 alice bob pk_b n_a x_a y_a pke_nonce sig_nonce sk_a in
+  let* msg_id = send_msg msg in
+  set_state alice alice_si (InitiatorSentMsg1 bob n_a x_a y_a);*
+  return (Some (alice_si, msg_id))
+
+// Bob receives message 1 and sends message 2
+[@@ "opaque_to_smt"]
+val receive_msg1_send_msg2: ban_ccitt_global_sess_ids -> principal -> principal -> nat -> bytes -> bytes -> traceful (option (state_id * nat))
+let receive_msg1_send_msg2 global_sess_id bob alice msg1_id x_b y_b =
+  let*? vk_a = get_public_key bob global_sess_id.pki (LongTermSigKey "BAN_CCITT.SigKey") alice in
+  let*? msg1_bytes = recv_msg msg1_id in
+  let*? msg1 = return (decode_message1 msg1_bytes bob vk_a) in
+  let* bob_si = new_session_id bob in
+  let* n_b = mk_rand NoUsage public 32 in
+  let* pke_nonce = mk_rand PkeNonce (long_term_key_label bob) 32 in
+  let* sig_nonce = mk_rand SigNonce (long_term_key_label bob) 32 in
+  let*? pk_a = get_public_key bob global_sess_id.pki (LongTermPkeKey "BAN_CCITT.PkeKey") alice in
+  let*? sk_b = get_private_key bob global_sess_id.private_keys (LongTermSigKey "BAN_CCITT.SigKey") in
+  trigger_event bob (Respond1 bob alice n_b x_b y_b msg1.m1_n_a);*
+  let msg2 = compute_message2 bob alice pk_a n_b msg1.m1_n_a x_b y_b pke_nonce sig_nonce sk_b in
+  let* msg2_id = send_msg msg2 in
+  set_state bob bob_si (ResponderSentMsg2 alice n_b x_b y_b msg1.m1_n_a);*
+  return (Some (bob_si, msg2_id))
+
+// Alice receives message 2 and sends message 3
+[@@ "opaque_to_smt"]
+val receive_msg2_send_msg3: ban_ccitt_global_sess_ids -> principal -> state_id -> principal -> nat -> traceful (option nat)
+let receive_msg2_send_msg3 global_sess_id alice alice_si bob msg2_id =
+  let*? session_state = get_state alice alice_si in
+  guard_tr (InitiatorSentMsg1? session_state);*?
+  let InitiatorSentMsg1 bob_id n_a x_a y_a = session_state in
+  guard_tr (bob = bob_id);*?
+  let*? vk_b = get_public_key alice global_sess_id.pki (LongTermSigKey "BAN_CCITT.SigKey") bob in
+  let*? msg2_bytes = recv_msg msg2_id in
+  let*? msg2 = return (decode_message2 msg2_bytes alice vk_b n_a) in
+  let* sig_nonce = mk_rand SigNonce (long_term_key_label alice) 32 in
+  let*? sk_a = get_private_key alice global_sess_id.private_keys (LongTermSigKey "BAN_CCITT.SigKey") in
+  trigger_event alice (Initiate2 alice bob msg2.m2_n_b);*
+  let msg3 = compute_message3 alice bob msg2.m2_n_b sig_nonce sk_a in
+  let* msg3_id = send_msg msg3 in
+  set_state alice alice_si (InitiatorSentMsg3 bob msg2.m2_n_b);*
+  return (Some msg3_id)
+
+// Bob receives message 3
+[@@ "opaque_to_smt"]
+val receive_msg3: ban_ccitt_global_sess_ids -> principal -> state_id -> principal -> nat -> traceful (option unit)
+let receive_msg3 global_sess_id bob bob_si alice msg3_id =
+  let*? session_state = get_state bob bob_si in
+  guard_tr (ResponderSentMsg2? session_state);*?
+  let ResponderSentMsg2 alice_id n_b x_b y_b n_a = session_state in
+  guard_tr (alice = alice_id);*?
+  let*? vk_a = get_public_key bob global_sess_id.pki (LongTermSigKey "BAN_CCITT.SigKey") alice in
+  let*? msg3_bytes = recv_msg msg3_id in
+  let*? msg3 = return (decode_message3 msg3_bytes bob vk_a n_b) in
+  trigger_event bob (Respond2 bob alice n_b);*
+  set_state bob bob_si (ResponderReceivedMsg3 alice n_b);*
+  return (Some ())

--- a/examples/BAN_CCITT_X509_3/DY.Example.BAN_CCITT_X509_3.Protocol.Total.Proof.fst
+++ b/examples/BAN_CCITT_X509_3/DY.Example.BAN_CCITT_X509_3.Protocol.Total.Proof.fst
@@ -1,0 +1,270 @@
+module DY.Example.BAN_CCITT_X509_3.Protocol.Total.Proof
+
+open Comparse
+open DY.Core
+open DY.Lib
+open DY.Example.BAN_CCITT_X509_3.Protocol.Total
+open DY.Example.BAN_CCITT_X509_3.Protocol.Stateful
+
+#set-options "--fuel 0 --ifuel 0 --z3cliopt 'smt.qi.eager_threshold=100'"
+
+(*** Cryptographic invariants ***)
+
+instance ban_ccitt_crypto_usages: crypto_usages = default_crypto_usages
+
+#push-options "--ifuel 2 --fuel 0"
+val ban_ccitt_crypto_preds: crypto_predicates
+let ban_ccitt_crypto_preds = {
+  default_crypto_predicates with
+
+  pke_pred = {
+    pred = (fun tr sk_usage pk msg ->
+      (exists prin. sk_usage == long_term_key_type_to_usage (LongTermPkeKey "BAN_CCITT.PkeKey") prin /\ (
+        match parse userdata msg with
+        | Some ud -> (
+          (exists alice n_a x_a y_a. ud.data == y_a /\ event_triggered tr alice (Initiate1 alice prin n_a x_a y_a)) \/
+          (exists bob n_b x_b y_b n_a. ud.data == y_b /\ event_triggered tr bob (Respond1 bob prin n_b x_b y_b n_a))
+        )
+        | None -> False
+      ))
+    );
+    pred_later = (fun tr1 tr2 sk_usage pk msg ->
+      parse_wf_lemma userdata (bytes_well_formed tr1) msg
+    );
+  };
+
+  sign_pred = {
+    pred = (fun tr sk_usage vk msg ->
+      (exists prin. sk_usage == long_term_key_type_to_usage (LongTermSigKey "BAN_CCITT.SigKey") prin /\ (
+        match parse sig_message msg with
+        | Some (SigMsg1 sm1) ->
+          exists y_a. event_triggered tr prin (Initiate1 prin sm1.sm1_bob sm1.sm1_n_a sm1.sm1_x_a y_a)
+        | Some (SigMsg2 sm2) ->
+          exists y_b. event_triggered tr prin (Respond1 prin sm2.sm2_alice sm2.sm2_n_b sm2.sm2_x_b y_b sm2.sm2_n_a)
+        | Some (SigMsg3 sm3) ->
+          event_triggered tr prin (Initiate2 prin sm3.sm3_bob sm3.sm3_n_b)
+        | None -> False
+      ))
+    );
+    pred_later = (fun tr1 tr2 sk_usage vk msg ->
+      parse_wf_lemma sig_message (bytes_well_formed tr1) msg
+    );
+  };
+}
+#pop-options
+
+instance ban_ccitt_crypto_invs: crypto_invariants = {
+  usages = ban_ccitt_crypto_usages;
+  preds = ban_ccitt_crypto_preds;
+}
+
+(*** Proofs ***)
+
+#push-options "--z3rlimit 100 --fuel 1 --ifuel 1"
+val compute_message1_proof:
+  tr:trace ->
+  alice:principal -> bob:principal -> pk_b:bytes -> n_a:bytes -> x_a:bytes -> y_a:bytes -> pke_nonce:bytes -> sig_nonce:bytes -> sk_a:bytes ->
+  Lemma
+    (requires
+      event_triggered tr alice (Initiate1 alice bob n_a x_a y_a) /\
+      is_publishable tr x_a /\
+      is_publishable tr n_a /\
+      is_knowable_by (ban_ccitt_label alice bob) tr y_a /\
+      is_private_key_for tr sk_a (LongTermSigKey "BAN_CCITT.SigKey") alice /\
+      is_public_key_for tr pk_b (LongTermPkeKey "BAN_CCITT.PkeKey") bob /\
+      is_secret (long_term_key_label alice) tr pke_nonce /\ pke_nonce `has_usage tr` PkeNonce /\
+      is_secret (long_term_key_label alice) tr sig_nonce /\ sig_nonce `has_usage tr` SigNonce
+    )
+    (ensures is_publishable tr (compute_message1 alice bob pk_b n_a x_a y_a pke_nonce sig_nonce sk_a))
+let compute_message1_proof tr alice bob pk_b n_a x_a y_a pke_nonce sig_nonce sk_a =
+  reveal_opaque (`%compute_message1) (compute_message1 alice bob pk_b n_a x_a y_a pke_nonce sig_nonce sk_a);
+  let inner_payload : userdata = {data=y_a} in
+  serialize_wf_lemma userdata (is_knowable_by (ban_ccitt_label alice bob) tr) inner_payload;
+  let y_a_enc = pke_enc pk_b pke_nonce (serialize userdata inner_payload) in
+  assert(is_publishable tr y_a_enc);
+  let signed_part : sig_message1 = { sm1_n_a = n_a; sm1_bob = bob; sm1_x_a = x_a; sm1_y_a_enc = y_a_enc } in
+  let sig_payload : sig_message = SigMsg1 signed_part in
+  serialize_wf_lemma sig_message (is_publishable tr) sig_payload;
+  let sg = sign sk_a sig_nonce (serialize sig_message sig_payload) in
+  parse_serialize_inv_lemma #bytes sig_message sig_payload;
+  assert(is_publishable tr sg);
+  let m : message = Msg1 { m1_alice = alice; m1_n_a = n_a; m1_bob = bob; m1_x_a = x_a; m1_y_a_enc = y_a_enc; m1_sg = sg } in
+  serialize_wf_lemma message (is_publishable tr) m
+#pop-options
+
+#push-options "--ifuel 2 --fuel 1 --z3rlimit 100"
+val decode_message1_proof:
+  tr:trace ->
+  msg1_bytes:bytes -> bob:principal -> alice:principal -> vk_a:bytes ->
+  Lemma
+  (requires
+    is_publishable tr msg1_bytes /\
+    is_public_key_for tr vk_a (LongTermSigKey "BAN_CCITT.SigKey") alice
+  )
+  (ensures (
+    match decode_message1 msg1_bytes bob vk_a with
+    | Some msg1 -> (
+      is_publishable tr msg1.m1_n_a /\
+      is_publishable tr msg1.m1_x_a /\
+      is_publishable tr msg1.m1_y_a_enc /\
+      (is_corrupt tr (long_term_key_label alice) \/ (exists y_a. event_triggered tr alice (Initiate1 alice bob msg1.m1_n_a msg1.m1_x_a y_a)))
+    )
+    | None -> True
+  ))
+let decode_message1_proof tr msg1_bytes bob alice vk_a =
+  reveal_opaque (`%decode_message1) (decode_message1 msg1_bytes bob vk_a);
+  match decode_message1 msg1_bytes bob vk_a with
+  | None -> ()
+  | Some msg1 ->
+    parse_wf_lemma message (is_publishable tr) msg1_bytes;
+    let signed_part : sig_message1 = { sm1_n_a = msg1.m1_n_a; sm1_bob = msg1.m1_bob; sm1_x_a = msg1.m1_x_a; sm1_y_a_enc = msg1.m1_y_a_enc } in
+    let sig_payload : sig_message = SigMsg1 signed_part in
+    serialize_wf_lemma sig_message (is_publishable tr) sig_payload;
+    parse_serialize_inv_lemma #bytes sig_message sig_payload
+#pop-options
+
+#push-options "--z3rlimit 100 --fuel 1 --ifuel 1"
+val compute_message2_proof:
+  tr:trace ->
+  bob:principal -> alice:principal -> pk_a:bytes -> n_b:bytes -> n_a:bytes -> x_b:bytes -> y_b:bytes -> pke_nonce:bytes -> sig_nonce:bytes -> sk_b:bytes ->
+  Lemma
+    (requires
+      event_triggered tr bob (Respond1 bob alice n_b x_b y_b n_a) /\
+      is_publishable tr x_b /\ is_publishable tr n_a /\
+      is_publishable tr n_b /\
+      is_knowable_by (ban_ccitt_label alice bob) tr y_b /\
+      is_private_key_for tr sk_b (LongTermSigKey "BAN_CCITT.SigKey") bob /\
+      is_public_key_for tr pk_a (LongTermPkeKey "BAN_CCITT.PkeKey") alice /\
+      is_secret (long_term_key_label bob) tr pke_nonce /\ pke_nonce `has_usage tr` PkeNonce /\
+      is_secret (long_term_key_label bob) tr sig_nonce /\ sig_nonce `has_usage tr` SigNonce
+    )
+    (ensures is_publishable tr (compute_message2 bob alice pk_a n_b n_a x_b y_b pke_nonce sig_nonce sk_b))
+let compute_message2_proof tr bob alice pk_a n_b n_a x_b y_b pke_nonce sig_nonce sk_b =
+  reveal_opaque (`%compute_message2) (compute_message2 bob alice pk_a n_b n_a x_b y_b pke_nonce sig_nonce sk_b);
+  let inner_payload : userdata = {data=y_b} in
+  serialize_wf_lemma userdata (is_knowable_by (ban_ccitt_label alice bob) tr) inner_payload;
+  let y_b_enc = pke_enc pk_a pke_nonce (serialize userdata inner_payload) in
+  assert(is_publishable tr y_b_enc);
+  let signed_part : sig_message2 = { sm2_n_b = n_b; sm2_alice = alice; sm2_n_a = n_a; sm2_x_b = x_b; sm2_y_b_enc = y_b_enc } in
+  let sig_payload : sig_message = SigMsg2 signed_part in
+  serialize_wf_lemma sig_message (is_publishable tr) sig_payload;
+  let sg = sign sk_b sig_nonce (serialize sig_message sig_payload) in
+  parse_serialize_inv_lemma #bytes sig_message sig_payload;
+  assert(is_publishable tr sg);
+  let m : message = Msg2 { m2_bob = bob; m2_n_b = n_b; m2_alice = alice; m2_n_a = n_a; m2_x_b = x_b; m2_y_b_enc = y_b_enc; m2_sg = sg } in
+  serialize_wf_lemma message (is_publishable tr) m
+#pop-options
+
+#push-options "--ifuel 2 --fuel 1 --z3rlimit 100"
+val decode_message2_proof:
+  tr:trace ->
+  msg2_bytes:bytes -> alice:principal -> bob:principal -> vk_b:bytes -> n_a:bytes ->
+  Lemma
+  (requires
+    is_publishable tr msg2_bytes /\
+    is_public_key_for tr vk_b (LongTermSigKey "BAN_CCITT.SigKey") bob
+  )
+  (ensures (
+    match decode_message2 msg2_bytes alice vk_b n_a with
+    | Some msg2 -> (
+      is_publishable tr msg2.m2_n_b /\
+      is_publishable tr msg2.m2_x_b /\
+      is_publishable tr msg2.m2_y_b_enc /\
+      (is_corrupt tr (long_term_key_label bob) \/ (exists y_b. event_triggered tr bob (Respond1 bob alice msg2.m2_n_b msg2.m2_x_b y_b n_a)))
+    )
+    | None -> True
+  ))
+let decode_message2_proof tr msg2_bytes alice bob vk_b n_a =
+  reveal_opaque (`%decode_message2) (decode_message2 msg2_bytes alice vk_b n_a);
+  match decode_message2 msg2_bytes alice vk_b n_a with
+  | None -> ()
+  | Some msg2 ->
+    parse_wf_lemma message (is_publishable tr) msg2_bytes;
+    let signed_part : sig_message2 = { sm2_n_b = msg2.m2_n_b; sm2_alice = msg2.m2_alice; sm2_n_a = msg2.m2_n_a; sm2_x_b = msg2.m2_x_b; sm2_y_b_enc = msg2.m2_y_b_enc } in
+    let sig_payload : sig_message = SigMsg2 signed_part in
+    serialize_wf_lemma sig_message (is_publishable tr) sig_payload;
+    parse_serialize_inv_lemma #bytes sig_message sig_payload
+#pop-options
+
+#push-options "--z3rlimit 100 --fuel 1 --ifuel 1"
+val compute_message3_proof:
+  tr:trace ->
+  alice:principal -> bob:principal -> n_b:bytes -> sig_nonce:bytes -> sk_a:bytes ->
+  Lemma
+    (requires
+      event_triggered tr alice (Initiate2 alice bob n_b) /\
+      is_publishable tr n_b /\
+      is_private_key_for tr sk_a (LongTermSigKey "BAN_CCITT.SigKey") alice /\
+      is_secret (long_term_key_label alice) tr sig_nonce /\ sig_nonce `has_usage tr` SigNonce
+    )
+    (ensures is_publishable tr (compute_message3 alice bob n_b sig_nonce sk_a))
+let compute_message3_proof tr alice bob n_b sig_nonce sk_a =
+  reveal_opaque (`%compute_message3) (compute_message3 alice bob n_b sig_nonce sk_a);
+  let signed_part : sig_message3 = { sm3_bob = bob; sm3_n_b = n_b } in
+  let sig_payload : sig_message = SigMsg3 signed_part in
+  serialize_wf_lemma sig_message (is_publishable tr) sig_payload;
+  let sg = sign sk_a sig_nonce (serialize sig_message sig_payload) in
+  parse_serialize_inv_lemma #bytes sig_message sig_payload;
+  assert(is_publishable tr sg);
+  let m : message = Msg3 { m3_alice = alice; m3_bob = bob; m3_n_b = n_b; m3_sg = sg } in
+  serialize_wf_lemma message (is_publishable tr) m
+#pop-options
+
+#push-options "--ifuel 2 --fuel 1 --z3rlimit 100"
+val decode_message3_proof:
+  tr:trace ->
+  msg3_bytes:bytes -> bob:principal -> alice:principal -> vk_a:bytes -> n_b:bytes ->
+  Lemma
+  (requires
+    is_publishable tr msg3_bytes /\
+    is_public_key_for tr vk_a (LongTermSigKey "BAN_CCITT.SigKey") alice
+  )
+  (ensures (
+    match decode_message3 msg3_bytes bob vk_a n_b with
+    | Some msg3 -> (
+      (is_corrupt tr (long_term_key_label alice) \/ (event_triggered tr alice (Initiate2 alice bob n_b)))
+    )
+    | None -> True
+  ))
+let decode_message3_proof tr msg3_bytes bob alice vk_a n_b =
+  reveal_opaque (`%decode_message3) (decode_message3 msg3_bytes bob vk_a n_b);
+  match decode_message3 msg3_bytes bob vk_a n_b with
+  | None -> ()
+  | Some msg3 ->
+    parse_wf_lemma message (is_publishable tr) msg3_bytes;
+    let signed_part : sig_message3 = { sm3_bob = msg3.m3_bob; sm3_n_b = msg3.m3_n_b } in
+    let sig_payload : sig_message = SigMsg3 signed_part in
+    serialize_wf_lemma sig_message (is_publishable tr) sig_payload;
+    parse_serialize_inv_lemma #bytes sig_message sig_payload
+#pop-options
+
+#push-options "--ifuel 2 --fuel 1 --z3rlimit 100"
+val decode_y_proof:
+  tr:trace -> y_enc:bytes -> sk:bytes -> prin:principal ->
+  Lemma
+  (requires
+    is_private_key_for tr sk (LongTermPkeKey "BAN_CCITT.PkeKey") prin /\
+    bytes_invariant tr y_enc
+  )
+  (ensures (
+    match decode_y y_enc sk with
+    | Some y -> (
+      is_publishable tr y \/
+      (exists p_other n_a x_a. event_triggered tr p_other (Initiate1 p_other prin n_a x_a y)) \/
+      (exists p_other n_b x_b n_a. event_triggered tr p_other (Respond1 p_other prin n_b x_b y n_a))
+    )
+    | None -> True
+  ))
+let decode_y_proof tr y_enc sk prin =
+  reveal_opaque (`%decode_y) (decode_y y_enc sk);
+  match decode_y y_enc sk with
+  | None -> ()
+  | Some y -> (
+    let Some y_plain = pke_dec sk y_enc in
+    let Some y_struct = parse userdata y_plain in
+    assert(y_struct.data == y);
+    // From bytes_invariant_pke_dec: pke_pred holds OR get_label y_plain can_flow public.
+    // In the publishable case, derive is_publishable tr y from parse_wf_lemma.
+    FStar.Classical.move_requires (parse_wf_lemma userdata (is_publishable tr)) y_plain
+  )
+#pop-options

--- a/examples/BAN_CCITT_X509_3/DY.Example.BAN_CCITT_X509_3.Protocol.Total.fst
+++ b/examples/BAN_CCITT_X509_3/DY.Example.BAN_CCITT_X509_3.Protocol.Total.fst
@@ -1,0 +1,194 @@
+module DY.Example.BAN_CCITT_X509_3.Protocol.Total
+
+open Comparse
+open DY.Core
+open DY.Lib
+
+(*** Message 1 ***)
+
+[@@ with_bytes bytes]
+type sig_message1 = {
+  sm1_n_a: bytes;
+  sm1_bob: principal;
+  sm1_x_a: bytes;
+  sm1_y_a_enc: bytes;
+}
+
+%splice [ps_sig_message1] (gen_parser (`sig_message1))
+%splice [ps_sig_message1_is_well_formed] (gen_is_well_formed_lemma (`sig_message1))
+instance parseable_serializeable_sig_message1: parseable_serializeable bytes sig_message1 = mk_parseable_serializeable ps_sig_message1
+
+[@@ with_bytes bytes]
+type message1 = {
+  m1_alice: principal;
+  m1_n_a: bytes;
+  m1_bob: principal;
+  m1_x_a: bytes;
+  m1_y_a_enc: bytes;
+  m1_sg: bytes;
+}
+
+%splice [ps_message1] (gen_parser (`message1))
+%splice [ps_message1_is_well_formed] (gen_is_well_formed_lemma (`message1))
+instance parseable_serializeable_message1: parseable_serializeable bytes message1 = mk_parseable_serializeable ps_message1
+
+(*** Message 2 ***)
+
+[@@ with_bytes bytes]
+type sig_message2 = {
+  sm2_n_b: bytes;
+  sm2_alice: principal;
+  sm2_n_a: bytes;
+  sm2_x_b: bytes;
+  sm2_y_b_enc: bytes;
+}
+
+%splice [ps_sig_message2] (gen_parser (`sig_message2))
+%splice [ps_sig_message2_is_well_formed] (gen_is_well_formed_lemma (`sig_message2))
+instance parseable_serializeable_sig_message2: parseable_serializeable bytes sig_message2 = mk_parseable_serializeable ps_sig_message2
+
+[@@ with_bytes bytes]
+type message2 = {
+  m2_bob: principal;
+  m2_n_b: bytes;
+  m2_alice: principal;
+  m2_n_a: bytes;
+  m2_x_b: bytes;
+  m2_y_b_enc: bytes;
+  m2_sg: bytes;
+}
+
+%splice [ps_message2] (gen_parser (`message2))
+%splice [ps_message2_is_well_formed] (gen_is_well_formed_lemma (`message2))
+instance parseable_serializeable_message2: parseable_serializeable bytes message2 = mk_parseable_serializeable ps_message2
+
+(*** Message 3 ***)
+
+[@@ with_bytes bytes]
+type sig_message3 = {
+  sm3_bob: principal;
+  sm3_n_b: bytes;
+}
+
+%splice [ps_sig_message3] (gen_parser (`sig_message3))
+%splice [ps_sig_message3_is_well_formed] (gen_is_well_formed_lemma (`sig_message3))
+instance parseable_serializeable_sig_message3: parseable_serializeable bytes sig_message3 = mk_parseable_serializeable ps_sig_message3
+
+[@@ with_bytes bytes]
+type message3 = {
+  m3_alice: principal;
+  m3_bob: principal;
+  m3_n_b: bytes;
+  m3_sg: bytes;
+}
+
+%splice [ps_message3] (gen_parser (`message3))
+%splice [ps_message3_is_well_formed] (gen_is_well_formed_lemma (`message3))
+instance parseable_serializeable_message3: parseable_serializeable bytes message3 = mk_parseable_serializeable ps_message3
+
+(*** Global message type ***)
+
+[@@ with_bytes bytes]
+type message =
+  | Msg1: message1 -> message
+  | Msg2: message2 -> message
+  | Msg3: message3 -> message
+
+%splice [ps_message] (gen_parser (`message))
+%splice [ps_message_is_well_formed] (gen_is_well_formed_lemma (`message))
+
+instance parseable_serializeable_bytes_message: parseable_serializeable bytes message = mk_parseable_serializeable ps_message
+
+instance parseable_serializeable_principal: parseable_serializeable bytes principal = mk_parseable_serializeable ps_principal
+
+(*** Tagged signed payload (union) ***)
+
+[@@ with_bytes bytes]
+type sig_message =
+  | SigMsg1: sig_message1 -> sig_message
+  | SigMsg2: sig_message2 -> sig_message
+  | SigMsg3: sig_message3 -> sig_message
+
+%splice [ps_sig_message] (gen_parser (`sig_message))
+%splice [ps_sig_message_is_well_formed] (gen_is_well_formed_lemma (`sig_message))
+
+instance parseable_serializeable_bytes_sig_message: parseable_serializeable bytes sig_message = mk_parseable_serializeable ps_sig_message
+
+(*** Userdata for Ya and Yb ***)
+
+[@@ with_bytes bytes]
+type userdata = {
+  data: bytes;
+}
+
+%splice [ps_userdata] (gen_parser (`userdata))
+%splice [ps_userdata_is_well_formed] (gen_is_well_formed_lemma (`userdata))
+
+instance parseable_serializeable_bytes_userdata: parseable_serializeable bytes userdata = mk_parseable_serializeable ps_userdata
+
+(*** Processing functions ***)
+
+[@@"opaque_to_smt"]
+val compute_message1: principal -> principal -> bytes -> bytes -> bytes -> bytes -> bytes -> bytes -> bytes -> bytes
+let compute_message1 alice bob pk_b n_a x_a y_a pke_nonce sig_nonce sk_a =
+  let y_a_enc = pke_enc pk_b pke_nonce (serialize userdata {data=y_a}) in
+  let signed_part = { sm1_n_a = n_a; sm1_bob = bob; sm1_x_a = x_a; sm1_y_a_enc = y_a_enc } in
+  let sg = sign sk_a sig_nonce (serialize sig_message (SigMsg1 signed_part)) in
+  serialize message (Msg1 { m1_alice = alice; m1_n_a = n_a; m1_bob = bob; m1_x_a = x_a; m1_y_a_enc = y_a_enc; m1_sg = sg })
+
+[@@"opaque_to_smt"]
+val decode_message1: bytes -> principal -> bytes -> option message1
+let decode_message1 msg1_bytes bob vk_a =
+  let? msg = parse message msg1_bytes in
+  guard (Msg1? msg);?
+  let msg1 = Msg1?._0 msg in
+  guard (msg1.m1_bob = bob);?
+  let signed_part = { sm1_n_a = msg1.m1_n_a; sm1_bob = msg1.m1_bob; sm1_x_a = msg1.m1_x_a; sm1_y_a_enc = msg1.m1_y_a_enc } in
+  guard (verify vk_a (serialize sig_message (SigMsg1 signed_part)) msg1.m1_sg);?
+  Some msg1
+
+[@@"opaque_to_smt"]
+val compute_message2: principal -> principal -> bytes -> bytes -> bytes -> bytes -> bytes -> bytes -> bytes -> bytes -> bytes
+let compute_message2 bob alice pk_a n_b n_a x_b y_b pke_nonce sig_nonce sk_b =
+  let y_b_enc = pke_enc pk_a pke_nonce (serialize userdata {data=y_b}) in
+  let signed_part = { sm2_n_b = n_b; sm2_alice = alice; sm2_n_a = n_a; sm2_x_b = x_b; sm2_y_b_enc = y_b_enc } in
+  let sg = sign sk_b sig_nonce (serialize sig_message (SigMsg2 signed_part)) in
+  serialize message (Msg2 { m2_bob = bob; m2_n_b = n_b; m2_alice = alice; m2_n_a = n_a; m2_x_b = x_b; m2_y_b_enc = y_b_enc; m2_sg = sg })
+
+[@@"opaque_to_smt"]
+val decode_message2: bytes -> principal -> bytes -> bytes -> option message2
+let decode_message2 msg2_bytes alice vk_b n_a =
+  let? msg = parse message msg2_bytes in
+  guard (Msg2? msg);?
+  let msg2 = Msg2?._0 msg in
+  guard (msg2.m2_alice = alice);?
+  guard (msg2.m2_n_a = n_a);?
+  let signed_part = { sm2_n_b = msg2.m2_n_b; sm2_alice = msg2.m2_alice; sm2_n_a = msg2.m2_n_a; sm2_x_b = msg2.m2_x_b; sm2_y_b_enc = msg2.m2_y_b_enc } in
+  guard (verify vk_b (serialize sig_message (SigMsg2 signed_part)) msg2.m2_sg);?
+  Some msg2
+
+[@@"opaque_to_smt"]
+val compute_message3: principal -> principal -> bytes -> bytes -> bytes -> bytes
+let compute_message3 alice bob n_b sig_nonce sk_a =
+  let signed_part = { sm3_bob = bob; sm3_n_b = n_b } in
+  let sg = sign sk_a sig_nonce (serialize sig_message (SigMsg3 signed_part)) in
+  serialize message (Msg3 { m3_alice = alice; m3_bob = bob; m3_n_b = n_b; m3_sg = sg })
+
+[@@"opaque_to_smt"]
+val decode_message3: bytes -> principal -> bytes -> bytes -> option message3
+let decode_message3 msg3_bytes bob vk_a n_b =
+  let? msg = parse message msg3_bytes in
+  guard (Msg3? msg);?
+  let msg3 = Msg3?._0 msg in
+  guard (msg3.m3_bob = bob);?
+  guard (msg3.m3_n_b = n_b);?
+  let signed_part = { sm3_bob = msg3.m3_bob; sm3_n_b = msg3.m3_n_b } in
+  guard (verify vk_a (serialize sig_message (SigMsg3 signed_part)) msg3.m3_sg);?
+  Some msg3
+
+[@@"opaque_to_smt"]
+val decode_y: bytes -> bytes -> option bytes
+let decode_y y_enc sk =
+  let? y_plain = pke_dec sk y_enc in
+  let? y_struct = parse userdata y_plain in
+  Some y_struct.data

--- a/examples/BAN_CCITT_X509_3/DY.Example.BAN_CCITT_X509_3.SecurityProperties.fst
+++ b/examples/BAN_CCITT_X509_3/DY.Example.BAN_CCITT_X509_3.SecurityProperties.fst
@@ -1,0 +1,60 @@
+module DY.Example.BAN_CCITT_X509_3.SecurityProperties
+
+open DY.Core
+open DY.Lib
+open DY.Example.BAN_CCITT_X509_3.Protocol.Total
+open DY.Example.BAN_CCITT_X509_3.Protocol.Total.Proof
+open DY.Example.BAN_CCITT_X509_3.Protocol.Stateful
+open DY.Example.BAN_CCITT_X509_3.Protocol.Stateful.Proof
+
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 100 --z3cliopt 'smt.qi.eager_threshold=100'"
+
+(*** Authentication ***)
+
+val authentication_a_to_b:
+  tr:trace -> bob:principal -> alice:principal -> n_b:bytes ->
+  Lemma
+  (requires trace_invariant tr /\ event_triggered tr bob (Respond2 bob alice n_b))
+  (ensures is_corrupt tr (long_term_key_label alice) \/ event_triggered tr alice (Initiate2 alice bob n_b))
+let authentication_a_to_b tr bob alice n_b = ()
+
+val authentication_b_to_a:
+  tr:trace -> alice:principal -> bob:principal -> n_b:bytes ->
+  Lemma
+  (requires trace_invariant tr /\ event_triggered tr alice (Initiate2 alice bob n_b))
+  (ensures is_corrupt tr (long_term_key_label bob) \/ (exists x_b y_b n_a. event_triggered tr bob (Respond1 bob alice n_b x_b y_b n_a)))
+let authentication_b_to_a tr alice bob n_b = ()
+
+(*** Confidentiality ***)
+
+/// If Alice's payload y_a is labeled exactly with the shared secret label
+/// (ban_ccitt_label alice bob) and is later publishable, then either alice
+/// or bob's principal label has been corrupted.
+
+val confidentiality_ya:
+  tr:trace -> alice:principal -> bob:principal -> n_a:bytes -> x_a:bytes -> y_a:bytes ->
+  Lemma
+  (requires
+    trace_invariant tr /\
+    is_secret (ban_ccitt_label alice bob) tr y_a /\
+    is_publishable tr y_a
+  )
+  (ensures
+    is_corrupt tr (principal_label alice) \/
+    is_corrupt tr (principal_label bob)
+  )
+let confidentiality_ya tr alice bob n_a x_a y_a = ()
+
+val confidentiality_yb:
+  tr:trace -> bob:principal -> alice:principal -> n_b:bytes -> x_b:bytes -> y_b:bytes -> n_a:bytes ->
+  Lemma
+  (requires
+    trace_invariant tr /\
+    is_secret (ban_ccitt_label alice bob) tr y_b /\
+    is_publishable tr y_b
+  )
+  (ensures
+    is_corrupt tr (principal_label alice) \/
+    is_corrupt tr (principal_label bob)
+  )
+let confidentiality_yb tr bob alice n_b x_b y_b n_a = ()

--- a/examples/BAN_CCITT_X509_3/Makefile
+++ b/examples/BAN_CCITT_X509_3/Makefile
@@ -1,0 +1,6 @@
+DY_HOME ?= ../..
+include $(DY_HOME)/Makefile
+
+test:
+	cd $(DY_HOME)/obj; $(FSTAR_EXE) --ocamlenv ocamlbuild -use-ocamlfind -pkg batteries -pkg fstar.lib DY_Example_BAN_CCITT_X509_3_Debug.native
+	$(DY_HOME)/obj/DY_Example_BAN_CCITT_X509_3_Debug.native

--- a/examples/BAN_CCITT_X509_3/spec.txt
+++ b/examples/BAN_CCITT_X509_3/spec.txt
@@ -1,0 +1,59 @@
+BAN modified version of CCITT X.509 (3)
+
+Author(s): Michael Burrows and Martin Abadi and Roger Needham 1989
+Last modified January 16, 2003
+
+Summary: Modified version of the three messages protocol in the recommendations
+of the CCITT for the CCITT.X.509 standard (CCITT X.509 (3)). The identity of B
+has been added to the signature in message 3 to prevent the parallel session
+attack from [BAN89]. With this modification, timestamps become redundant and
+are removed.
+
+Protocol specification (in common syntax):
+
+ A, B :    principal
+ Na, Nb :  nonce
+ Ya, Yb :  userdata
+ Xa, Xb :  userdata
+ PK, SK :  principal -> key (keypair)
+
+ 1.   A -> B :   A, {Na, B, Xa, {Ya}PK(B)}SK(A)
+ 2.   B -> A :   B, {Nb, A, Na, Xb, {Yb}PK(A)}SK(B)
+ 3.   A -> B :   A, {B, Nb}SK(A)
+
+Description of the protocol rules:
+
+Compared to CCITT X.509 (3), the identity of B has been added to the signature
+in message 3. This prevents the parallel session attack from [BAN89] on the
+CCITT X.509 (3) protocol, which can occur when B does not check the timestamps.
+With this modification, the timestamps become redundant and can be removed.
+
+In message 1, A sends its identity, a fresh nonce Na, public data Xa, and the
+confidential payload Ya encrypted under B's public key, all signed under A's
+private key.
+
+In message 2, B responds with its identity, a fresh nonce Nb, a challenge Na
+for A, public data Xb, and the confidential payload Yb encrypted under A's
+public key, all signed under B's private key.
+
+In message 3, A closes the handshake by signing B's identity and nonce Nb,
+proving it participated in this specific session with B.
+
+Requirements:
+
+The protocol must ensure the confidentiality of Ya and Yb: if A and B follow
+the protocol, then an attacker should not be able to obtain Ya or Yb.
+
+The protocol must ensure the recipient B of message 1 that the data Xa and Ya
+originate from A (authentication of A to B).
+
+The protocol must ensure the recipient A of message 2 that the data Xb and Yb
+originate from B (authentication of B to A).
+
+References:
+
+[BAN89], [CCI87].
+
+See also:
+
+CCITT X.509 (1), CCITT X.509 (1c), CCITT X.509 (3).

--- a/examples/andrew_rpc/DY.Example.AndrewRPC.Debug.Proof.fst
+++ b/examples/andrew_rpc/DY.Example.AndrewRPC.Debug.Proof.fst
@@ -1,0 +1,51 @@
+module DY.Example.AndrewRPC.Debug.Proof
+
+open Comparse
+open DY.Core
+open DY.Lib
+open DY.Example.AndrewRPC.Protocol.Total
+open DY.Example.AndrewRPC.Protocol.Total.Proof
+open DY.Example.AndrewRPC.Protocol.Stateful
+open DY.Example.AndrewRPC.Protocol.Stateful.Proof
+open DY.Example.AndrewRPC.Debug
+
+#set-options "--fuel 1 --ifuel 2 --z3rlimit 800 --z3cliopt 'smt.qi.eager_threshold=100'"
+
+val debug_proof:
+  tr:trace ->
+  Lemma
+  (requires
+    trace_invariant tr /\
+    has_pki_invariant /\
+    has_private_keys_invariant
+  )
+  (ensures (
+    let (_, tr_out) = debug () tr in
+    trace_invariant tr_out
+  ))
+let debug_proof tr =
+  let alice = "alice" in
+  let bob = "bob" in
+  let (_, tr1) = initialize_pki alice tr in
+  let (_, tr2) = initialize_pki bob tr1 in
+  let (_, tr3) = initialize_private_keys alice tr2 in
+  let (_, tr4) = initialize_private_keys bob tr3 in
+  let kab_usg = AeadKey andrew_rpc_kab_tag (serialize _ {akd_alice = alice; akd_bob = bob}) in
+  let (kab, tr5) = mk_rand kab_usg (andrew_rpc_nonce_label alice bob) 32 tr4 in
+  mk_rand_bytes_invariant kab_usg (andrew_rpc_nonce_label alice bob) 32 tr4;
+  mk_rand_get_label kab_usg (andrew_rpc_nonce_label alice bob) 32 tr4;
+  mk_rand_has_usage kab_usg (andrew_rpc_nonce_label alice bob) 32 tr4;
+  assert(is_kab_for tr5 kab alice bob);
+  alice_send_msg1_proof alice bob tr5;
+  let ((alice_sid, msg1_id), tr6) = alice_send_msg1 alice bob tr5 in
+  bob_recv_msg1_send_msg2_proof bob alice kab msg1_id tr6;
+  match bob_recv_msg1_send_msg2 bob alice kab msg1_id tr6 with
+  | (None, _) -> ()
+  | (Some (bob_sid, msg2_id), tr7) -> (
+    alice_recv_msg2_send_msg3_proof alice bob alice_sid kab msg2_id tr7;
+    match alice_recv_msg2_send_msg3 alice bob alice_sid kab msg2_id tr7 with
+    | (None, _) -> ()
+    | (Some msg3_id, tr8) -> (
+      bob_recv_msg3_send_msg4_proof bob bob_sid msg3_id tr8
+    )
+  )

--- a/examples/andrew_rpc/DY.Example.AndrewRPC.Debug.fst
+++ b/examples/andrew_rpc/DY.Example.AndrewRPC.Debug.fst
@@ -1,0 +1,29 @@
+module DY.Example.AndrewRPC.Debug
+
+open Comparse
+open DY.Core
+open DY.Lib
+open DY.Example.AndrewRPC.Protocol.Total
+open DY.Example.AndrewRPC.Protocol.Stateful
+
+val debug: unit -> traceful (option unit)
+let debug () =
+  let alice = "alice" in
+  let bob = "bob" in
+  let* _ = initialize_pki alice in
+  let* _ = initialize_pki bob in
+  let* _ = initialize_private_keys alice in
+  let* _ = initialize_private_keys bob in
+  let* kab = mk_rand (AeadKey andrew_rpc_kab_tag (serialize _ {akd_alice = alice; akd_bob = bob})) (andrew_rpc_nonce_label alice bob) 32 in
+  let* (alice_sid, msg1_id) = alice_send_msg1 alice bob in
+  let*? (bob_sid, msg2_id) = bob_recv_msg1_send_msg2 bob alice kab msg1_id in
+  let*? msg3_id = alice_recv_msg2_send_msg3 alice bob alice_sid kab msg2_id in
+  let*? msg4_id = bob_recv_msg3_send_msg4 bob bob_sid msg3_id in
+  let* tr = get_trace in
+  let _ = IO.debug_print_string "Andrew RPC trace:\n" in
+  let _ = IO.debug_print_string (trace_to_string default_trace_to_string_printers tr) in
+  return (Some ())
+
+#push-options "--warn_error -272"
+let _ = debug () empty_trace
+#pop-options

--- a/examples/andrew_rpc/DY.Example.AndrewRPC.Protocol.Stateful.Proof.fst
+++ b/examples/andrew_rpc/DY.Example.AndrewRPC.Protocol.Stateful.Proof.fst
@@ -1,0 +1,241 @@
+module DY.Example.AndrewRPC.Protocol.Stateful.Proof
+
+open Comparse
+open DY.Core
+open DY.Lib
+open DY.Example.AndrewRPC.Protocol.Total
+open DY.Example.AndrewRPC.Protocol.Total.Proof
+open DY.Example.AndrewRPC.Protocol.Stateful
+
+#set-options "--fuel 0 --ifuel 0 --z3cliopt 'smt.qi.eager_threshold=100'"
+
+(*** Invariants ***)
+
+#push-options "--ifuel 2 --z3rlimit 50"
+let andrew_rpc_session_pred: local_state_predicate andrew_rpc_session = {
+  pred = (fun tr prin sess_id session ->
+    match session with
+    | InitiatorSentMsg1 bob n_a -> (
+      is_publishable tr n_a /\
+      event_triggered tr prin (Initiate1 prin bob n_a)
+    )
+    | InitiatorReceivedMsg2 bob n_a k_prime_ab -> (
+      is_publishable tr n_a /\
+      event_triggered tr prin (Initiate2 prin bob n_a) /\
+      is_knowable_by (andrew_rpc_nonce_label prin bob) tr k_prime_ab /\
+      (
+        is_publishable tr k_prime_ab \/
+        k_prime_ab `has_usage tr` (AeadKey andrew_rpc_k_prime_ab_tag (serialize _ {askd_alice = prin; askd_bob = bob; askd_n_a = n_a}))
+      )
+    )
+    | ResponderSentMsg2 alice n_a k_prime_ab -> (
+      is_publishable tr n_a /\
+      is_secret (andrew_rpc_session_key_label alice prin n_a) tr k_prime_ab /\
+      k_prime_ab `has_usage tr` (AeadKey andrew_rpc_k_prime_ab_tag (serialize _ {askd_alice = alice; askd_bob = prin; askd_n_a = n_a})) /\
+      event_triggered tr prin (Respond1 alice prin n_a k_prime_ab)
+    )
+    | ResponderReceivedMsg3 alice n_a k_prime_ab -> (
+      is_publishable tr n_a /\
+      is_secret (andrew_rpc_session_key_label alice prin n_a) tr k_prime_ab /\
+      k_prime_ab `has_usage tr` (AeadKey andrew_rpc_k_prime_ab_tag (serialize _ {askd_alice = alice; askd_bob = prin; askd_n_a = n_a})) /\
+      event_triggered tr prin (Respond2 alice prin n_a k_prime_ab)
+    )
+    | ResponderReceivedMsg1 alice n_a -> (
+      is_publishable tr n_a
+    )
+  );
+  pred_later = (fun tr1 tr2 prin sess_id session -> ());
+  pred_knowable = (fun tr prin sess_id session -> ());
+}
+
+let andrew_rpc_event_pred: event_predicate andrew_rpc_event =
+  fun tr prin event ->
+    match event with
+    | Initiate1 alice bob n_a -> (
+      prin == alice /\
+      is_publishable tr n_a
+    )
+    | Respond1 alice bob n_a k_prime_ab -> (
+      prin == bob /\
+      is_publishable tr n_a /\
+      is_secret (andrew_rpc_session_key_label alice bob n_a) tr k_prime_ab /\
+      k_prime_ab `has_usage tr` (AeadKey andrew_rpc_k_prime_ab_tag (serialize _ {askd_alice = alice; askd_bob = bob; askd_n_a = n_a}))
+    )
+    | Initiate2 alice bob n_a -> (
+      prin == alice /\
+      event_triggered tr alice (Initiate1 alice bob n_a) /\
+      (is_corrupt tr (andrew_rpc_nonce_label alice bob) \/ (
+        exists k_prime_ab. event_triggered tr bob (Respond1 alice bob n_a k_prime_ab)
+      ))
+    )
+    | Respond2 alice bob n_a k_prime_ab -> (
+      prin == bob /\
+      event_triggered tr bob (Respond1 alice bob n_a k_prime_ab) /\
+      (is_corrupt tr (andrew_rpc_session_key_label alice bob n_a) \/ (
+        event_triggered tr alice (Initiate2 alice bob n_a)
+      ))
+    )
+#pop-options
+
+let all_sessions = [
+  pki_tag_and_invariant;
+  private_keys_tag_and_invariant;
+  mk_local_state_tag_and_pred andrew_rpc_session_pred;
+]
+
+let all_events = [
+  mk_event_tag_and_pred andrew_rpc_event_pred;
+]
+
+let andrew_rpc_trace_invs: trace_invariants = {
+  state_pred = mk_state_pred all_sessions;
+  event_pred = mk_event_pred all_events;
+}
+
+instance protocol_invariants_andrew_rpc : protocol_invariants = {
+  crypto_invs = crypto_invariants_andrew_rpc;
+  trace_invs = andrew_rpc_trace_invs;
+}
+
+let _ = do_split_boilerplate mk_state_pred_correct all_sessions
+let _ = do_split_boilerplate mk_event_pred_correct all_events
+
+(*** Helper predicates ***)
+
+val is_kab_for: trace -> bytes -> principal -> principal -> prop
+let is_kab_for tr kab alice bob =
+  kab `has_usage tr` (AeadKey andrew_rpc_kab_tag (serialize _ {akd_alice = alice; akd_bob = bob})) /\
+  is_secret (andrew_rpc_nonce_label alice bob) tr kab
+
+(*** Proofs ***)
+
+#push-options "--z3rlimit 50"
+val alice_send_msg1_proof:
+  alice:principal -> bob:principal -> tr:trace ->
+  Lemma
+  (requires trace_invariant tr)
+  (ensures (
+    let ((sid, msg_id), tr_out) = alice_send_msg1 alice bob tr in
+    trace_invariant tr_out
+  ))
+  [SMTPat (trace_invariant tr); SMTPat (alice_send_msg1 alice bob tr)]
+let alice_send_msg1_proof alice bob tr =
+  reveal_opaque (`%alice_send_msg1) (alice_send_msg1 alice bob tr);
+  let (sid, tr0) = new_session_id alice tr in
+  let (n_a, tr1) = mk_rand NoUsage public 32 tr0 in
+  let ((), tr2) = trigger_event alice (Initiate1 alice bob n_a) tr1 in
+  let ((), tr3) = set_state alice sid (InitiatorSentMsg1 bob n_a) tr2 in
+  compute_message1_proof tr3 alice n_a;
+  ()
+#pop-options
+
+#push-options "--z3rlimit 100 --split_queries always"
+val bob_recv_msg1_send_msg2_proof:
+  bob:principal -> alice:principal -> kab:bytes -> msg1_id:nat -> tr:trace ->
+  Lemma
+  (requires
+    trace_invariant tr /\
+    is_kab_for tr kab alice bob
+  )
+  (ensures (
+    let (opt_res, tr_out) = bob_recv_msg1_send_msg2 bob alice kab msg1_id tr in
+    trace_invariant tr_out
+  ))
+  [SMTPat (trace_invariant tr); SMTPat (bob_recv_msg1_send_msg2 bob alice kab msg1_id tr); SMTPat (is_kab_for tr kab alice bob)]
+let bob_recv_msg1_send_msg2_proof bob alice kab msg1_id tr =
+  reveal_opaque (`%bob_recv_msg1_send_msg2) (bob_recv_msg1_send_msg2 bob alice kab msg1_id tr);
+  match recv_msg msg1_id tr with
+  | (None, _) -> ()
+  | (Some msg1_bytes, tr0) -> (
+    decode_message1_proof tr0 msg1_bytes;
+    match decode_message1 msg1_bytes with
+    | None -> ()
+    | Some (alice_recv, n_a) -> (
+      if alice = alice_recv then (
+        let (sid, tr1) = new_session_id bob tr0 in
+        let (k_prime_ab, tr2) = mk_rand (AeadKey andrew_rpc_k_prime_ab_tag (serialize _ {askd_alice = alice; askd_bob = bob; askd_n_a = n_a})) (andrew_rpc_session_key_label alice bob n_a) 32 tr1 in
+        let (nonce, tr3) = mk_rand NoUsage public 12 tr2 in
+        let ((), tr4) = trigger_event bob (Respond1 alice bob n_a k_prime_ab) tr3 in
+        let ((), tr5) = set_state bob sid (ResponderSentMsg2 alice n_a k_prime_ab) tr4 in
+        compute_message2_proof tr5 alice bob kab n_a k_prime_ab nonce;
+        ()
+      ) else ()
+    )
+  )
+#pop-options
+
+#push-options "--z3rlimit 400 --ifuel 2"
+val alice_recv_msg2_send_msg3_proof:
+  alice:principal -> bob:principal -> sid:state_id -> kab:bytes -> msg2_id:nat -> tr:trace ->
+  Lemma
+  (requires
+    trace_invariant tr /\
+    is_kab_for tr kab alice bob
+  )
+  (ensures (
+    let (opt_res, tr_out) = alice_recv_msg2_send_msg3 alice bob sid kab msg2_id tr in
+    trace_invariant tr_out
+  ))
+  [SMTPat (trace_invariant tr); SMTPat (alice_recv_msg2_send_msg3 alice bob sid kab msg2_id tr); SMTPat (is_kab_for tr kab alice bob)]
+let alice_recv_msg2_send_msg3_proof alice bob sid kab msg2_id tr =
+  reveal_opaque (`%alice_recv_msg2_send_msg3) (alice_recv_msg2_send_msg3 alice bob sid kab msg2_id tr);
+  match get_state alice sid tr with
+  | (Some (InitiatorSentMsg1 bob_sess n_a), tr) -> (
+    if bob_sess = bob then (
+      match recv_msg msg2_id tr with
+      | (Some msg2_bytes, tr) -> (
+        decode_message2_proof tr alice bob kab msg2_bytes;
+        match decode_message2 kab msg2_bytes with
+        | Some msg2 -> (
+          if msg2.m2_n_a = n_a && msg2.m2_bob = bob then (
+            let ((), tr_a) = trigger_event alice (Initiate2 alice bob n_a) tr in
+            let ((), tr_b) = set_state alice sid (InitiatorReceivedMsg2 bob n_a msg2.m2_k_prime_ab) tr_a in
+            let (nonce3, tr_c) = mk_rand NoUsage public 12 tr_b in
+            mk_rand_bytes_invariant NoUsage public 12 tr_b;
+            mk_rand_get_label NoUsage public 12 tr_b;
+            compute_message3_proof tr_c alice bob n_a msg2.m2_k_prime_ab nonce3
+          ) else ()
+        )
+        | None -> ()
+      )
+      | (None, _) -> ()
+    ) else ()
+  )
+  | _ -> ()
+#pop-options
+
+#push-options "--z3rlimit 400 --ifuel 2 --split_queries always"
+val bob_recv_msg3_send_msg4_proof:
+  bob:principal -> sid:state_id -> msg3_id:nat -> tr:trace ->
+  Lemma
+  (requires trace_invariant tr)
+  (ensures (
+    let (opt_res, tr_out) = bob_recv_msg3_send_msg4 bob sid msg3_id tr in
+    trace_invariant tr_out
+  ))
+  [SMTPat (trace_invariant tr); SMTPat (bob_recv_msg3_send_msg4 bob sid msg3_id tr)]
+let bob_recv_msg3_send_msg4_proof bob sid msg3_id tr =
+  reveal_opaque (`%bob_recv_msg3_send_msg4) (bob_recv_msg3_send_msg4 bob sid msg3_id tr);
+  match get_state bob sid tr with
+  | (Some (ResponderSentMsg2 alice n_a k_prime_ab), tr) -> (
+    match recv_msg msg3_id tr with
+    | (Some msg3_bytes, tr) -> (
+      decode_message3_proof tr alice bob n_a k_prime_ab msg3_bytes;
+      match decode_message3 k_prime_ab msg3_bytes with
+      | Some msg3 -> (
+        if msg3.m3_n_a = n_a then (
+          let ((), tr_e) = trigger_event bob (Respond2 alice bob n_a k_prime_ab) tr in
+          let ((), tr_s) = set_state bob sid (ResponderReceivedMsg3 alice n_a k_prime_ab) tr_e in
+          let (n_b, tr_r) = mk_rand NoUsage public 32 tr_s in
+          mk_rand_bytes_invariant NoUsage public 32 tr_s;
+          mk_rand_get_label NoUsage public 32 tr_s;
+          assert(is_publishable tr_r n_b);
+          compute_message4_proof tr_r n_b
+        ) else ()
+      )
+      | None -> ()
+    )
+    | (None, _) -> ()
+  )
+  | _ -> ()
+#pop-options

--- a/examples/andrew_rpc/DY.Example.AndrewRPC.Protocol.Stateful.fst
+++ b/examples/andrew_rpc/DY.Example.AndrewRPC.Protocol.Stateful.fst
@@ -1,0 +1,126 @@
+module DY.Example.AndrewRPC.Protocol.Stateful
+
+open Comparse
+open DY.Core
+open DY.Lib
+open DY.Example.AndrewRPC.Protocol.Total
+
+(*** Definition of state ***)
+
+[@@ with_bytes bytes]
+type andrew_rpc_session =
+  | InitiatorSentMsg1: bob:principal -> n_a:bytes -> andrew_rpc_session
+  | InitiatorReceivedMsg2: bob:principal -> n_a:bytes -> k_prime_ab:bytes -> andrew_rpc_session
+  | ResponderReceivedMsg1: alice:principal -> n_a:bytes -> andrew_rpc_session
+  | ResponderSentMsg2: alice:principal -> n_a:bytes -> k_prime_ab:bytes -> andrew_rpc_session
+  | ResponderReceivedMsg3: alice:principal -> n_a:bytes -> k_prime_ab:bytes -> andrew_rpc_session
+
+%splice [ps_andrew_rpc_session] (gen_parser (`andrew_rpc_session))
+%splice [ps_andrew_rpc_session_is_well_formed] (gen_is_well_formed_lemma (`andrew_rpc_session))
+
+instance andrew_rpc_session_parseable_serializeable: parseable_serializeable bytes andrew_rpc_session
+ = mk_parseable_serializeable ps_andrew_rpc_session
+
+(*** Definition of events ***)
+[@@ with_bytes bytes]
+type andrew_rpc_event =
+  | Initiate1: alice:principal -> bob:principal -> n_a:bytes -> andrew_rpc_event
+  | Respond1: alice:principal -> bob:principal -> n_a:bytes -> k_prime_ab:bytes -> andrew_rpc_event
+  | Initiate2: alice:principal -> bob:principal -> n_a:bytes -> andrew_rpc_event
+  | Respond2: alice:principal -> bob:principal -> n_a:bytes -> k_prime_ab:bytes -> andrew_rpc_event
+
+%splice [ps_andrew_rpc_event] (gen_parser (`andrew_rpc_event))
+
+instance andrew_rpc_event_instance: event andrew_rpc_event = {
+  tag = "AndrewRPC.Event";
+  format = mk_parseable_serializeable ps_andrew_rpc_event;
+}
+
+(*** Setup for the stateful code ***)
+
+instance local_state_andrew_rpc_session: local_state andrew_rpc_session = {
+  tag = "AndrewRPC.Session";
+  format = mk_parseable_serializeable ps_andrew_rpc_session;
+}
+
+val andrew_rpc_kab_tag: string
+let andrew_rpc_kab_tag = "AndrewRPC.Kab"
+
+val andrew_rpc_k_prime_ab_tag: string
+let andrew_rpc_k_prime_ab_tag = "AndrewRPC.K_prime_ab"
+
+(*** Labels used to generate randomness ***)
+
+val andrew_rpc_nonce_label: principal -> principal -> label
+let andrew_rpc_nonce_label alice bob =
+  join (principal_label alice) (principal_label bob)
+
+val andrew_rpc_session_key_label: principal -> principal -> bytes -> label
+let andrew_rpc_session_key_label alice bob n_a =
+  join (principal_label alice) (principal_label bob)
+
+(*** Stateful code ***)
+
+// Alice initiates the protocol
+[@@ "opaque_to_smt"]
+val alice_send_msg1: principal -> principal -> traceful (state_id & nat)
+let alice_send_msg1 alice bob =
+  let* sid = new_session_id alice in
+  let* n_a = mk_rand NoUsage public 32 in
+  trigger_event alice (Initiate1 alice bob n_a);*
+  set_state alice sid (InitiatorSentMsg1 bob n_a);*
+  let msg = compute_message1 alice n_a in
+  let* msg_id = send_msg msg in
+  return (sid, msg_id)
+
+// Bob receives msg1 and sends msg2
+[@@ "opaque_to_smt"]
+val bob_recv_msg1_send_msg2: principal -> principal -> bytes -> nat -> traceful (option (state_id & nat))
+let bob_recv_msg1_send_msg2 bob alice kab msg1_id =
+  let*? msg1_bytes = recv_msg msg1_id in
+  let*? (alice_recv, n_a) = return (decode_message1 msg1_bytes) in
+  guard_tr (alice = alice_recv);*?
+  let* sid = new_session_id bob in
+  let* k_prime_ab = mk_rand (AeadKey andrew_rpc_k_prime_ab_tag (serialize _ {askd_alice = alice; askd_bob = bob; askd_n_a = n_a})) (andrew_rpc_session_key_label alice bob n_a) 32 in
+  let* nonce = mk_rand NoUsage public 12 in
+  trigger_event bob (Respond1 alice bob n_a k_prime_ab);*
+  set_state bob sid (ResponderSentMsg2 alice n_a k_prime_ab);*
+  let msg2 = compute_message2 kab n_a k_prime_ab nonce bob in
+  let* msg2_id = send_msg msg2 in
+  return (Some (sid, msg2_id))
+
+// Alice receives msg2 and sends msg3
+[@@ "opaque_to_smt"]
+val alice_recv_msg2_send_msg3: principal -> principal -> state_id -> bytes -> nat -> traceful (option nat)
+let alice_recv_msg2_send_msg3 alice bob sid kab msg2_id =
+  let*? session = get_state alice sid in
+  guard_tr (InitiatorSentMsg1? session);*?
+  let InitiatorSentMsg1 bob_sess n_a = session in
+  guard_tr (bob_sess = bob);*?
+  let*? msg2_bytes = recv_msg msg2_id in
+  let*? msg2 = return (decode_message2 kab msg2_bytes) in
+  guard_tr (msg2.m2_n_a = n_a);*?
+  guard_tr (msg2.m2_bob = bob);*?
+  trigger_event alice (Initiate2 alice bob n_a);*
+  set_state alice sid (InitiatorReceivedMsg2 bob n_a msg2.m2_k_prime_ab);*
+  let* nonce3 = mk_rand NoUsage public 12 in
+  let msg3 = compute_message3 msg2.m2_k_prime_ab n_a nonce3 in
+  let* msg3_id = send_msg msg3 in
+  return (Some msg3_id)
+
+// Bob receives msg3 and sends msg4
+[@@ "opaque_to_smt"]
+val bob_recv_msg3_send_msg4: principal -> state_id -> nat -> traceful (option nat)
+let bob_recv_msg3_send_msg4 bob sid msg3_id =
+  let*? session = get_state bob sid in
+  guard_tr (ResponderSentMsg2? session);*?
+  let ResponderSentMsg2 alice n_a k_prime_ab = session in
+  let*? msg3_bytes = recv_msg msg3_id in
+  let*? msg3 = return (decode_message3 k_prime_ab msg3_bytes) in
+  guard_tr (msg3.m3_n_a = n_a);*?
+  trigger_event bob (Respond2 alice bob n_a k_prime_ab);*
+  set_state bob sid (ResponderReceivedMsg3 alice n_a k_prime_ab);*
+  let* n_b = mk_rand NoUsage public 32 in
+  let msg4 = compute_message4 n_b in
+  let* msg4_id = send_msg msg4 in
+  return (Some msg4_id)

--- a/examples/andrew_rpc/DY.Example.AndrewRPC.Protocol.Total.Proof.fst
+++ b/examples/andrew_rpc/DY.Example.AndrewRPC.Protocol.Total.Proof.fst
@@ -1,0 +1,274 @@
+module DY.Example.AndrewRPC.Protocol.Total.Proof
+
+open Comparse
+open DY.Core
+open DY.Lib
+open DY.Example.AndrewRPC.Protocol.Total
+open DY.Example.AndrewRPC.Protocol.Stateful
+
+#set-options "--fuel 0 --ifuel 0 --z3cliopt 'smt.qi.eager_threshold=100'"
+
+(*** Cryptographic invariants ***)
+
+instance crypto_usages_andrew_rpc : crypto_usages = default_crypto_usages
+
+#push-options "--ifuel 2 --fuel 0"
+val crypto_predicates_andrew_rpc: crypto_predicates
+let crypto_predicates_andrew_rpc = {
+  default_crypto_predicates with
+
+  aead_pred = {
+    pred = (fun tr key_usage key nonce msg ad ->
+      match key_usage with
+      | AeadKey tag data -> (
+        if tag = andrew_rpc_kab_tag then (
+          match parse andrew_rpc_key_data data with
+          | Some {akd_alice = alice; akd_bob = bob} -> (
+            match parse message msg with
+            | Some (Msg2 msg2) -> (
+              msg2.m2_bob == bob /\
+              event_triggered tr bob (Respond1 alice bob msg2.m2_n_a msg2.m2_k_prime_ab) /\
+              msg2.m2_k_prime_ab `has_usage tr` (AeadKey andrew_rpc_k_prime_ab_tag (serialize _ {askd_alice = alice; askd_bob = bob; askd_n_a = msg2.m2_n_a}))
+            )
+            | _ -> False
+          )
+          | _ -> False
+        ) else if tag = andrew_rpc_k_prime_ab_tag then (
+          match parse andrew_rpc_session_key_data data with
+          | Some {askd_alice = alice; askd_bob = bob; askd_n_a = n_a} -> (
+            match parse message msg with
+            | Some (Msg3 msg3) -> (
+              msg3.m3_n_a == n_a /\
+              event_triggered tr alice (Initiate2 alice bob n_a)
+            )
+            | _ -> False
+          )
+          | _ -> False
+        ) else False
+      )
+      | _ -> False
+    );
+    pred_later = (fun tr1 tr2 key_usage key nonce msg ad ->
+      parse_wf_lemma message (bytes_well_formed tr1) msg
+    );
+  };
+}
+#pop-options
+
+instance crypto_invariants_andrew_rpc : crypto_invariants = {
+  usages = crypto_usages_andrew_rpc;
+  preds = crypto_predicates_andrew_rpc;
+}
+
+(*** Proofs ***)
+
+#push-options "--z3rlimit 25"
+val compute_message1_proof:
+  tr:trace ->
+  alice:principal -> n_a:bytes ->
+  Lemma
+  (requires
+    is_publishable tr n_a
+  )
+  (ensures is_publishable tr (compute_message1 alice n_a))
+let compute_message1_proof tr alice n_a =
+  reveal_opaque (`%compute_message1) (compute_message1 alice n_a);
+  let msg = Msg1 alice n_a in
+  serialize_wf_lemma message (is_publishable tr) msg
+#pop-options
+
+#push-options "--ifuel 1 --fuel 0 --z3rlimit 25"
+val decode_message1_proof:
+  tr:trace ->
+  msg_bytes:bytes ->
+  Lemma
+  (requires
+    is_publishable tr msg_bytes
+  )
+  (ensures (
+    match decode_message1 msg_bytes with
+    | None -> True
+    | Some (alice, n_a) -> (
+      is_publishable tr n_a
+    )
+  ))
+let decode_message1_proof tr msg_bytes =
+  reveal_opaque (`%decode_message1) (decode_message1 msg_bytes);
+  match decode_message1 msg_bytes with
+  | None -> ()
+  | Some (alice, n_a) ->
+    parse_wf_lemma message (is_publishable tr) msg_bytes
+#pop-options
+
+#push-options "--z3rlimit 50"
+val compute_message2_proof:
+  tr:trace ->
+  alice:principal -> bob:principal -> kab:bytes -> n_a:bytes -> k_prime_ab:bytes -> nonce:bytes ->
+  Lemma
+  (requires
+    kab `has_usage tr` (AeadKey andrew_rpc_kab_tag (serialize _ {akd_alice = alice; akd_bob = bob})) /\
+    is_secret (andrew_rpc_nonce_label alice bob) tr kab /\
+    is_publishable tr n_a /\
+    is_knowable_by (andrew_rpc_nonce_label alice bob) tr k_prime_ab /\
+    k_prime_ab `has_usage tr` (AeadKey andrew_rpc_k_prime_ab_tag (serialize _ {askd_alice = alice; askd_bob = bob; askd_n_a = n_a})) /\
+    is_publishable tr nonce /\
+    event_triggered tr bob (Respond1 alice bob n_a k_prime_ab)
+  )
+  (ensures is_publishable tr (compute_message2 kab n_a k_prime_ab nonce bob))
+let compute_message2_proof tr alice bob kab n_a k_prime_ab nonce =
+  reveal_opaque (`%compute_message2) (compute_message2 kab n_a k_prime_ab nonce bob);
+  let msg2_struct = {m2_n_a = n_a; m2_k_prime_ab = k_prime_ab; m2_bob = bob} in
+  let msg = Msg2 msg2_struct in
+  // The plaintext serialized message is knowable by kab's label
+  serialize_wf_lemma message (is_knowable_by (andrew_rpc_nonce_label alice bob) tr) msg;
+  let plain_bytes = serialize message msg in
+  // Show we are in the AEAD-pred branch (kab honest with the right tag)
+  let key_usg = AeadKey andrew_rpc_kab_tag (serialize _ {akd_alice = alice; akd_bob = bob}) in
+  // The serialize/parse round-trip on the key data
+  parse_serialize_inv_lemma #bytes andrew_rpc_key_data ({akd_alice = alice; akd_bob = bob});
+  // The serialize/parse round-trip on the message
+  parse_serialize_inv_lemma #bytes message msg;
+  // Encryption result is publishable (label is public always); bytes_invariant follows from aead_pred
+  let ciphertext = aead_enc kab nonce plain_bytes empty in
+  assert(get_label tr ciphertext == public);
+  ()
+#pop-options
+
+#push-options "--ifuel 1 --fuel 0 --z3rlimit 50"
+val decode_message2_proof:
+  tr:trace ->
+  alice:principal -> bob:principal -> kab:bytes -> msg2_with_nonce:bytes ->
+  Lemma
+  (requires
+    kab `has_usage tr` (AeadKey andrew_rpc_kab_tag (serialize _ {akd_alice = alice; akd_bob = bob})) /\
+    is_secret (andrew_rpc_nonce_label alice bob) tr kab /\
+    is_publishable tr msg2_with_nonce
+  )
+  (ensures (
+    match decode_message2 kab msg2_with_nonce with
+    | None -> True
+    | Some msg2 -> (
+      is_knowable_by (andrew_rpc_nonce_label alice bob) tr msg2.m2_k_prime_ab /\ (
+        (is_corrupt tr (andrew_rpc_nonce_label alice bob)) \/ (
+          msg2.m2_bob == bob /\
+          event_triggered tr bob (Respond1 alice bob msg2.m2_n_a msg2.m2_k_prime_ab) /\
+          msg2.m2_k_prime_ab `has_usage tr` (AeadKey andrew_rpc_k_prime_ab_tag (serialize _ {askd_alice = alice; askd_bob = bob; askd_n_a = msg2.m2_n_a}))
+        )
+      )
+    )
+  ))
+let decode_message2_proof tr alice bob kab msg2_with_nonce =
+  reveal_opaque (`%decode_message2) (decode_message2 kab msg2_with_nonce);
+  match decode_message2 kab msg2_with_nonce with
+  | None -> ()
+  | Some msg2 ->
+    let Some (nonce, ciphertext) = split msg2_with_nonce 12 in
+    let ad = empty in
+    let Some msg_bytes = aead_dec kab nonce ciphertext ad in
+    parse_serialize_inv_lemma #bytes andrew_rpc_key_data ({akd_alice = alice; akd_bob = bob});
+    parse_wf_lemma message (is_knowable_by (andrew_rpc_nonce_label alice bob) tr) msg_bytes;
+    FStar.Classical.move_requires (parse_wf_lemma message (is_publishable tr)) msg_bytes;
+    FStar.Classical.move_requires (parse_wf_lemma message (bytes_invariant tr)) msg_bytes
+#pop-options
+
+#push-options "--z3rlimit 50 --ifuel 1"
+val compute_message3_proof:
+  tr:trace ->
+  alice:principal -> bob:principal -> n_a:bytes -> k_prime_ab:bytes -> nonce:bytes ->
+  Lemma
+  (requires
+    bytes_invariant tr k_prime_ab /\
+    is_publishable tr nonce /\
+    is_publishable tr n_a /\
+    (
+      is_publishable tr k_prime_ab \/
+      (
+        k_prime_ab `has_usage tr` (AeadKey andrew_rpc_k_prime_ab_tag (serialize _ {askd_alice = alice; askd_bob = bob; askd_n_a = n_a})) /\
+        event_triggered tr alice (Initiate2 alice bob n_a)
+      )
+    )
+  )
+  (ensures is_publishable tr (compute_message3 k_prime_ab n_a nonce))
+let compute_message3_proof tr alice bob n_a k_prime_ab nonce =
+  reveal_opaque (`%compute_message3) (compute_message3 k_prime_ab n_a nonce);
+  let msg3_struct = {m3_n_a = n_a} in
+  let msg = Msg3 msg3_struct in
+  serialize_wf_lemma message (is_publishable tr) msg;
+  let plain_bytes = serialize message msg in
+  parse_serialize_inv_lemma #bytes andrew_rpc_session_key_data ({askd_alice = alice; askd_bob = bob; askd_n_a = n_a});
+  parse_serialize_inv_lemma #bytes message msg;
+  FStar.Classical.move_requires (aead_enc_preserves_publishability tr k_prime_ab nonce plain_bytes) empty;
+  let ciphertext = aead_enc k_prime_ab nonce plain_bytes empty in
+  assert(get_label tr ciphertext == public)
+#pop-options
+
+#push-options "--ifuel 1 --fuel 0 --z3rlimit 50"
+val decode_message3_proof:
+  tr:trace ->
+  alice:principal -> bob:principal -> n_a:bytes -> k_prime_ab:bytes -> msg3_with_nonce:bytes ->
+  Lemma
+  (requires
+    k_prime_ab `has_usage tr` (AeadKey andrew_rpc_k_prime_ab_tag (serialize _ {askd_alice = alice; askd_bob = bob; askd_n_a = n_a})) /\
+    is_secret (andrew_rpc_session_key_label alice bob n_a) tr k_prime_ab /\
+    is_publishable tr msg3_with_nonce
+  )
+  (ensures (
+    match decode_message3 k_prime_ab msg3_with_nonce with
+    | None -> True
+    | Some msg3 -> (
+      (is_corrupt tr (andrew_rpc_session_key_label alice bob n_a)) \/ (
+        msg3.m3_n_a == n_a /\
+        event_triggered tr alice (Initiate2 alice bob n_a)
+      )
+    )
+  ))
+let decode_message3_proof tr alice bob n_a k_prime_ab msg3_with_nonce =
+  reveal_opaque (`%decode_message3) (decode_message3 k_prime_ab msg3_with_nonce);
+  match decode_message3 k_prime_ab msg3_with_nonce with
+  | None -> ()
+  | Some msg3 ->
+    let Some (nonce, ciphertext) = split msg3_with_nonce 12 in
+    let ad = empty in
+    let Some msg_bytes = aead_dec k_prime_ab nonce ciphertext ad in
+    parse_serialize_inv_lemma #bytes andrew_rpc_session_key_data ({askd_alice = alice; askd_bob = bob; askd_n_a = n_a});
+    FStar.Classical.move_requires (parse_wf_lemma message (is_publishable tr)) msg_bytes;
+    FStar.Classical.move_requires (parse_wf_lemma message (bytes_invariant tr)) msg_bytes
+#pop-options
+
+#push-options "--z3rlimit 25"
+val compute_message4_proof:
+  tr:trace ->
+  n_b:bytes ->
+  Lemma
+  (requires
+    is_publishable tr n_b
+  )
+  (ensures is_publishable tr (compute_message4 n_b))
+let compute_message4_proof tr n_b =
+  reveal_opaque (`%compute_message4) (compute_message4 n_b);
+  let msg = Msg4 n_b in
+  serialize_wf_lemma message (is_publishable tr) msg
+#pop-options
+
+#push-options "--ifuel 1 --fuel 0 --z3rlimit 25"
+val decode_message4_proof:
+  tr:trace ->
+  msg_bytes:bytes ->
+  Lemma
+  (requires
+    is_publishable tr msg_bytes
+  )
+  (ensures (
+    match decode_message4 msg_bytes with
+    | None -> True
+    | Some n_b -> (
+      is_publishable tr n_b
+    )
+  ))
+let decode_message4_proof tr msg_bytes =
+  reveal_opaque (`%decode_message4) (decode_message4 msg_bytes);
+  match decode_message4 msg_bytes with
+  | None -> ()
+  | Some n_b ->
+    parse_wf_lemma message (is_publishable tr) msg_bytes
+#pop-options

--- a/examples/andrew_rpc/DY.Example.AndrewRPC.Protocol.Total.fst
+++ b/examples/andrew_rpc/DY.Example.AndrewRPC.Protocol.Total.fst
@@ -1,0 +1,124 @@
+module DY.Example.AndrewRPC.Protocol.Total
+
+open Comparse
+open DY.Core
+open DY.Lib
+
+[@@ with_bytes bytes]
+type andrew_rpc_key_data = {
+  akd_alice: principal;
+  akd_bob: principal;
+}
+
+%splice [ps_andrew_rpc_key_data] (gen_parser (`andrew_rpc_key_data))
+%splice [ps_andrew_rpc_key_data_is_well_formed] (gen_is_well_formed_lemma (`andrew_rpc_key_data))
+
+instance parseable_serializeable_andrew_rpc_key_data: parseable_serializeable bytes andrew_rpc_key_data = mk_parseable_serializeable ps_andrew_rpc_key_data
+
+[@@ with_bytes bytes]
+type andrew_rpc_session_key_data = {
+  askd_alice: principal;
+  askd_bob: principal;
+  askd_n_a: bytes;
+}
+
+%splice [ps_andrew_rpc_session_key_data] (gen_parser (`andrew_rpc_session_key_data))
+%splice [ps_andrew_rpc_session_key_data_is_well_formed] (gen_is_well_formed_lemma (`andrew_rpc_session_key_data))
+
+instance parseable_serializeable_andrew_rpc_session_key_data: parseable_serializeable bytes andrew_rpc_session_key_data = mk_parseable_serializeable ps_andrew_rpc_session_key_data
+
+[@@ with_bytes bytes]
+type message2 = {
+  m2_n_a: bytes;
+  m2_k_prime_ab: bytes;
+  m2_bob: principal;
+}
+
+%splice [ps_message2] (gen_parser (`message2))
+%splice [ps_message2_is_well_formed] (gen_is_well_formed_lemma (`message2))
+
+[@@ with_bytes bytes]
+type message3 = {
+  m3_n_a: bytes;
+}
+
+%splice [ps_message3] (gen_parser (`message3))
+%splice [ps_message3_is_well_formed] (gen_is_well_formed_lemma (`message3))
+
+[@@ with_bytes bytes]
+type message =
+  | Msg1: alice:principal -> n_a:bytes -> message
+  | Msg2: message2 -> message
+  | Msg3: message3 -> message
+  | Msg4: n_b:bytes -> message
+
+%splice [ps_message] (gen_parser (`message))
+%splice [ps_message_is_well_formed] (gen_is_well_formed_lemma (`message))
+
+instance parseable_serializeable_message: parseable_serializeable bytes message = mk_parseable_serializeable ps_message
+
+(*** Message 1 ***)
+[@@ "opaque_to_smt"]
+val compute_message1: principal -> bytes -> bytes
+let compute_message1 alice n_a =
+  serialize message (Msg1 alice n_a)
+
+[@@ "opaque_to_smt"]
+val decode_message1: bytes -> option (principal & bytes)
+let decode_message1 msg_bytes =
+  let? msg = parse message msg_bytes in
+  guard (Msg1? msg);?
+  let Msg1 alice n_a = msg in
+  Some (alice, n_a)
+
+(*** Message 2 ***)
+[@@ "opaque_to_smt"]
+val compute_message2: bytes -> bytes -> bytes -> bytes -> principal -> bytes
+let compute_message2 kab n_a k_prime_ab nonce bob =
+  let msg2 = Msg2 {m2_n_a = n_a; m2_k_prime_ab = k_prime_ab; m2_bob = bob} in
+  let ad = empty in
+  let ciphertext = aead_enc kab nonce (serialize message msg2) ad in
+  concat nonce ciphertext
+
+[@@ "opaque_to_smt"]
+val decode_message2: bytes -> bytes -> option message2
+let decode_message2 kab msg2_with_nonce =
+  let? (nonce, ciphertext) = split msg2_with_nonce 12 in
+  let ad = empty in
+  let? msg_bytes = aead_dec kab nonce ciphertext ad in
+  let? msg = parse message msg_bytes in
+  guard (Msg2? msg);?
+  Some (Msg2?._0 msg)
+
+(*** Message 3 ***)
+[@@ "opaque_to_smt"]
+val compute_message3: bytes -> bytes -> bytes -> bytes
+let compute_message3 k_prime_ab n_a nonce =
+  let msg3 = Msg3 {m3_n_a = n_a} in
+  let ad = empty in
+  let ciphertext = aead_enc k_prime_ab nonce (serialize message msg3) ad in
+  concat nonce ciphertext
+
+[@@ "opaque_to_smt"]
+val decode_message3: bytes -> bytes -> option message3
+let decode_message3 k_prime_ab msg3_with_nonce =
+  let? (nonce, ciphertext) = split msg3_with_nonce 12 in
+  let ad = empty in
+  let? msg_bytes = aead_dec k_prime_ab nonce ciphertext ad in
+  let? msg = parse message msg_bytes in
+  guard (Msg3? msg);?
+  Some (Msg3?._0 msg)
+
+(*** Message 4 ***)
+[@@ "opaque_to_smt"]
+val compute_message4: bytes -> bytes
+let compute_message4 n_b =
+  serialize message (Msg4 n_b)
+
+[@@ "opaque_to_smt"]
+val decode_message4: bytes -> option bytes
+let decode_message4 msg_bytes =
+  let? msg = parse message msg_bytes in
+  guard (Msg4? msg);?
+  let Msg4 n_b = msg in
+  Some n_b

--- a/examples/andrew_rpc/DY.Example.AndrewRPC.SecurityProperties.fst
+++ b/examples/andrew_rpc/DY.Example.AndrewRPC.SecurityProperties.fst
@@ -1,0 +1,35 @@
+module DY.Example.AndrewRPC.SecurityProperties
+
+open Comparse
+open DY.Core
+open DY.Lib
+open DY.Example.AndrewRPC.Protocol.Total
+open DY.Example.AndrewRPC.Protocol.Total.Proof
+open DY.Example.AndrewRPC.Protocol.Stateful
+open DY.Example.AndrewRPC.Protocol.Stateful.Proof
+
+#set-options "--fuel 0 --ifuel 0 --z3rlimit 50 --z3cliopt 'smt.qi.eager_threshold=100'"
+
+val secrecy_of_k_prime_ab:
+  tr:trace -> alice:principal -> bob:principal -> n_a:bytes -> k_prime_ab:bytes ->
+  Lemma
+  (requires
+    trace_invariant tr /\
+    event_triggered tr bob (Respond1 alice bob n_a k_prime_ab) /\
+    ~(is_corrupt tr (andrew_rpc_session_key_label alice bob n_a))
+  )
+  (ensures ~(attacker_knows tr k_prime_ab))
+let secrecy_of_k_prime_ab tr alice bob n_a k_prime_ab =
+  FStar.Classical.move_requires (attacker_only_knows_publishable_values tr) k_prime_ab
+
+val authenticity_of_k_prime_ab:
+  tr:trace -> alice:principal -> bob:principal -> n_a:bytes -> k_prime_ab:bytes ->
+  Lemma
+  (requires
+    trace_invariant tr /\
+    event_triggered tr bob (Respond2 alice bob n_a k_prime_ab) /\
+    ~(is_corrupt tr (andrew_rpc_session_key_label alice bob n_a))
+  )
+  (ensures event_triggered tr alice (Initiate2 alice bob n_a))
+let authenticity_of_k_prime_ab tr alice bob n_a k_prime_ab =
+  ()

--- a/examples/andrew_rpc/Makefile
+++ b/examples/andrew_rpc/Makefile
@@ -1,0 +1,6 @@
+DY_HOME ?= ../..
+include $(DY_HOME)/Makefile
+
+test:
+	cd $(DY_HOME)/obj; $(FSTAR_EXE) --ocamlenv ocamlbuild -use-ocamlfind -pkg batteries -pkg fstar.lib DY_Example_AndrewRPC_Debug.native
+	$(DY_HOME)/obj/DY_Example_AndrewRPC_Debug.native

--- a/examples/andrew_rpc/spec.txt
+++ b/examples/andrew_rpc/spec.txt
@@ -1,0 +1,58 @@
+Lowe modified BAN concrete Andrew Secure RPC
+
+Author(s): Gavin Lowe 1996
+Last modified November 14, 2002
+
+Summary: A modified version of the BAN concrete Andrew Secure RPC protocol
+preventing a parallel session attack. Establishes a fresh shared symmetric key
+K'ab. Symmetric key cryptography.
+
+Protocol specification (in common syntax):
+
+ A, B :      principal
+ Kab, K'ab : symkey
+ Na, Nb :    nonce
+
+ 1.   A -> B :   A, Na
+ 2.   B -> A :   {Na, K'ab, B}Kab
+ 3.   A -> B :   {Na}K'ab
+ 4.   B -> A :   Nb
+
+Description of the protocol rules:
+
+This protocol establishes the fresh shared symmetric key K'ab between A and B.
+
+We assume that initially, the symmetric key Kab is known only to A and B
+(pre-shared long-term key).
+
+In message 1, A sends its identity and a fresh nonce Na to B.
+
+In message 2, B generates a fresh session key K'ab and returns it to A,
+encrypted under the pre-shared key Kab, together with Na (for freshness
+binding) and B's identity (added by Lowe to prevent a parallel session attack
+present in the original BAN concrete Andrew Secure RPC).
+
+In message 3, A confirms receipt and acceptance of K'ab by encrypting Na
+under the fresh key K'ab. This proves to B that A has obtained K'ab.
+
+In message 4, B sends a fresh nonce Nb in the clear, to be used in a future
+session. (Note: Nb is not used for authentication within this session.)
+
+Requirements:
+
+The protocol must guarantee the secrecy of the new shared key K'ab: in every
+session, the value of K'ab must be known only by the participants playing the
+roles of A and B.
+
+The protocol must guarantee the authenticity of K'ab: in every session, on
+reception of message 3, B must be ensured that the key K'ab was accepted by A
+in the same session with the same nonce Na.
+
+References:
+
+[Low96].
+
+See also:
+
+Andrew Secure RPC, BAN modified Andrew Secure RPC, BAN concrete Andrew Secure
+RPC.

--- a/examples/ccitt_x509_1c/DY.Example.CCITT.Debug.Proof.fst
+++ b/examples/ccitt_x509_1c/DY.Example.CCITT.Debug.Proof.fst
@@ -1,0 +1,60 @@
+module DY.Example.CCITT.Debug.Proof
+
+open Comparse
+open DY.Core
+open DY.Lib
+open DY.Example.CCITT.Protocol.Total
+open DY.Example.CCITT.Protocol.Total.Proof
+open DY.Example.CCITT.Protocol.Stateful
+open DY.Example.CCITT.Protocol.Stateful.Proof
+open DY.Example.CCITT.Debug
+
+#set-options "--fuel 1 --ifuel 2 --z3rlimit 1200 --z3cliopt 'smt.qi.eager_threshold=100' --split_queries always"
+
+val debug_proof:
+  tr:trace ->
+  Lemma
+  (requires
+    trace_invariant tr /\
+    has_pki_invariant /\
+    has_private_keys_invariant
+  )
+  (ensures (
+    let (_, tr_out) = debug () tr in
+    trace_invariant tr_out
+  ))
+let debug_proof tr =
+  let alice = "alice" in
+  let bob = "bob" in
+  let (alice_priv_key_id, tr_a) = initialize_private_keys alice tr in
+  let (_, tr_b) = generate_private_key alice alice_priv_key_id (LongTermSigKey ccitt_sign_tag) tr_a in
+  let (alice_pki_id, tr_c) = initialize_pki alice tr_b in
+  let (bob_priv_key_id, tr_d) = initialize_private_keys bob tr_c in
+  let (_, tr_e) = generate_private_key bob bob_priv_key_id (LongTermPkeKey ccitt_pke_tag) tr_d in
+  let (bob_pki_id, tr_f) = initialize_pki bob tr_e in
+  match compute_public_key alice alice_priv_key_id (LongTermSigKey ccitt_sign_tag) tr_f with
+  | (None, _) -> ()
+  | (Some vk_a, tr_g) -> (
+    let (_, tr_h) = install_public_key bob bob_pki_id (LongTermSigKey ccitt_sign_tag) alice vk_a tr_g in
+    match compute_public_key bob bob_priv_key_id (LongTermPkeKey ccitt_pke_tag) tr_h with
+    | (None, _) -> ()
+    | (Some pk_b, tr_i) -> (
+      let (_, tr_j) = install_public_key alice alice_pki_id (LongTermPkeKey ccitt_pke_tag) bob pk_b tr_i in
+      let ta = serialize string "2026-05-09" in
+      let xa = serialize string "public data" in
+      let ya = serialize string "secret data" in
+      serialize_wf_lemma string (is_publishable tr_j) "2026-05-09";
+      serialize_wf_lemma string (is_publishable tr_j) "public data";
+      serialize_wf_lemma string (is_publishable tr_j) "secret data";
+      assert(is_publishable tr_j ta);
+      assert(is_publishable tr_j xa);
+      assert(is_publishable tr_j ya);
+      assert(is_knowable_by (ccitt_label alice bob) tr_j ya);
+      alice_send_msg1_proof alice_pki_id alice_priv_key_id alice bob ta xa ya tr_j;
+      match alice_send_msg1 alice_pki_id alice_priv_key_id alice bob ta xa ya tr_j with
+      | (None, _) -> ()
+      | (Some msg1_id, tr_k) -> (
+        bob_receive_msg1_proof bob_pki_id bob_priv_key_id bob alice msg1_id tr_k
+      )
+    )
+  )

--- a/examples/ccitt_x509_1c/DY.Example.CCITT.Debug.fst
+++ b/examples/ccitt_x509_1c/DY.Example.CCITT.Debug.fst
@@ -1,0 +1,52 @@
+module DY.Example.CCITT.Debug
+
+open Comparse
+open DY.Core
+open DY.Lib
+open DY.Example.CCITT.Protocol.Total
+open DY.Example.CCITT.Protocol.Stateful
+
+#set-options "--fuel 0 --ifuel 0 --z3rlimit 100"
+
+(*** Example Protocol Run with Trace Printing ***)
+
+let debug () : traceful (option unit)  =
+  let _ = IO.debug_print_string "************* Trace *************\n" in
+  let alice = "alice" in
+  let bob = "bob" in
+
+  // Initialize state for Alice
+  let* alice_priv_key_id = initialize_private_keys alice in
+  generate_private_key alice alice_priv_key_id (LongTermSigKey ccitt_sign_tag);*
+  let* alice_pki_id = initialize_pki alice in
+  
+  // Initialize state for Bob
+  let* bob_priv_key_id = initialize_private_keys bob in
+  generate_private_key bob bob_priv_key_id (LongTermPkeKey ccitt_pke_tag);*
+  let* bob_pki_id = initialize_pki bob in
+
+  // Install keys
+  let*? vk_a = compute_public_key alice alice_priv_key_id (LongTermSigKey ccitt_sign_tag) in
+  install_public_key bob bob_pki_id (LongTermSigKey ccitt_sign_tag) alice vk_a;*
+  
+  let*? pk_b = compute_public_key bob bob_priv_key_id (LongTermPkeKey ccitt_pke_tag) in
+  install_public_key alice alice_pki_id (LongTermPkeKey ccitt_pke_tag) bob pk_b;*
+
+  let alice_ids = {pki=alice_pki_id; private_keys=alice_priv_key_id} in
+  let bob_ids = {pki=bob_pki_id; private_keys=bob_priv_key_id} in
+  
+  let ta = serialize string "2026-05-09" in
+  let xa = serialize string "public data" in
+  let ya = serialize string "secret data" in
+  
+  let*? msg1_id = alice_send_msg1 alice_ids.pki alice_ids.private_keys alice bob ta xa ya in
+  let*? _ = bob_receive_msg1 bob_ids.pki bob_ids.private_keys bob alice msg1_id in
+  
+  let* tr = get_trace in
+  let _ = IO.debug_print_string (trace_to_string default_trace_to_string_printers tr) in
+
+  return (Some ())
+
+#push-options "--warn_error -272"
+let _ = debug () empty_trace
+#pop-options

--- a/examples/ccitt_x509_1c/DY.Example.CCITT.Protocol.Stateful.Proof.fst
+++ b/examples/ccitt_x509_1c/DY.Example.CCITT.Protocol.Stateful.Proof.fst
@@ -1,0 +1,132 @@
+module DY.Example.CCITT.Protocol.Stateful.Proof
+
+open Comparse
+open DY.Core
+open DY.Lib
+open DY.Example.CCITT.Protocol.Total
+open DY.Example.CCITT.Protocol.Total.Proof
+open DY.Example.CCITT.Protocol.Stateful
+
+#set-options "--fuel 0 --ifuel 0 --z3rlimit 100 --z3cliopt 'smt.qi.eager_threshold=100'"
+
+(*** Trace invariants ***)
+
+#push-options "--ifuel 1"
+let event_predicate_ccitt: event_predicate ccitt_event =
+  fun tr prin e ->
+    match e with
+    | AliceSends alice bob ta na xa ya ->
+      prin == alice /\
+      is_publishable tr ta /\
+      is_publishable tr na /\
+      is_publishable tr xa /\
+      is_knowable_by (ccitt_label alice bob) tr ya
+    | BobReceives alice bob ta na xa ya ->
+      prin == bob /\
+      is_publishable tr ta /\
+      is_publishable tr na /\
+      is_publishable tr xa /\
+      is_knowable_by (long_term_key_label bob) tr ya /\
+      (is_corrupt tr (ccitt_label alice bob) \/
+       event_triggered tr alice (AliceSends alice bob ta na xa ya))
+#pop-options
+
+let all_sessions = [
+  pki_tag_and_invariant;
+  private_keys_tag_and_invariant;
+]
+
+let all_events = [
+  mk_event_tag_and_pred event_predicate_ccitt;
+]
+
+let trace_invariants_ccitt: trace_invariants = {
+  state_pred = mk_state_pred all_sessions;
+  event_pred = mk_event_pred all_events;
+}
+
+instance protocol_invariants_ccitt : protocol_invariants = {
+  trace_invs = trace_invariants_ccitt;
+  crypto_invs = crypto_invariants_ccitt;
+}
+
+let _ = do_split_boilerplate mk_state_pred_correct all_sessions
+let _ = do_split_boilerplate mk_event_pred_correct all_events
+
+(*** Proofs ***)
+
+#push-options "--z3rlimit 400 --fuel 1 --ifuel 2 --split_queries always"
+val alice_send_msg1_proof:
+  pki:state_id -> private_keys:state_id ->
+  alice:principal -> bob:principal ->
+  ta:bytes -> xa:bytes -> ya:bytes ->
+  tr:trace ->
+  Lemma
+  (requires
+    trace_invariant tr /\
+    is_publishable tr ta /\
+    is_publishable tr xa /\
+    is_knowable_by (ccitt_label alice bob) tr ya
+  )
+  (ensures (
+    match alice_send_msg1 pki private_keys alice bob ta xa ya tr with
+    | (Some msg_id, tr_out) -> trace_invariant tr_out
+    | (None, tr_out) -> trace_invariant tr_out
+  ))
+  [SMTPat (alice_send_msg1 pki private_keys alice bob ta xa ya tr)]
+let alice_send_msg1_proof pki private_keys alice bob ta xa ya tr =
+  reveal_opaque (`%alice_send_msg1) (alice_send_msg1 pki private_keys alice bob ta xa ya tr);
+  match get_private_key alice private_keys (LongTermSigKey ccitt_sign_tag) tr with
+  | (None, _) -> ()
+  | (Some sk_a, tr0) -> (
+    match get_public_key alice pki (LongTermPkeKey ccitt_pke_tag) bob tr0 with
+    | (None, _) -> ()
+    | (Some pk_b, tr1) -> (
+      let (na, tr2) = mk_rand NoUsage public 32 tr1 in
+      let (n_inner_sig, tr3) = mk_rand SigNonce (long_term_key_label alice) 32 tr2 in
+      let (n_inner_pke, tr4) = mk_rand PkeNonce (long_term_key_label alice) 32 tr3 in
+      let (n_outer, tr5) = mk_rand SigNonce (long_term_key_label alice) 32 tr4 in
+      let ((), tr6) = trigger_event alice (AliceSends alice bob ta na xa ya) tr5 in
+      compute_message1_proof tr6 ta na bob xa ya pk_b sk_a n_inner_sig n_inner_pke n_outer alice
+    )
+  )
+#pop-options
+
+#push-options "--z3rlimit 600 --fuel 1 --ifuel 2 --split_queries always"
+val bob_receive_msg1_proof:
+  pki:state_id -> private_keys:state_id ->
+  bob:principal -> alice:principal ->
+  msg1_id:timestamp ->
+  tr:trace ->
+  Lemma
+  (requires
+    trace_invariant tr
+  )
+  (ensures (
+    match bob_receive_msg1 pki private_keys bob alice msg1_id tr with
+    | (Some (), tr_out) -> trace_invariant tr_out
+    | (None, tr_out) -> trace_invariant tr_out
+  ))
+  [SMTPat (bob_receive_msg1 pki private_keys bob alice msg1_id tr)]
+let bob_receive_msg1_proof pki private_keys bob alice msg1_id tr =
+  reveal_opaque (`%bob_receive_msg1) (bob_receive_msg1 pki private_keys bob alice msg1_id tr);
+  match get_private_key bob private_keys (LongTermPkeKey ccitt_pke_tag) tr with
+  | (None, _) -> ()
+  | (Some sk_b, tr0) -> (
+    match get_public_key bob pki (LongTermSigKey ccitt_sign_tag) alice tr0 with
+    | (None, _) -> ()
+    | (Some vk_a, tr1) -> (
+      match recv_msg msg1_id tr1 with
+      | (None, _) -> ()
+      | (Some msg1_bytes, tr2) -> (
+        decode_message1_proof tr2 bob msg1_bytes sk_b vk_a alice;
+        match decode_message1 bob msg1_bytes sk_b vk_a with
+        | None -> ()
+        | Some (ta, na, bob', xa, ya) -> (
+          if bob' = bob then ()
+          else ()
+        )
+      )
+    )
+  )
+#pop-options

--- a/examples/ccitt_x509_1c/DY.Example.CCITT.Protocol.Stateful.fst
+++ b/examples/ccitt_x509_1c/DY.Example.CCITT.Protocol.Stateful.fst
@@ -1,0 +1,67 @@
+module DY.Example.CCITT.Protocol.Stateful
+
+open Comparse
+open DY.Core
+open DY.Lib
+open DY.Example.CCITT.Protocol.Total
+
+(*** Events ***)
+
+[@@ with_bytes bytes]
+type ccitt_event =
+  | AliceSends: alice:principal -> bob:principal -> ta:bytes -> na:bytes -> xa:bytes -> ya:bytes -> ccitt_event
+  | BobReceives: alice:principal -> bob:principal -> ta:bytes -> na:bytes -> xa:bytes -> ya:bytes -> ccitt_event
+
+%splice [ps_ccitt_event] (gen_parser (`ccitt_event))
+%splice [ps_ccitt_event_is_well_formed] (gen_is_well_formed_lemma (`ccitt_event))
+
+instance event_instance: event ccitt_event = {
+  tag = "CCITT.Event";
+  format = mk_parseable_serializeable ps_ccitt_event;
+}
+
+(*** Stateful Functions ***)
+
+val ccitt_sign_tag: string
+let ccitt_sign_tag = "CCITT.SignKey"
+
+val ccitt_pke_tag: string
+let ccitt_pke_tag = "CCITT.PkeKey"
+
+val ccitt_label: principal -> principal -> label
+let ccitt_label p1 p2 = join (principal_label p1) (principal_label p2)
+
+[@@ "opaque_to_smt"]
+val alice_send_msg1:
+  pki:state_id -> private_keys:state_id ->
+  alice:principal -> bob:principal ->
+  ta:bytes -> xa:bytes -> ya:bytes ->
+  traceful (option timestamp)
+let alice_send_msg1 pki private_keys alice bob ta xa ya =
+  let*? sk_a = get_private_key alice private_keys (LongTermSigKey ccitt_sign_tag) in
+  let*? pk_b = get_public_key alice pki (LongTermPkeKey ccitt_pke_tag) bob in
+  let* na = mk_rand NoUsage public 32 in
+  let* n_inner_sig = mk_rand SigNonce (long_term_key_label alice) 32 in
+  let* n_inner_pke = mk_rand PkeNonce (long_term_key_label alice) 32 in
+  let* n_outer = mk_rand SigNonce (long_term_key_label alice) 32 in
+  trigger_event alice (AliceSends alice bob ta na xa ya);*
+  let msg1 = compute_message1 ta na bob xa ya pk_b sk_a n_inner_sig n_inner_pke n_outer in
+  let* msg_id = send_msg msg1 in
+  return (Some msg_id)
+
+[@@ "opaque_to_smt"]
+val bob_receive_msg1:
+  pki:state_id -> private_keys:state_id ->
+  bob:principal -> alice:principal ->
+  timestamp ->
+  traceful (option unit)
+let bob_receive_msg1 pki private_keys bob alice msg1_id =
+  let*? sk_b = get_private_key bob private_keys (LongTermPkeKey ccitt_pke_tag) in
+  let*? vk_a = get_public_key bob pki (LongTermSigKey ccitt_sign_tag) alice in
+  let*? msg1_bytes = recv_msg msg1_id in
+  let*? (ta, na, bob', xa, ya) = return (decode_message1 bob msg1_bytes sk_b vk_a) in
+  // Check that the intended recipient is indeed bob
+  if bob' <> bob then return None else (
+    trigger_event bob (BobReceives alice bob ta na xa ya);*
+    return (Some ())
+  )

--- a/examples/ccitt_x509_1c/DY.Example.CCITT.Protocol.Total.Proof.fst
+++ b/examples/ccitt_x509_1c/DY.Example.CCITT.Protocol.Total.Proof.fst
@@ -1,0 +1,264 @@
+module DY.Example.CCITT.Protocol.Total.Proof
+
+open Comparse
+open DY.Core
+open DY.Lib
+open DY.Example.CCITT.Protocol.Total
+open DY.Example.CCITT.Protocol.Stateful
+
+#set-options "--fuel 0 --ifuel 0 --z3cliopt 'smt.qi.eager_threshold=100'"
+
+(*** Cryptographic invariants ***)
+
+instance crypto_usages_ccitt : crypto_usages = default_crypto_usages
+
+#push-options "--ifuel 2 --fuel 1"
+val crypto_predicates_ccitt: crypto_predicates
+let crypto_predicates_ccitt = {
+  default_crypto_predicates with
+
+  pke_pred = {
+    pred = (fun tr sk_usage pk msg ->
+      match sk_usage with
+      | PkeKey tag data ->
+        if tag = ccitt_pke_tag then (
+          match parse long_term_key_usage_data data with
+          | Some {who = bob} -> (
+            match parse inner_payload msg with
+            | Some ip ->
+              exists alice ta na xa.
+                event_triggered tr alice (AliceSends alice bob ta na xa ip.ya) /\
+                (get_label tr ip.ya) `can_flow tr` (ccitt_label alice bob)
+            | None -> False
+          )
+          | None -> False
+        ) else False
+      | _ -> False
+    );
+    pred_later = (fun tr1 tr2 sk_usage pk msg ->
+      parse_wf_lemma inner_payload (bytes_well_formed tr1) msg
+    );
+  };
+
+  sign_pred = {
+    pred = (fun tr sk_usage vk msg ->
+      match sk_usage with
+      | SigKey tag data ->
+        if tag = ccitt_sign_tag then (
+          match parse long_term_key_usage_data data with
+          | Some {who = alice} -> (
+            match parse sig_message msg with
+            | Some (SigInner h_ya) ->
+              // Inner signature variant: hash_of_ya == hash ya for some ya, and an
+              // AliceSends event was triggered for that ya.
+              exists ya. h_ya == hash ya /\
+                (exists bob ta na xa. event_triggered tr alice (AliceSends alice bob ta na xa ya))
+            | Some (SigOuter payload) ->
+              // Outer signature variant: inner_cipher commits to a specific ya via
+              // symbolic injectivity of pke_enc, tying the outer-signed event to that ya.
+              exists ya pk_b' inner_nonce' inner_sig'.
+                payload.inner_cipher == pke_enc pk_b' inner_nonce' (serialize inner_payload ({ya; sig_h_ya = inner_sig'} <: inner_payload)) /\
+                event_triggered tr alice (AliceSends alice payload.bob payload.ta payload.na payload.xa ya)
+            | None -> False
+          )
+          | None -> False
+        ) else False
+      | _ -> False
+    );
+    pred_later = (fun tr1 tr2 sk_usage vk msg ->
+      parse_wf_lemma sig_message (bytes_well_formed tr1) msg
+    );
+  };
+}
+#pop-options
+
+instance crypto_invariants_ccitt : crypto_invariants = {
+  usages = crypto_usages_ccitt;
+  preds = crypto_predicates_ccitt;
+}
+
+(*** Proofs ***)
+
+#push-options "--z3rlimit 400 --fuel 1 --ifuel 2 --split_queries always"
+val compute_message1_proof:
+  tr:trace ->
+  ta:bytes -> na:bytes -> bob:principal -> xa:bytes -> ya:bytes ->
+  pk_b:bytes -> sk_a:bytes ->
+  n_inner_sig:bytes -> n_inner_pke:bytes -> n_outer:bytes ->
+  alice:principal ->
+  Lemma
+  (requires
+    is_publishable tr ta /\
+    is_publishable tr na /\
+    is_publishable tr xa /\
+    is_knowable_by (ccitt_label alice bob) tr ya /\
+    is_public_key_for tr pk_b (LongTermPkeKey ccitt_pke_tag) bob /\
+    is_private_key_for tr sk_a (LongTermSigKey ccitt_sign_tag) alice /\
+    is_secret (long_term_key_label alice) tr n_inner_sig /\
+    n_inner_sig `has_usage tr` SigNonce /\
+    is_secret (long_term_key_label alice) tr n_inner_pke /\
+    n_inner_pke `has_usage tr` PkeNonce /\
+    is_secret (long_term_key_label alice) tr n_outer /\
+    n_outer `has_usage tr` SigNonce /\
+    event_triggered tr alice (AliceSends alice bob ta na xa ya)
+  )
+  (ensures is_publishable tr (compute_message1 ta na bob xa ya pk_b sk_a n_inner_sig n_inner_pke n_outer))
+let compute_message1_proof tr ta na bob xa ya pk_b sk_a n_inner_sig n_inner_pke n_outer alice =
+  reveal_opaque (`%compute_message1) (compute_message1 ta na bob xa ya pk_b sk_a n_inner_sig n_inner_pke n_outer);
+  let h_ya = hash ya in
+  let inner_sig_msg : sig_message = SigInner h_ya in
+  let inner_sig_msg_bytes = serialize sig_message inner_sig_msg in
+  let sig_h_ya = sign sk_a n_inner_sig inner_sig_msg_bytes in
+  let ip = ({ ya; sig_h_ya } <: inner_payload) in
+  let sk_usg = long_term_key_type_to_usage (LongTermSigKey ccitt_sign_tag) alice in
+  let pk_usg = long_term_key_type_to_usage (LongTermPkeKey ccitt_pke_tag) bob in
+  parse_serialize_inv_lemma #bytes long_term_key_usage_data ({who = alice});
+  parse_serialize_inv_lemma #bytes sig_message inner_sig_msg;
+  // --- Inner sign: derive bytes_invariant tr sig_h_ya via SigInner branch of sign_pred
+  serialize_wf_lemma sig_message (is_knowable_by (ccitt_label alice bob) tr) inner_sig_msg;
+  assert(sign_pred.pred tr sk_usg (vk sk_a) inner_sig_msg_bytes);
+  bytes_invariant_sign tr sk_a sk_usg n_inner_sig inner_sig_msg_bytes;
+  assert(bytes_invariant tr sig_h_ya);
+  assert(get_label tr sig_h_ya == get_label tr inner_sig_msg_bytes);
+  assert(is_knowable_by (ccitt_label alice bob) tr sig_h_ya);
+  // --- Inner payload bytes
+  parse_serialize_inv_lemma #bytes inner_payload ip;
+  serialize_wf_lemma inner_payload (is_knowable_by (ccitt_label alice bob) tr) ip;
+  let ip_bytes = serialize inner_payload ip in
+  // --- Inner pke: derive bytes_invariant tr inner_cipher
+  assert(parse inner_payload ip_bytes == Some ip);
+  assert(ip.ya == ya);
+  introduce exists alice' ta' na' xa'. event_triggered tr alice' (AliceSends alice' bob ta' na' xa' ip.ya) /\
+    (get_label tr ip.ya) `can_flow tr` (ccitt_label alice' bob)
+  with alice ta na xa and ();
+  assert(pke_pred.pred tr pk_usg pk_b ip_bytes);
+  bytes_invariant_pke_enc tr pk_b pk_usg n_inner_pke ip_bytes;
+  let inner_cipher = pke_enc pk_b n_inner_pke ip_bytes in
+  assert(bytes_invariant tr inner_cipher);
+  assert(is_publishable tr inner_cipher);
+  // --- Outer payload bytes
+  let payload = ({ ta; na; bob; xa; inner_cipher } <: msg1_payload) in
+  parse_serialize_inv_lemma #bytes msg1_payload payload;
+  let outer_sig_msg : sig_message = SigOuter payload in
+  let outer_sig_msg_bytes = serialize sig_message outer_sig_msg in
+  parse_serialize_inv_lemma #bytes sig_message outer_sig_msg;
+  serialize_wf_lemma sig_message (is_publishable tr) outer_sig_msg;
+  // --- Outer sign: derive bytes_invariant tr signature via SigOuter branch of sign_pred
+  assert(payload.inner_cipher == pke_enc pk_b n_inner_pke (serialize inner_payload ({ya; sig_h_ya} <: inner_payload)));
+  assert(sign_pred.pred tr sk_usg (vk sk_a) outer_sig_msg_bytes);
+  bytes_invariant_sign tr sk_a sk_usg n_outer outer_sig_msg_bytes;
+  let signature = sign sk_a n_outer outer_sig_msg_bytes in
+  serialize_wf_lemma msg1_payload (is_publishable tr) payload;
+  assert(bytes_invariant tr signature);
+  assert(is_publishable tr signature);
+  // --- Final message
+  let final_msg : message = Msg1 payload signature in
+  serialize_wf_lemma message (is_publishable tr) final_msg
+#pop-options
+
+#push-options "--z3rlimit 2000 --fuel 2 --ifuel 4"
+val decode_message1_event_helper:
+  tr:trace ->
+  alice:principal -> bob:principal ->
+  payload:msg1_payload -> signature:bytes ->
+  sk_b:bytes -> vk_a:bytes -> ip_bytes:bytes -> ip:inner_payload ->
+  Lemma
+  (requires
+    is_private_key_for tr sk_b (LongTermPkeKey ccitt_pke_tag) bob /\
+    is_public_key_for tr vk_a (LongTermSigKey ccitt_sign_tag) alice /\
+    bytes_invariant tr (serialize sig_message (SigOuter payload)) /\
+    bytes_invariant tr signature /\
+    verify vk_a (serialize sig_message (SigOuter payload)) signature /\
+    pke_dec sk_b payload.inner_cipher == Some ip_bytes /\
+    parse inner_payload ip_bytes == Some ip /\
+    payload.bob == bob
+  )
+  (ensures
+    is_corrupt tr (ccitt_label alice bob) \/
+    event_triggered tr alice (AliceSends alice bob payload.ta payload.na payload.xa ip.ya)
+  )
+let decode_message1_event_helper tr alice bob payload signature sk_b vk_a ip_bytes ip =
+  reveal_opaque (`%pke_dec) (pke_dec sk_b);
+  reveal_opaque (`%pke_enc) (pke_enc);
+  parse_serialize_inv_lemma #bytes inner_payload ip;
+  parse_serialize_inv_lemma #bytes long_term_key_usage_data ({who = alice});
+  let outer_sig_msg : sig_message = SigOuter payload in
+  let outer_sig_msg_bytes = serialize sig_message outer_sig_msg in
+  parse_serialize_inv_lemma #bytes sig_message outer_sig_msg;
+  let sk_usg_a = long_term_key_type_to_usage (LongTermSigKey ccitt_sign_tag) alice in
+  bytes_invariant_verify tr vk_a sk_usg_a outer_sig_msg_bytes signature;
+  // bytes_invariant_verify gives:
+  //   sign_pred.pred tr sk_usg_a vk_a outer_sig_msg_bytes  \/  get_signkey_label vk_a `can_flow tr` public
+  // get_signkey_label vk_a == long_term_key_label alice.
+  // Show that the right disjunct (signkey corrupt) implies ccitt_label corrupt.
+  introduce
+    (get_signkey_label tr vk_a) `can_flow tr` public ==>
+    is_corrupt tr (ccitt_label alice bob)
+  with _. (
+    // get_signkey_label vk_a == long_term_key_label alice (from is_public_key_for).
+    assert(get_signkey_label tr vk_a == long_term_key_label alice);
+    assert(is_corrupt tr (long_term_key_label alice));
+    // principal_label alice can_flow long_term_key_label alice. SMT pat triggers via
+    // state_pred_label_can_flow_state_pred_label when both labels are unfolded.
+    assert(principal_label alice `can_flow tr` long_term_key_label alice);
+    assert(is_corrupt tr (principal_label alice));
+    assert(is_corrupt tr (ccitt_label alice bob))
+  );
+  introduce
+    sign_pred.pred tr sk_usg_a vk_a outer_sig_msg_bytes ==>
+    event_triggered tr alice (AliceSends alice bob payload.ta payload.na payload.xa ip.ya)
+  with _. (
+    eliminate exists ya' pk_b' inner_nonce' inner_sig'.
+      payload.inner_cipher == pke_enc pk_b' inner_nonce' (serialize inner_payload ({ya = ya'; sig_h_ya = inner_sig'} <: inner_payload)) /\
+      event_triggered tr alice (AliceSends alice payload.bob payload.ta payload.na payload.xa ya')
+    returns event_triggered tr alice (AliceSends alice bob payload.ta payload.na payload.xa ip.ya)
+    with _. (
+      let ip' : inner_payload = {ya = ya'; sig_h_ya = inner_sig'} in
+      parse_serialize_inv_lemma #bytes inner_payload ip';
+      assert(ip.ya == ya')
+    )
+  )
+#pop-options
+
+#push-options "--z3rlimit 1000 --fuel 4 --ifuel 4"
+val decode_message1_proof:
+  tr:trace ->
+  bob:principal -> msg_bytes:bytes ->
+  sk_b:bytes -> vk_a:bytes -> alice:principal ->
+  Lemma
+  (requires
+    is_private_key_for tr sk_b (LongTermPkeKey ccitt_pke_tag) bob /\
+    is_public_key_for tr vk_a (LongTermSigKey ccitt_sign_tag) alice /\
+    is_publishable tr msg_bytes
+  )
+  (ensures (
+    match decode_message1 bob msg_bytes sk_b vk_a with
+    | Some (ta, na, bob', xa, ya) ->
+      is_publishable tr ta /\
+      is_publishable tr na /\
+      bob' == bob /\
+      is_publishable tr xa /\
+      is_knowable_by (long_term_key_label bob) tr ya /\
+      (is_corrupt tr (ccitt_label alice bob) \/
+       event_triggered tr alice (AliceSends alice bob ta na xa ya))
+    | None -> True
+  ))
+let decode_message1_proof tr bob msg_bytes sk_b vk_a alice =
+  reveal_opaque (`%decode_message1) (decode_message1 bob msg_bytes sk_b vk_a);
+  parse_wf_lemma message (is_publishable tr) msg_bytes;
+  match decode_message1 bob msg_bytes sk_b vk_a with
+  | None -> ()
+  | Some (ta, na, bob', xa, ya) -> (
+    let Some msg = parse message msg_bytes in
+    let Msg1 payload signature = msg in
+    serialize_wf_lemma msg1_payload (is_publishable tr) payload;
+    let outer_sig_msg : sig_message = SigOuter payload in
+    serialize_wf_lemma sig_message (is_publishable tr) outer_sig_msg;
+    let pk_usg = long_term_key_type_to_usage (LongTermPkeKey ccitt_pke_tag) bob in
+    let Some ip_bytes = pke_dec sk_b payload.inner_cipher in
+    bytes_invariant_pke_dec tr sk_b pk_usg payload.inner_cipher;
+    parse_wf_lemma inner_payload (is_knowable_by (long_term_key_label bob) tr) ip_bytes;
+    let Some ip = parse inner_payload ip_bytes in
+    decode_message1_event_helper tr alice bob payload signature sk_b vk_a ip_bytes ip
+  )
+#pop-options

--- a/examples/ccitt_x509_1c/DY.Example.CCITT.Protocol.Total.fst
+++ b/examples/ccitt_x509_1c/DY.Example.CCITT.Protocol.Total.fst
@@ -1,0 +1,96 @@
+module DY.Example.CCITT.Protocol.Total
+
+open Comparse
+open DY.Core
+open DY.Lib
+
+instance parseable_serializeable_string: parseable_serializeable bytes string = mk_parseable_serializeable ps_string
+
+(*** Message types ***)
+
+[@@ with_bytes bytes]
+type inner_payload = {
+  ya: bytes;
+  sig_h_ya: bytes;
+}
+
+%splice [ps_inner_payload] (gen_parser (`inner_payload))
+%splice [ps_inner_payload_is_well_formed] (gen_is_well_formed_lemma (`inner_payload))
+
+instance parseable_serializeable_inner_payload: parseable_serializeable bytes inner_payload = mk_parseable_serializeable ps_inner_payload
+
+[@@ with_bytes bytes]
+type msg1_payload = {
+  ta: bytes;
+  na: bytes;
+  bob: principal;
+  xa: bytes;
+  inner_cipher: bytes;
+}
+
+%splice [ps_msg1_payload] (gen_parser (`msg1_payload))
+%splice [ps_msg1_payload_is_well_formed] (gen_is_well_formed_lemma (`msg1_payload))
+
+instance parseable_serializeable_msg1_payload: parseable_serializeable bytes msg1_payload = mk_parseable_serializeable ps_msg1_payload
+
+/// Tagged union of signed payload variants. Using one tagged union (rather than
+/// signing each variant separately) ensures the sign predicate's parse step
+/// dispatches exactly one branch per byte string.
+
+[@@ with_bytes bytes]
+type sig_message =
+  | SigInner: hash_of_ya:bytes -> sig_message
+  | SigOuter: payload:msg1_payload -> sig_message
+
+%splice [ps_sig_message] (gen_parser (`sig_message))
+%splice [ps_sig_message_is_well_formed] (gen_is_well_formed_lemma (`sig_message))
+
+instance parseable_serializeable_sig_message: parseable_serializeable bytes sig_message = mk_parseable_serializeable ps_sig_message
+
+[@@ with_bytes bytes]
+type message =
+  | Msg1: payload:msg1_payload -> signature:bytes -> message
+
+%splice [ps_message] (gen_parser (`message))
+%splice [ps_message_is_well_formed] (gen_is_well_formed_lemma (`message))
+
+instance parseable_serializeable_bytes_message: parseable_serializeable bytes message = mk_parseable_serializeable ps_message
+
+(*** Message 1 ***)
+
+/// Alice generates message 1.
+/// Both the inner and outer signatures wrap their payload in `sig_message`
+/// so that the crypto sign predicate has a single dispatched branch per byte string.
+
+[@@"opaque_to_smt"]
+val compute_message1:
+  ta:bytes -> na:bytes -> bob:principal -> xa:bytes -> ya:bytes ->
+  pk_b:bytes -> sk_a:bytes ->
+  n_inner_sig:bytes -> n_inner_pke:bytes -> n_outer:bytes ->
+  bytes
+let compute_message1 ta na bob xa ya pk_b sk_a n_inner_sig n_inner_pke n_outer =
+  let h_ya = hash ya in
+  let sig_h_ya = sign sk_a n_inner_sig (serialize sig_message (SigInner h_ya)) in
+  let ip = { ya; sig_h_ya; } in
+  let inner_cipher = pke_enc pk_b n_inner_pke (serialize inner_payload ip) in
+  let payload = { ta; na; bob; xa; inner_cipher; } in
+  let signature = sign sk_a n_outer (serialize sig_message (SigOuter payload)) in
+  serialize message (Msg1 payload signature)
+
+/// Bob processes message 1.
+
+[@@"opaque_to_smt"]
+val decode_message1:
+  bob:principal -> msg_bytes:bytes ->
+  sk_b:bytes -> vk_a:bytes ->
+  option (bytes & bytes & principal & bytes & bytes)
+let decode_message1 bob msg_bytes sk_b vk_a =
+  let? msg = parse message msg_bytes in
+  guard (Msg1? msg);?
+  let Msg1 payload signature = msg in
+  guard (payload.bob = bob);?
+  guard (verify vk_a (serialize sig_message (SigOuter payload)) signature);?
+  let? ip_bytes = pke_dec sk_b payload.inner_cipher in
+  let? ip = parse inner_payload ip_bytes in
+  guard (verify vk_a (serialize sig_message (SigInner (hash ip.ya))) ip.sig_h_ya);?
+  Some (payload.ta, payload.na, payload.bob, payload.xa, ip.ya)

--- a/examples/ccitt_x509_1c/DY.Example.CCITT.SecurityProperties.fst
+++ b/examples/ccitt_x509_1c/DY.Example.CCITT.SecurityProperties.fst
@@ -1,0 +1,46 @@
+module DY.Example.CCITT.SecurityProperties
+
+open Comparse
+open DY.Core
+open DY.Lib
+open DY.Example.CCITT.Protocol.Total
+open DY.Example.CCITT.Protocol.Total.Proof
+open DY.Example.CCITT.Protocol.Stateful
+open DY.Example.CCITT.Protocol.Stateful.Proof
+
+#set-options "--fuel 0 --ifuel 1 --z3rlimit 100"
+
+/// Authentication: if Bob successfully received the protocol message and the
+/// long-term keys are not corrupt, Alice indeed triggered the matching AliceSends.
+val authentication_bob:
+  tr:trace ->
+  alice:principal -> bob:principal ->
+  ta:bytes -> na:bytes -> xa:bytes -> ya:bytes ->
+  Lemma
+  (requires
+    trace_invariant tr /\
+    event_triggered tr bob (BobReceives alice bob ta na xa ya) /\
+    ~(is_corrupt tr (ccitt_label alice bob))
+  )
+  (ensures
+    event_triggered tr alice (AliceSends alice bob ta na xa ya)
+  )
+let authentication_bob tr alice bob ta na xa ya = ()
+
+/// Secrecy: if ya is a secret value labelled with ccitt_label alice bob
+/// (i.e. only knowable to Alice and Bob), and that label is not corrupt,
+/// then the attacker cannot learn ya.
+val secrecy_ya:
+  tr:trace ->
+  alice:principal -> bob:principal -> ya:bytes ->
+  Lemma
+  (requires
+    trace_invariant tr /\
+    is_secret (ccitt_label alice bob) tr ya /\
+    ~(is_corrupt tr (ccitt_label alice bob))
+  )
+  (ensures
+    ~(attacker_knows tr ya)
+  )
+let secrecy_ya tr alice bob ya =
+  FStar.Classical.move_requires (attacker_only_knows_publishable_values tr) ya

--- a/examples/ccitt_x509_1c/Makefile
+++ b/examples/ccitt_x509_1c/Makefile
@@ -1,0 +1,6 @@
+DY_HOME ?= ../..
+include $(DY_HOME)/Makefile
+
+test:
+	cd $(DY_HOME)/obj; $(FSTAR_EXE) --ocamlenv ocamlbuild -use-ocamlfind -pkg batteries -pkg fstar.lib DY_Example_CCITT_Debug.native
+	$(DY_HOME)/obj/DY_Example_CCITT_Debug.native

--- a/examples/ccitt_x509_1c/spec.txt
+++ b/examples/ccitt_x509_1c/spec.txt
@@ -1,0 +1,57 @@
+CCITT X.509 (1c)
+
+Author(s): M. Abadi and R. Needham 1996
+Last modified November 11, 2002
+
+Summary: Correction of the CCITT X.509 (1) one message protocol. The fix signs
+the confidential payload Ya before encrypting it, closing an authentication
+flaw in the original.
+
+Protocol specification (in common syntax):
+
+ A, B :    principal
+ Na :      nonce
+ Ta :      timestamp
+ Ya :      userdata
+ Xa :      userdata
+ PK, SK :  principal -> key (keypair)
+ h :       userdata -> userdata (one-way)
+
+ 1.   A -> B :   A, {Ta, Na, B, Xa, {Ya, {h(Ya)}SK(A)}PK(B)}SK(A)
+
+Description of the protocol rules:
+
+This is a corrected version of CCITT X.509 (1). The original protocol sends
+{Ya}PK(B) without any inner authentication, allowing an attacker to substitute
+a different value for Ya under the outer signature. The fix proposed in [AN96]
+is to sign a hash of Ya with SK(A) before encrypting it, making the inner
+payload {Ya, {h(Ya)}SK(A)}PK(B).
+
+The full message structure is:
+  - Outer layer: A signs (Ta, Na, B, Xa, inner_ciphertext) with SK(A).
+  - Inner layer: A encrypts (Ya, sign(h(Ya), SK(A))) under B's public key PK(B).
+
+Ta is a timestamp used for replay prevention. Na is a nonce. Xa is public data
+transmitted by A. Ya is confidential data whose privacy and authenticity must
+be guaranteed.
+
+Note on DY* modeling: The DY* framework operates in a symbolic model without
+a notion of real time. The timestamp Ta should be modeled as a public byte
+string (e.g., a nonce or constant) with no freshness guarantee beyond what the
+symbolic attacker model provides.
+
+Requirements:
+
+The protocol must ensure the confidentiality of Ya: if A and B follow the
+protocol, then an attacker should not be able to obtain Ya.
+
+The protocol must ensure the recipient B that the data Xa and Ya originate
+from A (authentication of A to B).
+
+References:
+
+[AN96], [CCI87].
+
+See also:
+
+CCITT X.509 (1), CCITT X.509 (3).


### PR DESCRIPTION
These benchmarks cover areas not yet covered by DY*, such as symmetric AEAD encryption and timestamp. Secrecy and authentication are proved. The two-step proof synthesis workflow uses Gemini 3 (Auto) and Claude Opus 4.7 for protocol modeling and proof discharge respectively, proving the feasibility of such an approach in the DY* extrinsic library. The input specifications provided to the LLMs are provided as spec.txt in the respective directory.